### PR TITLE
Assign result of StringToPointer to _entrypoint

### DIFF
--- a/SDL3-CS/SDL/GPU/gpu/GPUShaderCreateInfo.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUShaderCreateInfo.cs
@@ -90,7 +90,7 @@ public static partial class SDL
         public string Entrypoint
         {
             get => PointerToString(_entrypoint)!;
-            set => StringToPointer(value);
+            set => _entrypoint = StringToPointer(value);
         }
     }
 }


### PR DESCRIPTION
Fixes issue mentioned in edwardgushchin/SDL3-CS#148.

Work around is to use `_entryPoint` instead of `EntryPoint` when creating a `GPUShaderCreateInfo` struct instance.