### PR TITLE
Fixed HIDAPI wide string functions + HIDDeviceInfo wide string fields

### DIFF
--- a/SDL3-CS/SDL/Input Events/hidapi/HIDDeviceInfo.cs
+++ b/SDL3-CS/SDL/Input Events/hidapi/HIDDeviceInfo.cs
@@ -52,7 +52,7 @@ public static partial class SDL
         /// <summary>
         /// Serial Number
         /// </summary>
-        [MarshalAs(UnmanagedType.LPUTF8Str)] public string SerialNumber;
+        public IntPtr SerialNumber;
         
         /// <summary>
         /// Device Release Number in binary-coded decimal,
@@ -63,12 +63,12 @@ public static partial class SDL
         /// <summary>
         /// Manufacturer String
         /// </summary>
-        [MarshalAs(UnmanagedType.LPUTF8Str)] public string ManufacturerString;
+        public IntPtr ManufacturerString;
         
         /// <summary>
         /// Product string
         /// </summary>
-        [MarshalAs(UnmanagedType.LPUTF8Str)] public string ProductString;
+        public IntPtr ProductString;
         
         /// <summary>
         /// Usage Page for this Device/Interface

--- a/SDL3-CS/SDL/Input Events/hidapi/PInvoke.cs
+++ b/SDL3-CS/SDL/Input Events/hidapi/PInvoke.cs
@@ -315,6 +315,8 @@ public static partial class SDL
     public static partial int HIDClose(IntPtr dev);
     
     
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_manufacturer_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int SDL_hid_get_manufacturer_string(IntPtr dev, IntPtr @string, UIntPtr maxlen);
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_hid_get_manufacturer_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);</code>
     /// <summary>
     /// Get The Manufacturer String from a HID device.
@@ -325,10 +327,28 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_manufacturer_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int HIDGetManufacturerString(IntPtr dev, [MarshalUsing(typeof(WCharStringMarshaller))] out string @string, UIntPtr maxlen);
+    public static int HIDGetManufacturerString(IntPtr dev, out string @string, UIntPtr maxlen) {
+        // Allocate a buffer for maxlen characters
+        var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
+        var buf = Marshal.AllocHGlobal((int)maxbytes);
+        maxlen = maxbytes / WCharStringMarshaller.WCharSize; // In case the previous multiplication overflowed
+        
+        try
+        {
+            // Call original function to populate the buffer
+            var result = SDL_hid_get_manufacturer_string(dev, buf, maxlen);
+            // Convert contents of buffer into managed string
+            @string = WCharStringMarshaller.ConvertToManaged(buf)!;
+            return result;
+        }
+        finally {
+            Marshal.FreeHGlobal(buf);
+        }
+    }
     
     
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_product_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int SDL_hid_get_product_string(IntPtr dev, IntPtr @string, UIntPtr maxlen);
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_hid_get_product_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);</code>
     /// <summary>
     /// Get The Product String from a HID device.
@@ -338,10 +358,28 @@ public static partial class SDL
     /// <param name="maxlen">the length of the buffer in multiples of wchar_t.</param>
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_product_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int HIDGetProductString(IntPtr dev, [MarshalUsing(typeof(WCharStringMarshaller))] out string @string, UIntPtr maxlen);
+    public static int HIDGetProductString(IntPtr dev, out string @string, UIntPtr maxlen) {
+        // Allocate a buffer for maxlen characters
+        var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
+        var buf = Marshal.AllocHGlobal((int)maxbytes);
+        maxlen = maxbytes / WCharStringMarshaller.WCharSize; // In case the previous multiplication overflowed
+        
+        try
+        {
+            // Call original function to populate the buffer
+            var result = SDL_hid_get_product_string(dev, buf, maxlen);
+            // Convert contents of buffer into managed string
+            @string = WCharStringMarshaller.ConvertToManaged(buf)!;
+            return result;
+        }
+        finally {
+            Marshal.FreeHGlobal(buf);
+        }
+    }
     
     
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_serial_number_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int SDL_hid_get_serial_number_string(IntPtr dev, IntPtr @string, UIntPtr maxlen);
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_hid_get_serial_number_string(SDL_hid_device *dev, wchar_t *string, size_t maxlen);</code>
     /// <summary>
     /// Get The Serial Number String from a HID device.
@@ -352,10 +390,28 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_serial_number_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int HIDGetSerialNumberString(IntPtr dev, [MarshalUsing(typeof(WCharStringMarshaller))] out string @string, UIntPtr maxlen);
+    public static int HIDGetSerialNumberString(IntPtr dev, out string @string, UIntPtr maxlen) {
+        // Allocate a buffer for maxlen characters
+        var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
+        var buf = Marshal.AllocHGlobal((int)maxbytes);
+        maxlen = maxbytes / WCharStringMarshaller.WCharSize; // In case the previous multiplication overflowed
+        
+        try
+        {
+            // Call original function to populate the buffer
+            var result = SDL_hid_get_serial_number_string(dev, buf, maxlen);
+            // Convert contents of buffer into managed string
+            @string = WCharStringMarshaller.ConvertToManaged(buf)!;
+            return result;
+        }
+        finally {
+            Marshal.FreeHGlobal(buf);
+        }
+    }
     
     
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_indexed_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial int SDL_hid_get_indexed_string(IntPtr dev, int stringIndex, IntPtr @string, UIntPtr maxlen);
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_hid_get_indexed_string(SDL_hid_device *dev, int string_index, wchar_t *string, size_t maxlen);</code>
     /// <summary>
     /// Get a string from a HID device, based on its string index.
