### PR TITLE
Enable DXC for SDL_shadercross Windows workflow builds

### DIFF
--- a/.github/workflows/build-sdl_shadercross.yml
+++ b/.github/workflows/build-sdl_shadercross.yml
@@ -117,6 +117,19 @@ jobs:
         run: cmake --install "$BUILD_DIR/SDL" --config ${CMAKE_BUILD_TYPE}
 
       # DXC/vcpkg шаги удалены (собираем без DXC)
+      - name: Download DXC binaries (Windows)
+        if: matrix.host_os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $dxcVersion = "v1.8.2407.1"
+          $dxcZip = "dxc_2024_07_26.zip"
+          $dxcUrl = "https://github.com/microsoft/DirectXShaderCompiler/releases/download/$dxcVersion/$dxcZip"
+          $destRoot = Join-Path $env:GITHUB_WORKSPACE "SDL_shadercross/external/DirectXShaderCompiler-binaries"
+          $zipPath = Join-Path $env:RUNNER_TEMP $dxcZip
+          New-Item -ItemType Directory -Force -Path $destRoot | Out-Null
+          Invoke-WebRequest -Uri $dxcUrl -OutFile $zipPath
+          Expand-Archive -Path $zipPath -DestinationPath $destRoot -Force
 
       - name: Build & Install SPIRV-Cross
         shell: bash
@@ -145,6 +158,13 @@ jobs:
             if [[ -f "$d/SDL3Config.cmake" ]]; then SDL_HINT="-DSDL3_DIR=$d"; break; fi
           done
 
+          DXC_FLAG=""
+          if [[ "${{ matrix.host_os }}" == "Windows" ]]; then
+            DXC_FLAG="-DSDLSHADERCROSS_DXC=ON"
+          else
+            DXC_FLAG="-DSDLSHADERCROSS_DXC=OFF"
+          fi
+
           cmake -S SDL_shadercross -B "$BUILD_DIR/SDL_shadercross" \
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
             -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
@@ -155,7 +175,7 @@ jobs:
             -DSDLSHADERCROSS_STATIC=ON \
             -DSDLSHADERCROSS_CLI=OFF \
             -DSDLSHADERCROSS_SPIRVCROSS_SHARED=ON \
-            -DSDLSHADERCROSS_DXC=OFF \
+            ${DXC_FLAG} \
             ${SDL_HINT} \
             ${{ matrix.cmake_osx_arch || '' }}
 
@@ -166,6 +186,37 @@ jobs:
       - name: Install SDL_shadercross
         shell: bash
         run: cmake --install "$BUILD_DIR/SDL_shadercross" --config ${CMAKE_BUILD_TYPE}
+
+      - name: Stage DXC runtime binaries (Windows)
+        if: matrix.host_os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $installBin = Join-Path $env:INSTALL_PREFIX "bin"
+          $dxcRoot = Join-Path $env:GITHUB_WORKSPACE "SDL_shadercross/external/DirectXShaderCompiler-binaries"
+          if (!(Test-Path $installBin)) {
+            New-Item -ItemType Directory -Force -Path $installBin | Out-Null
+          }
+          $binCandidates = @(
+            Join-Path $dxcRoot "bin/${{ matrix.arch_label }}",
+            Join-Path $dxcRoot "bin/${{ matrix.vs_arch }}",
+            Join-Path $dxcRoot "bin/x64",
+            Join-Path $dxcRoot "windows/bin/${{ matrix.arch_label }}",
+            Join-Path $dxcRoot "windows/bin/${{ matrix.vs_arch }}",
+            Join-Path $dxcRoot "windows/bin/x64"
+          )
+          $found = $false
+          foreach ($binDir in $binCandidates) {
+            if (Test-Path $binDir) {
+              Copy-Item -Path (Join-Path $binDir "dxcompiler.dll") -Destination $installBin -Force
+              Copy-Item -Path (Join-Path $binDir "dxil.dll") -Destination $installBin -Force
+              $found = $true
+              break
+            }
+          }
+          if (-not $found) {
+            Write-Error "DXC binaries not found under $dxcRoot"
+          }
 
       - name: Assert SDL3_shadercross is installed
         shell: bash
@@ -198,4 +249,3 @@ jobs:
             ${{ env.INSTALL_PREFIX }}/lib/**
             ${{ env.INSTALL_PREFIX }}/bin/**
             ${{ env.INSTALL_PREFIX }}/lib/cmake/SDL3_shadercross/**
-


### PR DESCRIPTION
### Motivation
- The SDL3-CS.Native.Shadercross package lacked DXC (DirectX Shader Compiler) support which prevents runtime HLSL → SPIRV compilation, so CI must produce builds that include DXC on Windows.

### Description
- Modified ` .github/workflows/build-sdl_shadercross.yml` to add a `Download DXC binaries (Windows)` step that fetches official DirectXShaderCompiler release artifacts into `SDL_shadercross/external/DirectXShaderCompiler-binaries` using PowerShell.
- Added a conditional `DXC_FLAG` passed to CMake that sets `-DSDLSHADERCROSS_DXC=ON` for Windows runners and `OFF` elsewhere so Windows builds enable DXC integration.
- Added a `Stage DXC runtime binaries (Windows)` step that copies `dxcompiler.dll` and `dxil.dll` into the `INSTALL_PREFIX/bin` so the runtime DLLs are included in uploaded artifacts.
- Changes are limited to the workflow; non-Windows builds continue to build without DXC by default.

### Testing
- No automated tests were executed in this change because it only updates the GitHub Actions workflow; please run the workflow to validate Windows artifacts (presence of `dxcompiler.dll`/`dxil.dll`) and confirm HLSL compilation at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984af8e69cc832390375be6594b7163)