### PR TITLE
Prepare release 3.4.10.4

### DIFF
--- a/.github/release-tools/Test-PublicWrapperXmlDocs.ps1
+++ b/.github/release-tools/Test-PublicWrapperXmlDocs.ps1
@@ -9,7 +9,8 @@ if (-not (Test-Path -LiteralPath $SourceRoot -PathType Container)) {
 }
 
 $resolvedSourceRoot = (Resolve-Path -LiteralPath $SourceRoot).Path
-$violations = New-Object System.Collections.Generic.List[object]
+$privateDocViolations = New-Object System.Collections.Generic.List[object]
+$missingPublicDocViolations = New-Object System.Collections.Generic.List[object]
 
 function Get-RelativePath {
     param(
@@ -27,15 +28,112 @@ function Get-RelativePath {
 function Test-PrivateMethodDeclaration {
     param(
         [Parameter(Mandatory)]
+        [AllowEmptyString()]
         [string] $Line
     )
 
     return $Line -match '^\s*private\b.*\(' -and $Line -notmatch '^\s*private\b.*\b(class|record|struct)\b'
 }
 
+function Test-PublicMethodDeclaration {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Line
+    )
+
+    if ($Line -notmatch '^\s*public\b') {
+        return $false
+    }
+
+    if ($Line -match '^\s*public\s+(?:(?:static|partial|abstract|sealed|readonly|unsafe|ref)\s+)*(class|record|struct|interface|enum|delegate)\b') {
+        return $false
+    }
+
+    return $Line -match '^\s*public\s+(?:(?:static|partial|unsafe|extern|override|virtual|new|readonly|sealed|async)\s+)*(?:[\w@][\w@\.<>[\],?*]*\s+)+[\w@]+\s*\('
+}
+
+function Test-IgnorableBetweenDocAndDeclaration {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $Line
+    )
+
+    return $Line -match '^\s*$' -or
+        $Line -match '^\s*\[' -or
+        $Line -match '^\s*//(?!/)' -or
+        $Line -match '^\s*#pragma\b'
+}
+
+function Get-DeclarationLineIndex {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string[]] $Lines,
+
+        [Parameter(Mandatory)]
+        [int] $StartIndex
+    )
+
+    $targetLine = $StartIndex
+    while ($targetLine -lt $Lines.Count) {
+        if (Test-IgnorableBetweenDocAndDeclaration -Line $Lines[$targetLine]) {
+            $targetLine++
+            continue
+        }
+
+        break
+    }
+
+    return $targetLine
+}
+
+function Test-HasXmlDocumentation {
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string[]] $Lines,
+
+        [Parameter(Mandatory)]
+        [int] $DeclarationIndex
+    )
+
+    $lineIndex = $DeclarationIndex - 1
+    while ($lineIndex -ge 0) {
+        $line = $Lines[$lineIndex]
+
+        if ($line -match '^\s*$' -or $line -match '^\s*//(?!/)' -or $line -match '^\s*#pragma\b') {
+            $lineIndex--
+            continue
+        }
+
+        if ($line -match '^\s*\]') {
+            while ($lineIndex -ge 0 -and $Lines[$lineIndex] -notmatch '^\s*\[') {
+                $lineIndex--
+            }
+
+            if ($lineIndex -ge 0) {
+                $lineIndex--
+            }
+
+            continue
+        }
+
+        if ($line -match '^\s*\[') {
+            $lineIndex--
+            continue
+        }
+
+        break
+    }
+
+    return $lineIndex -ge 0 -and $Lines[$lineIndex] -match '^\s*///'
+}
+
 Get-ChildItem -LiteralPath $resolvedSourceRoot -Recurse -Filter '*.cs' | ForEach-Object {
     $path = $_.FullName
-    $lines = Get-Content -LiteralPath $path
+    $lines = @(Get-Content -LiteralPath $path)
 
     for ($i = 0; $i -lt $lines.Count; $i++) {
         if ($lines[$i] -notmatch '^\s*///') {
@@ -47,24 +145,11 @@ Get-ChildItem -LiteralPath $resolvedSourceRoot -Recurse -Filter '*.cs' | ForEach
             $i++
         }
         $docEnd = $i - 1
-        $targetLine = $i
-        while ($targetLine -lt $lines.Count) {
-            if ($lines[$targetLine] -match '^\s*$') {
-                $targetLine++
-                continue
-            }
-
-            if ($lines[$targetLine] -match '^\s*\[') {
-                $targetLine++
-                continue
-            }
-
-            break
-        }
+        $targetLine = Get-DeclarationLineIndex -Lines $lines -StartIndex $i
 
         if ($targetLine -lt $lines.Count -and (Test-PrivateMethodDeclaration -Line $lines[$targetLine])) {
             $docLine = $lines[$docStart].Trim()
-            $violations.Add([pscustomobject]@{
+            $privateDocViolations.Add([pscustomobject]@{
                 File = Get-RelativePath -Path $path -Root $resolvedSourceRoot
                 DocLine = $docStart + 1
                 DeclarationLine = $targetLine + 1
@@ -75,14 +160,39 @@ Get-ChildItem -LiteralPath $resolvedSourceRoot -Recurse -Filter '*.cs' | ForEach
 
         $i = $docEnd
     }
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if (-not (Test-PublicMethodDeclaration -Line $lines[$i])) {
+            continue
+        }
+
+        if (Test-HasXmlDocumentation -Lines $lines -DeclarationIndex $i) {
+            continue
+        }
+
+        $missingPublicDocViolations.Add([pscustomobject]@{
+            File = Get-RelativePath -Path $path -Root $resolvedSourceRoot
+            DeclarationLine = $i + 1
+            Declaration = $lines[$i].Trim()
+        })
+    }
 }
 
-if ($violations.Count -gt 0) {
-    $violations |
+if ($privateDocViolations.Count -gt 0) {
+    $privateDocViolations |
         Sort-Object File, DocLine |
         Format-Table File, DocLine, DeclarationLine, Declaration -AutoSize
 
-    throw "Found $($violations.Count) XML documentation block(s) attached to private methods. Move user-facing documentation to the public wrapper API."
+    throw "Found $($privateDocViolations.Count) XML documentation block(s) attached to private methods. Move user-facing documentation to the public wrapper API."
+}
+
+if ($missingPublicDocViolations.Count -gt 0) {
+    $missingPublicDocViolations |
+        Sort-Object File, DeclarationLine |
+        Format-Table File, DeclarationLine, Declaration -AutoSize
+
+    throw "Found $($missingPublicDocViolations.Count) public method declaration(s) without XML documentation."
 }
 
 Write-Host 'Public wrapper XML documentation placement is valid.'
+Write-Host 'Public method XML documentation completeness is valid.'

--- a/.github/release-tools/release-notes/v3.4.10.4.md
+++ b/.github/release-tools/release-notes/v3.4.10.4.md
@@ -1,0 +1,22 @@
+# SDL3-CS 3.4.10.4
+
+Stable SDL3-CS bugfix release for SDL 3.4.10.
+
+This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.10.4` |
+| `SDL3-CS.<Platform>` | `3.4.10.4` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.4` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.4` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.4` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.4` |
+
+## Changes
+
+- Fixed `SDL.AppInit` and `SDL.AppInitFunc` to pass `appstate` by reference, matching SDL's `void **appstate` contract so callbacks can store application state for later `AppIterate`, `AppEvent`, and `AppQuit` calls.
+- Added a public wrapper XML documentation completeness gate and filled the missing public XML documentation found around SDL main callbacks and related public helpers.
+- Switched the private `SDL_AppEvent` native entry point to the `LibraryImport` path while preserving the public `SDL.AppEvent(IntPtr appstate, ref SDL.Event event)` API and event mutation behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ For this repository, agent operational materials live inside the worktree but mu
 - Do not attach upstream C API XML documentation blocks, including blocks that start with `<code>extern SDL_DECLSPEC ...</code>`, to `private` `LibraryImport`, `DllImport`, `extern`, hook, delegate, or native-helper members.
 - When a binding uses a private native stub plus delegate/hook plus public wrapper, keep the original C declaration and the full XML documentation immediately above the public wrapper method. Keep the private native stub undocumented except for required attributes.
 - If there is no public wrapper for a native entry point, add the public wrapper first or leave the C API documentation out until the exposed API exists; do not hide user documentation on a private member.
-- Full-branch audits must run `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1` and report zero XML documentation blocks attached to private methods before wrapper documentation work is considered complete.
+- Every public C# method declaration in `SDL3-CS/**/*.cs` must have an XML documentation block. Use full upstream-derived XML documentation for SDL wrapper APIs and concise local XML documentation or `<inheritdoc/>` for managed helpers, overloads, `IDisposable.Dispose`, and `Stream` overrides.
+- Full-branch audits must run `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1` and report zero XML documentation blocks attached to private methods and zero public methods without XML documentation before wrapper documentation work is considered complete.
 
 ## SDL C API Porting Workflow
 - Use this workflow when the user provides an original SDL, SDL_image, SDL_mixer, SDL_ttf, or SDL_shadercross C API declaration with a Doxygen comment and asks to add a new C# binding, update an existing binding, or align XML C# documentation with the original SDL documentation.

--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,16 +4,16 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Latest Release
 
-Current stable release: [`SDL3-CS 3.4.10.3`](https://github.com/edwardgushchin/SDL3-CS/releases/tag/v3.4.10.3).
+Current stable release: [`SDL3-CS 3.4.10.4`](https://github.com/edwardgushchin/SDL3-CS/releases/tag/v3.4.10.4).
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.10.3` |
-| `SDL3-CS.<Platform>` | `3.4.10.3` |
-| `SDL3-CS.<Platform>.Image` | `3.4.4.3` |
-| `SDL3-CS.<Platform>.Mixer` | `3.2.4.3` |
-| `SDL3-CS.<Platform>.TTF` | `3.2.2.3` |
-| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.3` |
+| `SDL3-CS` | `3.4.10.4` |
+| `SDL3-CS.<Platform>` | `3.4.10.4` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.4` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.4` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.4` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.4` |
 
 ## Documentation
 

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -108,6 +108,8 @@ SDL3.Tests.SDL.Basics.Main.PInvokeTests.AppInit_ForwardsStateArgumentsAndReturns
 Console.WriteLine("SDL.AppInit binding test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.AppInit_NullAndEmptyArgumentsForwardNull();
 Console.WriteLine("SDL.AppInit null and empty argv normalization test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.AppInitFunc_AllowsCallbackToAssignAppstate();
+Console.WriteLine("SDL.AppInitFunc appstate assignment test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.AppIterate_ForwardsStateAndReturnsNativeValue();
 Console.WriteLine("SDL.AppIterate binding test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.AppEvent_ForwardsStateEventRefAndReturnsNativeValue();

--- a/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
@@ -8,6 +8,7 @@ namespace SDL3.Tests.SDL.Basics.Main;
 internal static class PInvokeTests
 {
     private static IntPtr capturedAppstate;
+    private static IntPtr nextAppstate;
     private static int capturedArgc;
     private static string[]? capturedArgv;
     private static uint capturedEventType;
@@ -30,17 +31,21 @@ internal static class PInvokeTests
     {
         MethodInfo nativeMethod = GetNativeMethod("SDL_AppInit");
         AssertLibraryImport(nativeMethod, "SDL_AppInit");
+        AssertByRefIntPtrParameter(nativeMethod, "appstate");
         AssertStringArrayParameterMarshal(nativeMethod, "argv", UnmanagedType.LPArray, UnmanagedType.LPUTF8Str);
 
         ResetCaptureState();
         nextAppResult = SDL3.SDL.AppResult.Continue;
+        nextAppstate = (IntPtr)909;
         string[] argv = ["app", "--video"];
         using NativeHookScope _ = NativeHookScope.Install("AppInitNativeFunction", nameof(CaptureAppInit));
 
-        SDL3.SDL.AppResult result = SDL3.SDL.AppInit((IntPtr)101, argv.Length, argv);
+        IntPtr appstate = (IntPtr)101;
+        SDL3.SDL.AppResult result = SDL3.SDL.AppInit(ref appstate, argv.Length, argv);
 
         TestAssert.Equal(SDL3.SDL.AppResult.Continue, result, "SDL.AppInit must return native AppResult.");
-        TestAssert.Equal((IntPtr)101, capturedAppstate, "SDL.AppInit must forward appstate.");
+        TestAssert.Equal((IntPtr)101, capturedAppstate, "SDL.AppInit must forward initial appstate.");
+        TestAssert.Equal((IntPtr)909, appstate, "SDL.AppInit must preserve appstate mutations from the native callback.");
         TestAssert.Equal(argv.Length, capturedArgc, "SDL.AppInit must forward argc.");
         TestAssert.True(ReferenceEquals(argv, capturedArgv), "SDL.AppInit must forward argv array.");
         TestAssert.Equal(1, capturedCallCount, "SDL.AppInit must call native hook once.");
@@ -51,17 +56,32 @@ internal static class PInvokeTests
         ResetCaptureState();
         using NativeHookScope _ = NativeHookScope.Install("AppInitNativeFunction", nameof(CaptureAppInit));
 
-        SDL3.SDL.AppInit(IntPtr.Zero, 0, null!);
+        IntPtr appstate = IntPtr.Zero;
+        SDL3.SDL.AppInit(ref appstate, 0, null!);
 
         TestAssert.Equal(0, capturedArgc, "SDL.AppInit must forward zero argc for null argv.");
         TestAssert.Equal<string[]?>(null, capturedArgv, "SDL.AppInit must forward null argv unchanged.");
 
         string[] argv = [];
-        SDL3.SDL.AppInit(IntPtr.Zero, 0, argv);
+        SDL3.SDL.AppInit(ref appstate, 0, argv);
 
         TestAssert.Equal(0, capturedArgc, "SDL.AppInit must forward zero argc for empty argv.");
         TestAssert.Equal<string[]?>(null, capturedArgv, "SDL.AppInit must normalize empty argv to null before native marshalling.");
         TestAssert.Equal(2, capturedCallCount, "SDL.AppInit must call native hook for both branches.");
+    }
+
+    public static void AppInitFunc_AllowsCallbackToAssignAppstate()
+    {
+        MethodInfo invoke = typeof(SDL3.SDL.AppInitFunc).GetMethod("Invoke")!;
+        AssertByRefIntPtrParameter(invoke, "appstate");
+
+        IntPtr appstate = IntPtr.Zero;
+        SDL3.SDL.AppInitFunc appinit = AssignAppstate;
+
+        SDL3.SDL.AppResult result = appinit(ref appstate, 0, null);
+
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, result, "SDL.AppInitFunc callback must return AppResult.");
+        TestAssert.Equal((IntPtr)5150, appstate, "SDL.AppInitFunc must allow managed callbacks to assign appstate.");
     }
 
     public static void AppIterate_ForwardsStateAndReturnsNativeValue()
@@ -215,6 +235,7 @@ internal static class PInvokeTests
         AssertLibraryImport(nativeMethod, "SDL_EnterAppMainCallbacks");
         AssertStringArrayParameterMarshal(nativeMethod, "argv", UnmanagedType.LPArray, UnmanagedType.LPUTF8Str);
         AssertCallbackCdecl(typeof(SDL3.SDL.AppInitFunc), "SDL.AppInitFunc");
+        AssertByRefIntPtrParameter(typeof(SDL3.SDL.AppInitFunc).GetMethod("Invoke")!, "appstate");
         AssertCallbackCdecl(typeof(SDL3.SDL.AppIterateFunc), "SDL.AppIterateFunc");
         AssertCallbackCdecl(typeof(SDL3.SDL.AppEventFunc), "SDL.AppEventFunc");
         AssertCallbackCdecl(typeof(SDL3.SDL.AppQuitFunc), "SDL.AppQuitFunc");
@@ -332,15 +353,17 @@ internal static class PInvokeTests
         capturedStyle = 0;
         capturedHInst = IntPtr.Zero;
         capturedReserved = IntPtr.Zero;
+        nextAppstate = IntPtr.Zero;
         nextAppResult = default;
         nextInt = 0;
         nextBool = false;
         capturedCallCount = 0;
     }
 
-    private static SDL3.SDL.AppResult CaptureAppInit(IntPtr appstate, int argc, string[]? argv)
+    private static SDL3.SDL.AppResult CaptureAppInit(ref IntPtr appstate, int argc, string[]? argv)
     {
         capturedAppstate = appstate;
+        appstate = nextAppstate;
         capturedArgc = argc;
         capturedArgv = argv;
         capturedCallCount++;
@@ -435,8 +458,14 @@ internal static class PInvokeTests
         return 0;
     }
 
-    private static SDL3.SDL.AppResult HandleAppInit(IntPtr appstate, int argc, string[]? argv)
+    private static SDL3.SDL.AppResult HandleAppInit(ref IntPtr appstate, int argc, string[]? argv)
     {
+        return SDL3.SDL.AppResult.Continue;
+    }
+
+    private static SDL3.SDL.AppResult AssignAppstate(ref IntPtr appstate, int argc, string[]? argv)
+    {
+        appstate = (IntPtr)5150;
         return SDL3.SDL.AppResult.Continue;
     }
 
@@ -510,6 +539,13 @@ internal static class PInvokeTests
         TestAssert.NotNull(marshalAs, $"SDL.{method.Name} parameter {parameterName} must keep MarshalAs metadata.");
         TestAssert.Equal(unmanagedType, marshalAs!.Value, $"SDL.{method.Name} parameter {parameterName} must use expected array marshalling.");
         TestAssert.Equal(arraySubType, marshalAs.ArraySubType, $"SDL.{method.Name} parameter {parameterName} must keep UTF-8 string array marshalling.");
+    }
+
+    private static void AssertByRefIntPtrParameter(MethodInfo method, string parameterName)
+    {
+        ParameterInfo parameter = method.GetParameters().Single(param => param.Name == parameterName);
+        TestAssert.True(parameter.ParameterType.IsByRef, $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must be passed by reference.");
+        TestAssert.Equal(typeof(IntPtr), parameter.ParameterType.GetElementType(), $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must be a by-ref IntPtr.");
     }
 
     private static void AssertCallbackCdecl(Type callbackType, string callbackName)

--- a/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
@@ -103,7 +103,8 @@ internal static class PInvokeTests
     public static void AppEvent_ForwardsStateEventRefAndReturnsNativeValue()
     {
         MethodInfo nativeMethod = GetNativeMethod("SDL_AppEvent");
-        AssertDllImport(nativeMethod, "SDL_AppEvent");
+        AssertLibraryImport(nativeMethod, "SDL_AppEvent");
+        AssertPointerParameter(nativeMethod, "event", typeof(SDL3.SDL.Event));
 
         ResetCaptureState();
         nextAppResult = SDL3.SDL.AppResult.Failure;
@@ -377,11 +378,11 @@ internal static class PInvokeTests
         return nextAppResult;
     }
 
-    private static SDL3.SDL.AppResult CaptureAppEvent(IntPtr appstate, ref SDL3.SDL.Event @event)
+    private static unsafe SDL3.SDL.AppResult CaptureAppEvent(IntPtr appstate, SDL3.SDL.Event* @event)
     {
         capturedAppstate = appstate;
-        capturedEventType = @event.Type;
-        @event.Type = (uint)SDL3.SDL.EventType.Terminating;
+        capturedEventType = @event->Type;
+        @event->Type = (uint)SDL3.SDL.EventType.Terminating;
         capturedCallCount++;
         return nextAppResult;
     }
@@ -546,6 +547,13 @@ internal static class PInvokeTests
         ParameterInfo parameter = method.GetParameters().Single(param => param.Name == parameterName);
         TestAssert.True(parameter.ParameterType.IsByRef, $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must be passed by reference.");
         TestAssert.Equal(typeof(IntPtr), parameter.ParameterType.GetElementType(), $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must be a by-ref IntPtr.");
+    }
+
+    private static void AssertPointerParameter(MethodInfo method, string parameterName, Type elementType)
+    {
+        ParameterInfo parameter = method.GetParameters().Single(param => param.Name == parameterName);
+        TestAssert.True(parameter.ParameterType.IsPointer, $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must be passed as a native pointer.");
+        TestAssert.Equal(elementType, parameter.ParameterType.GetElementType(), $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must point to the expected element type.");
     }
 
     private static void AssertCallbackCdecl(Type callbackType, string callbackName)

--- a/SDL3-CS/SDL/Additional Functionality/dialog/DialogFileFilter.cs
+++ b/SDL3-CS/SDL/Additional Functionality/dialog/DialogFileFilter.cs
@@ -48,6 +48,7 @@ public static partial class SDL
         public readonly IntPtr Name = Marshal.StringToCoTaskMemUTF8(name);
         public readonly IntPtr Pattern = Marshal.StringToCoTaskMemUTF8(pattern);
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (Name != IntPtr.Zero)

--- a/SDL3-CS/SDL/Additional Functionality/stdinc/Macros.cs
+++ b/SDL3-CS/SDL/Additional Functionality/stdinc/Macros.cs
@@ -27,6 +27,18 @@ namespace SDL3;
 
 public static partial class SDL
 {
+    /// <code>#define SDL_FOURCC(A, B, C, D)</code>
+    /// <summary>
+    /// <para>Define a four character code as a <see cref="uint"/>.</para>
+    /// </summary>
+    /// <param name="a">the first ASCII character.</param>
+    /// <param name="b">the second ASCII character.</param>
+    /// <param name="c">the third ASCII character.</param>
+    /// <param name="d">the fourth ASCII character.</param>
+    /// <returns>the four characters converted into a <see cref="uint"/>, one character
+    /// per-byte.</returns>
+    /// <threadsafety>It is safe to call this macro from any thread.</threadsafety>
+    /// <since>This macro is available since SDL 3.2.0.</since>
     [Macro]
 	public static uint FourCC(char a, char b, char c, char d)
 	{

--- a/SDL3-CS/SDL/Basics/init/Callbacks.cs
+++ b/SDL3-CS/SDL/Basics/init/Callbacks.cs
@@ -43,7 +43,7 @@ public partial class SDL
     /// terminate with success, <see cref="AppResult.Continue"/> to continue.</returns>
     /// <since>This datatype is available since SDL 3.2.0</since>
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate AppResult AppInitFunc(IntPtr appstate, int argc, string[]? argv);
+    public delegate AppResult AppInitFunc(ref IntPtr appstate, int argc, string[]? argv);
     
     
     /// <code>typedef SDL_AppResult (SDLCALL *SDL_AppIterate_func)(void *appstate);</code>

--- a/SDL3-CS/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS/SDL/Basics/main/PInvoke.cs
@@ -31,8 +31,8 @@ public partial class SDL
 {
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_AppInit"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial AppResult SDL_AppInit(IntPtr appstate, int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv);
-    private delegate AppResult AppInitNative(IntPtr appstate, int argc, string[]? argv);
+    private static partial AppResult SDL_AppInit(ref IntPtr appstate, int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv);
+    private delegate AppResult AppInitNative(ref IntPtr appstate, int argc, string[]? argv);
     private static AppInitNative AppInitNativeFunction = SDL_AppInit;
 
     /// <code>extern SDLMAIN_DECLSPEC SDL_AppResult SDLCALL SDL_AppInit(void **appstate, int argc, char *argv[]);</code>
@@ -71,9 +71,9 @@ public partial class SDL
     /// <seealso cref="AppIterate"/>
     /// <seealso cref="AppEvent"/>
     /// <seealso cref="AppQuit"/>
-    public static AppResult AppInit(IntPtr appstate, int argc, string[]? argv)
+    public static AppResult AppInit(ref IntPtr appstate, int argc, string[]? argv)
     {
-        return AppInitNativeFunction(appstate, argc, NormalizeMainArgv(argv));
+        return AppInitNativeFunction(ref appstate, argc, NormalizeMainArgv(argv));
     }
 
 

--- a/SDL3-CS/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS/SDL/Basics/main/PInvoke.cs
@@ -105,7 +105,7 @@ public partial class SDL
     /// <para>The <c>appstate</c> parameter is an optional pointer provided by the app during
     /// <see cref="AppInit"/>. If the app never provided a pointer, this will be <c>null</c>.</para>
     /// <para>If this function returns <see cref="AppResult.Continue"/>, the app will continue normal
-    /// operation, receiving repeated calls to <see cref="AppIterate"/> and SDL_AppEvent for
+    /// operation, receiving repeated calls to <see cref="AppIterate"/> and <see cref="AppEvent"/> for
     /// the life of the program. If this function returns <see cref="AppResult.Failure"/>, SDL will
     /// call <see cref="AppQuit"/> and terminate the process with an exit code that reports
     /// an error to the platform. If it returns <see cref="AppResult.Success"/>, SDL calls
@@ -127,13 +127,49 @@ public partial class SDL
     }
 
 
-    //extern SDLMAIN_DECLSPEC SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event);
     [ExcludeFromCodeCoverage]
     [DllImport(SDLLibrary, EntryPoint = "SDL_AppEvent"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static extern AppResult SDL_AppEvent(IntPtr appstate, ref Event @event);
     private delegate AppResult AppEventNative(IntPtr appstate, ref Event @event);
     private static AppEventNative AppEventNativeFunction = SDL_AppEvent;
 
+    /// <code>extern SDLMAIN_DECLSPEC SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event);</code>
+    /// <summary>
+    /// <para>App-implemented event entry point for SDL_MAIN_USE_CALLBACKS apps.</para>
+    /// <para>Apps implement this function when using SDL_MAIN_USE_CALLBACKS. If using a
+    /// standard "main" function, you should not supply this.</para>
+    /// <para>This function is called as needed by SDL after <see cref="AppInit"/> returns
+    /// <see cref="AppResult.Continue"/>. It is called once for each new event.</para>
+    /// <para>There is (currently) no guarantee about what thread this will be called
+    /// from; whatever thread pushes an event onto SDL's queue will trigger this
+    /// function. SDL is responsible for pumping the event queue between each call
+    /// to <see cref="AppIterate"/>, so in normal operation one should only get events in a
+    /// serial fashion, but be careful if you have a thread that explicitly calls
+    /// <see cref="PushEvent"/>. SDL itself will push events to the queue on the main thread.</para>
+    /// <para>Events sent to this function are not owned by the app; if you need to save
+    /// the data, you should copy it.</para>
+    /// <para>This function should not go into an infinite mainloop; it should handle the
+    /// provided event appropriately and return.</para>
+    /// <para>The <c>appstate</c> parameter is an optional pointer provided by the app during
+    /// <see cref="AppInit"/>. If the app never provided a pointer, this will be <c>null</c>.</para>
+    /// <para>If this function returns <see cref="AppResult.Continue"/>, the app will continue normal
+    /// operation, receiving repeated calls to <see cref="AppIterate"/> and <see cref="AppEvent"/> for
+    /// the life of the program. If this function returns <see cref="AppResult.Failure"/>, SDL will
+    /// call <see cref="AppQuit"/> and terminate the process with an exit code that reports
+    /// an error to the platform. If it returns <see cref="AppResult.Success"/>, SDL calls
+    /// <see cref="AppQuit"/> and terminates with an exit code that reports success to the
+    /// platform.</para>
+    /// </summary>
+    /// <param name="appstate">an optional pointer, provided by the app in <see cref="AppInit"/>.</param>
+    /// <param name="event">the new event for the app to examine.</param>
+    /// <returns><see cref="AppResult.Failure"/> to terminate with an error, <see cref="AppResult.Success"/> to
+    /// terminate with success, <see cref="AppResult.Continue"/> to continue.</returns>
+    /// <threadsafety>This function may get called concurrently with
+    /// <see cref="AppIterate"/> or <see cref="AppQuit"/> for events not pushed from
+    /// the main thread.</threadsafety>
+    /// <since>This function is available since SDL 3.2.0.</since>
+    /// <seealso cref="AppInit"/>
+    /// <seealso cref="AppIterate"/>
     public static AppResult AppEvent(IntPtr appstate, ref Event @event)
     {
         return AppEventNativeFunction(appstate, ref @event);

--- a/SDL3-CS/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS/SDL/Basics/main/PInvoke.cs
@@ -128,10 +128,10 @@ public partial class SDL
 
 
     [ExcludeFromCodeCoverage]
-    [DllImport(SDLLibrary, EntryPoint = "SDL_AppEvent"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static extern AppResult SDL_AppEvent(IntPtr appstate, ref Event @event);
-    private delegate AppResult AppEventNative(IntPtr appstate, ref Event @event);
-    private static AppEventNative AppEventNativeFunction = SDL_AppEvent;
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_AppEvent"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static unsafe partial AppResult SDL_AppEvent(IntPtr appstate, Event* @event);
+    private unsafe delegate AppResult AppEventNative(IntPtr appstate, Event* @event);
+    private static unsafe AppEventNative AppEventNativeFunction = SDL_AppEvent;
 
     /// <code>extern SDLMAIN_DECLSPEC SDL_AppResult SDLCALL SDL_AppEvent(void *appstate, SDL_Event *event);</code>
     /// <summary>
@@ -172,7 +172,13 @@ public partial class SDL
     /// <seealso cref="AppIterate"/>
     public static AppResult AppEvent(IntPtr appstate, ref Event @event)
     {
-        return AppEventNativeFunction(appstate, ref @event);
+        unsafe
+        {
+            fixed (Event* eventPtr = &@event)
+            {
+                return AppEventNativeFunction(appstate, eventPtr);
+            }
+        }
     }
 
 

--- a/SDL3-CS/SDL/File and IO Abstractions/iostream/PInvoke.cs
+++ b/SDL3-CS/SDL/File and IO Abstractions/iostream/PInvoke.cs
@@ -525,6 +525,13 @@ public static partial class SDL
     }
 
 
+    [ExcludeFromCodeCoverage]
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_IOprintf"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    // ReSharper disable once InconsistentNaming
+    private static partial UIntPtr SDL_IOprintf(IntPtr context, [MarshalAs(UnmanagedType.LPUTF8Str)] string fmt);
+    private delegate UIntPtr IOprintfNative(IntPtr context, string fmt);
+    private static IOprintfNative IOprintfNativeFunction = SDL_IOprintf;
+
     /// <code>extern SDL_DECLSPEC size_t SDLCALL SDL_IOprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, ...)  SDL_PRINTF_VARARG_FUNC(2);</code>
     /// <summary>
     /// <para>Print to an SDL_IOStream data stream.</para>
@@ -538,18 +545,18 @@ public static partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     /// <seealso cref="IOvprintf"/>
     /// <seealso cref="WriteIO"/>
-    [ExcludeFromCodeCoverage]
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_IOprintf"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    // ReSharper disable once InconsistentNaming
-    private static partial UIntPtr SDL_IOprintf(IntPtr context, [MarshalAs(UnmanagedType.LPUTF8Str)] string fmt);
-    private delegate UIntPtr IOprintfNative(IntPtr context, string fmt);
-    private static IOprintfNative IOprintfNativeFunction = SDL_IOprintf;
-
     public static UIntPtr IOprintf(IntPtr context, string fmt)
     {
         return IOprintfNativeFunction(context, fmt);
     }
 
+
+    [ExcludeFromCodeCoverage]
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_IOvprintf"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    // ReSharper disable once InconsistentNaming
+    private static partial UIntPtr SDL_IOvprintf(IntPtr context, [MarshalAs(UnmanagedType.LPUTF8Str)] string fmt, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[] ap);
+    private delegate UIntPtr IOvprintfNative(IntPtr context, string fmt, string[] ap);
+    private static IOvprintfNative IOvprintfNativeFunction = SDL_IOvprintf;
 
     /// <code>extern SDL_DECLSPEC size_t SDLCALL SDL_IOvprintf(SDL_IOStream *context, SDL_PRINTF_FORMAT_STRING const char *fmt, va_list ap) SDL_PRINTF_VARARG_FUNCV(2);</code>
     /// <summary>
@@ -565,13 +572,6 @@ public static partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     /// <seealso cref="IOprintf"/>
     /// <seealso cref="WriteIO"/>
-    [ExcludeFromCodeCoverage]
-    [LibraryImport(SDLLibrary, EntryPoint = "SDL_IOvprintf"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    // ReSharper disable once InconsistentNaming
-    private static partial UIntPtr SDL_IOvprintf(IntPtr context, [MarshalAs(UnmanagedType.LPUTF8Str)] string fmt, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[] ap);
-    private delegate UIntPtr IOvprintfNative(IntPtr context, string fmt, string[] ap);
-    private static IOvprintfNative IOvprintfNativeFunction = SDL_IOvprintf;
-
     public static UIntPtr IOvprintf(IntPtr context, string fmt, string[] ap)
     {
         return IOvprintfNativeFunction(context, fmt, ap);

--- a/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
@@ -2093,6 +2093,7 @@ public partial class SDL
     private delegate IntPtr BeginGPUComputePassPointerNativeDelegate(IntPtr commandBuffer, IntPtr storageTextureBindings, uint numStorageTextureBindings, IntPtr storageBufferBindings, uint numStorageBufferBindings);
     private static BeginGPUComputePassPointerNativeDelegate BeginGPUComputePassPointerNativeFunction = SDL_BeginGPUComputePass;
 
+    /// <inheritdoc cref="BeginGPUComputePass(nint, GPUStorageTextureReadWriteBinding[], uint, GPUStorageBufferReadWriteBinding[], uint)"/>
     public static IntPtr BeginGPUComputePass(IntPtr commandBuffer, IntPtr storageTextureBindings, uint numStorageTextureBindings, IntPtr storageBufferBindings, uint numStorageBufferBindings)
     {
         return BeginGPUComputePassPointerNativeFunction(commandBuffer, storageTextureBindings, numStorageTextureBindings, storageBufferBindings, numStorageBufferBindings);

--- a/SDL3-CS/SDL/Input Events/keycode/Macros.cs
+++ b/SDL3-CS/SDL/Input Events/keycode/Macros.cs
@@ -30,6 +30,12 @@ namespace SDL3;
 
 public static partial class SDL
 {
+    /// <code>#define SDL_SCANCODE_TO_KEYCODE(X) (X | SDLK_SCANCODE_MASK)</code>
+    /// <summary>
+    /// <para>Convert a scancode value to the corresponding scancode-masked keycode value.</para>
+    /// </summary>
+    /// <param name="scancode">the scancode to convert.</param>
+    /// <returns>the keycode value for <paramref name="scancode"/>.</returns>
     [Macro]
     public static Keycode ScancodeToKeycode(Scancode scancode)
     {

--- a/SDL3-CS/SDL/Input Events/mouse/Macros.cs
+++ b/SDL3-CS/SDL/Input Events/mouse/Macros.cs
@@ -30,6 +30,12 @@ namespace SDL3;
 
 public static partial class SDL
 {
+    /// <code>#define SDL_BUTTON_MASK(X) (1u &lt;&lt; ((X)-1))</code>
+    /// <summary>
+    /// <para>Convert a mouse button number to the corresponding button bitmask.</para>
+    /// </summary>
+    /// <param name="x">the mouse button number to convert.</param>
+    /// <returns>the bitmask for <paramref name="x"/>.</returns>
     [Macro]
     public static uint ButtonMask(int x) => 1u << (x - 1);
 

--- a/SDL3-CS/SDL/Stream.cs
+++ b/SDL3-CS/SDL/Stream.cs
@@ -116,6 +116,7 @@ public static partial class SDL
         /// <summary>The number of bytes available in the I/O stream.</summary>
         public int Length { get; }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (_disposed) return;
@@ -207,6 +208,7 @@ public static partial class SDL
             set => Seek(value, SeekOrigin.Begin);
         }
 
+        /// <inheritdoc/>
         public override int Read(byte[] buffer, int offset, int count)
         {
             ThrowIfDisposed();
@@ -227,6 +229,7 @@ public static partial class SDL
             }
         }
 
+        /// <inheritdoc/>
         public override void Write(byte[] buffer, int offset, int count)
         {
             ThrowIfDisposed();
@@ -248,6 +251,7 @@ public static partial class SDL
             }
         }
 
+        /// <inheritdoc/>
         public override long Seek(long offset, SeekOrigin origin)
         {
             ThrowIfDisposed();
@@ -264,11 +268,13 @@ public static partial class SDL
             return pos < 0 ? throw new IOException($"Failed to seek in SDL_IOStream: {GetError()}") : pos;
         }
 
+        /// <inheritdoc/>
         public override void Flush()
         {
             // SDL_IOStream is typically not buffered from the .NET side.
         }
 
+        /// <inheritdoc/>
         public override void SetLength(long value) =>
             throw new NotSupportedException("Changing the length of an SDL_IOStream is not supported.");
 

--- a/SDL3-CS/SDL/WCharStringMarshaller.cs
+++ b/SDL3-CS/SDL/WCharStringMarshaller.cs
@@ -42,6 +42,11 @@ public static class WCharStringMarshaller
 
     public static class WChar16 // Windows (UTF-16)
     {
+        /// <summary>
+        /// Converts a managed string to an unmanaged null-terminated UTF-16 buffer.
+        /// </summary>
+        /// <param name="managed">the managed string to convert, or <c>null</c>.</param>
+        /// <returns>a pointer to unmanaged UTF-16 data, or <see cref="IntPtr.Zero"/> for <c>null</c>.</returns>
         public static IntPtr ConvertToUnmanaged(string? managed)
         {
             if (managed is null)
@@ -53,16 +58,30 @@ public static class WCharStringMarshaller
             return ptr;
         }
 
+        /// <summary>
+        /// Converts an unmanaged null-terminated UTF-16 buffer to a managed string.
+        /// </summary>
+        /// <param name="unmanaged">a pointer to unmanaged UTF-16 data.</param>
+        /// <returns>the managed string, or <c>null</c> when <paramref name="unmanaged"/> is <see cref="IntPtr.Zero"/>.</returns>
         public static string? ConvertToManaged(IntPtr unmanaged)
         {
             return unmanaged == IntPtr.Zero ? null : Marshal.PtrToStringUni(unmanaged);
         }
 
+        /// <summary>
+        /// Frees unmanaged memory allocated by <see cref="ConvertToUnmanaged"/>.
+        /// </summary>
+        /// <param name="ptr">the unmanaged pointer to free.</param>
         public static void Free(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
     }
 
     public static class WChar32 // Linux/macOS (UTF-32)
     {
+        /// <summary>
+        /// Converts a managed string to an unmanaged null-terminated UTF-32 buffer.
+        /// </summary>
+        /// <param name="managed">the managed string to convert, or <c>null</c>.</param>
+        /// <returns>a pointer to unmanaged UTF-32 data, or <see cref="IntPtr.Zero"/> for <c>null</c>.</returns>
         public static IntPtr ConvertToUnmanaged(string? managed)
         {
             if (managed is null)
@@ -74,11 +93,21 @@ public static class WCharStringMarshaller
             return ptr;
         }
 
+        /// <summary>
+        /// Converts an unmanaged null-terminated UTF-32 buffer to a managed string.
+        /// </summary>
+        /// <param name="unmanaged">a pointer to unmanaged UTF-32 data.</param>
+        /// <returns>the managed string, or <c>null</c> when <paramref name="unmanaged"/> is <see cref="IntPtr.Zero"/>.</returns>
         public static string? ConvertToManaged(IntPtr unmanaged)
         {
             return unmanaged == IntPtr.Zero ? null : PtrToStringUTF32(unmanaged);
         }
 
+        /// <summary>
+        /// Converts an unmanaged null-terminated UTF-32 buffer to a managed string.
+        /// </summary>
+        /// <param name="ptr">a pointer to unmanaged UTF-32 data.</param>
+        /// <returns>the managed string, or <c>null</c> when <paramref name="ptr"/> is <see cref="IntPtr.Zero"/>.</returns>
         public static string? PtrToStringUTF32(IntPtr ptr)
         {
             if (ptr == IntPtr.Zero)
@@ -101,10 +130,16 @@ public static class WCharStringMarshaller
         }
 
 
+        /// <summary>
+        /// Frees unmanaged memory allocated by <see cref="ConvertToUnmanaged"/>.
+        /// </summary>
+        /// <param name="ptr">the unmanaged pointer to free.</param>
         public static void Free(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
     }
 
-    // The size in bytes of a wide character for the current runtime
+    /// <summary>
+    /// The size in bytes of a wide character for the current runtime.
+    /// </summary>
     public static UIntPtr WCharSize
     {
         get => (UIntPtr)(
@@ -115,18 +150,32 @@ public static class WCharStringMarshaller
 
 
     // Выбираем реализацию в зависимости от платформы
+    /// <summary>
+    /// Converts a managed string to an unmanaged null-terminated wide-character buffer for the current runtime.
+    /// </summary>
+    /// <param name="managed">the managed string to convert, or <c>null</c>.</param>
+    /// <returns>a pointer to unmanaged wide-character data, or <see cref="IntPtr.Zero"/> for <c>null</c>.</returns>
     public static IntPtr ConvertToUnmanaged(string? managed)
     {
         return IsWindowsFunction() ?
             WChar16.ConvertToUnmanaged(managed) : WChar32.ConvertToUnmanaged(managed);
     }
 
+    /// <summary>
+    /// Converts an unmanaged null-terminated wide-character buffer for the current runtime to a managed string.
+    /// </summary>
+    /// <param name="unmanaged">a pointer to unmanaged wide-character data.</param>
+    /// <returns>the managed string, or <c>null</c> when <paramref name="unmanaged"/> is <see cref="IntPtr.Zero"/>.</returns>
     public static string? ConvertToManaged(IntPtr unmanaged)
     {
         return IsWindowsFunction() ?
             WChar16.ConvertToManaged(unmanaged) : WChar32.ConvertToManaged(unmanaged);
     }
 
+    /// <summary>
+    /// Frees unmanaged memory allocated by <see cref="ConvertToUnmanaged"/>.
+    /// </summary>
+    /// <param name="ptr">the unmanaged pointer to free.</param>
     public static void Free(IntPtr ptr)
     {
         Marshal.FreeHGlobal(ptr);


### PR DESCRIPTION
## Summary

- Prepare `SDL3-CS 3.4.10.4` release notes and NuGet README package versions.
- Include fixes for SDL appstate callback propagation, public wrapper XML documentation coverage, and `SDL_AppEvent` `LibraryImport` interop metadata.
- Keep GitHub Release/NuGet publication out of this PR; publishing workflow was not dispatched.

## Checks

- `pwsh .\.github\release-tools\Test-PackageVersioning.ps1 -PackageRevision 4`
- `pwsh .\.github\release-tools\Test-ReleaseWorkflow.ps1`
- `pwsh .\.github\release-tools\Test-ReleasePublishPlan.ps1`
- `pwsh .\.github\release-tools\Publish-Release.ps1 -PackageRevision 4 -GitHubRelease -NuGetPush -DryRun`
- `pwsh .\.github\release-tools\Test-ReleaseReadiness.ps1 -PackageRevision 4 -SkipToolchainValidation -SkipNativeArtifactValidation -SkipNativeBuildReceiptValidation -FailOnError`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release`
- `dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build`
- External availability check: GitHub Release/tag `v3.4.10.4` available, NuGet package versions `31/31` available.