@@ -367,8 +423,24 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_hid_get_indexed_string"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial int HIDGetIndexedString(IntPtr dev, int stringIndex, [MarshalUsing(typeof(WCharStringMarshaller))] out string @string, UIntPtr maxlen);
+    public static int HIDGetIndexedString(IntPtr dev, int stringIndex, out string @string, UIntPtr maxlen) {
+        // Allocate a buffer for maxlen characters
+        var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
+        var buf = Marshal.AllocHGlobal((int)maxbytes);
+        maxlen = maxbytes / WCharStringMarshaller.WCharSize; // In case the previous multiplication overflowed
+        
+        try
+        {
+            // Call original function to populate the buffer
+            var result = SDL_hid_get_indexed_string(dev, stringIndex, buf, maxlen);
+            // Convert contents of buffer into managed string
+            @string = WCharStringMarshaller.ConvertToManaged(buf)!;
+            return result;
+        }
+        finally {
+            Marshal.FreeHGlobal(buf);
+        }
+    }
     
     
     /// <code>extern SDL_DECLSPEC SDL_hid_device_info * SDLCALL SDL_hid_get_device_info(SDL_hid_device *dev);</code>

--- a/SDL3-CS/SDL/Input Events/hidapi/PInvoke.cs
+++ b/SDL3-CS/SDL/Input Events/hidapi/PInvoke.cs
@@ -327,7 +327,8 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    public static int HIDGetManufacturerString(IntPtr dev, out string @string, UIntPtr maxlen) {
+    public static int HIDGetManufacturerString(IntPtr dev, out string @string, UIntPtr maxlen)
+    {
         // Allocate a buffer for maxlen characters
         var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
         var buf = Marshal.AllocHGlobal((int)maxbytes);
@@ -358,7 +359,8 @@ public static partial class SDL
     /// <param name="maxlen">the length of the buffer in multiples of wchar_t.</param>
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
-    public static int HIDGetProductString(IntPtr dev, out string @string, UIntPtr maxlen) {
+    public static int HIDGetProductString(IntPtr dev, out string @string, UIntPtr maxlen)
+    {
         // Allocate a buffer for maxlen characters
         var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
         var buf = Marshal.AllocHGlobal((int)maxbytes);
@@ -390,7 +392,8 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    public static int HIDGetSerialNumberString(IntPtr dev, out string @string, UIntPtr maxlen) {
+    public static int HIDGetSerialNumberString(IntPtr dev, out string @string, UIntPtr maxlen)
+    {
         // Allocate a buffer for maxlen characters
         var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
         var buf = Marshal.AllocHGlobal((int)maxbytes);
@@ -423,7 +426,8 @@ public static partial class SDL
     /// <returns>0 on success or a negative error code on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    public static int HIDGetIndexedString(IntPtr dev, int stringIndex, out string @string, UIntPtr maxlen) {
+    public static int HIDGetIndexedString(IntPtr dev, int stringIndex, out string @string, UIntPtr maxlen)
+    {
         // Allocate a buffer for maxlen characters
         var maxbytes = unchecked(WCharStringMarshaller.WCharSize * maxlen);
         var buf = Marshal.AllocHGlobal((int)maxbytes);

--- a/SDL3-CS/SDL/WCharStringMarshaller.cs
+++ b/SDL3-CS/SDL/WCharStringMarshaller.cs
@@ -73,11 +73,12 @@ public static class WCharStringMarshaller
     }
     
     // The size in bytes of a wide character for the current runtime
-    public static UIntPtr WCharSize {
+    public static UIntPtr WCharSize
+    {
         get => (UIntPtr)(
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
                 2 : 4
-            );
+        );
     }
         
 

--- a/SDL3-CS/SDL/WCharStringMarshaller.cs
+++ b/SDL3-CS/SDL/WCharStringMarshaller.cs
@@ -71,6 +71,15 @@ public static class WCharStringMarshaller
 
         public static void Free(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
     }
+    
+    // The size in bytes of a wide character for the current runtime
+    public static UIntPtr WCharSize {
+        get => (UIntPtr)(
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 
+                2 : 4
+            );
+    }
+        
 
     // Выбираем реализацию в зависимости от платформы
     public static IntPtr ConvertToUnmanaged(string? managed)


### PR DESCRIPTION
I've created wrappers for the HIDAPI functions that output wide strings to correct the original buggy behaviour: `HIDGetManufacturerString`, `HIDGetProductString`, `HIDGetSerialNumberString`, and `HIDGetIndexedString`. These are tested and working on Windows 11 x64.

I also changed the types of the wide string fields `SerialNumber`, `ManufacturerString`, and `ProductString` in the struct `HIDDeviceInfo` to `IntPtr`, as marshalling them as UTF-8 strings was resulting in incorrect values. Sadly custom marshalling is not supported on struct fields, and there doesn't seem to be a way to automatically marshal these correctly into managed strings. This is a breaking change, but it is unlikely anyone was depending on this buggy behaviour.