### PR TITLE
Make settable boolean properties

### DIFF
--- a/SDL3-CS/SDL/GPU/gpu/GPUDepthStencilState.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUDepthStencilState.cs
@@ -63,12 +63,9 @@ public static partial class SDL
         
         private Byte _enableDepthTest;
         
-        /// <summary>
-        /// true enables depth writes. Depth writes are always disabled when enable_depth_test is false.
-        /// </summary>
         private Byte _enableDepthWrite;
         
-        public Byte EnableStencilTest;
+        public Byte _enableStencilTest;
         
         private Byte _padding1;
         
@@ -79,11 +76,28 @@ public static partial class SDL
         /// <summary>
         /// true enables the depth test.
         /// </summary>
-        public bool EnableDepthTest => _enableDepthTest > 0;
-        
+        public bool EnableDepthTest
+        {
+            get => _enableDepthTest > 0;
+            set => _enableDepthTest = (byte)(value ? 1 : 0);
+        }
+
+        /// <summary>
+        /// true enables depth writes. Depth writes are always disabled when enable_depth_test is false.
+        /// </summary>
+        public bool EnableDepthWrite
+        {
+            get => _enableDepthWrite > 0;
+            set => _enableDepthWrite = (byte)(value ? 1 : 0);
+        }
+
         /// <summary>
         /// true enables the stencil test.
         /// </summary>
-        public bool EnableDepthWrite => _enableDepthWrite > 0;
+        public bool EnableStencilTest
+        {
+            get => _enableStencilTest > 0;
+            set => _enableStencilTest = (byte)(value ? 1 : 0);
+        }
     }
 }

--- a/SDL3-CS/SDL/GPU/gpu/GPUGraphicsPipelineTargetInfo.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUGraphicsPipelineTargetInfo.cs
@@ -53,15 +53,21 @@ public static partial class SDL
         /// </summary>
         public GPUTextureFormat DepthStencilFormat;
         
-        /// <summary>
-        /// true specifies that the pipeline uses a depth-stencil target.
-        /// </summary>
-        public  Byte HasDepthStencilTarget;
+        private Byte _hasDepthStencilTarget;
         
         private Byte _padding1;
         
         private Byte _padding2;
         
         private Byte _padding3;
+        
+        /// <summary>
+        /// true specifies that the pipeline uses a depth-stencil target.
+        /// </summary>
+        public bool HasDepthStencilTarget
+        {
+            get => _hasDepthStencilTarget > 0;
+            set => _hasDepthStencilTarget = (byte)(value ? 1 : 0);
+        }
     }
 }

--- a/SDL3-CS/SDL/GPU/gpu/GPURasterizerState.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPURasterizerState.cs
@@ -83,11 +83,19 @@ public static partial class SDL
         /// <summary>
         /// true to bias fragment depth values.
         /// </summary>
-        public bool EnableDepthBias => _enableDepthBias > 0;
+        public bool EnableDepthBias
+        {
+            get => _enableDepthBias > 0;
+            set => _enableDepthBias = (byte)(value ? 1 : 0);
+        }
 
         /// <summary>
         /// true to enable depth clip, false to enable depth clamp.
         /// </summary>
-        public bool EnableDepthClip => _enableDepthClip > 0;
+        public bool EnableDepthClip
+        {
+            get => _enableDepthClip > 0;
+            set => _enableDepthClip = (byte)(value ? 1 : 0);
+        }
     }
 }


### PR DESCRIPTION
Expose byte fields in structs as settable bool properties. This continues the pattern established in other parts of the codebase.

Fixes #154 #155 #156