### PR TITLE
Fix TTF GPU atlas draw sequence layout

### DIFF
--- a/.github/release-tools/Invoke-GitHubReleaseWorkflow.ps1
+++ b/.github/release-tools/Invoke-GitHubReleaseWorkflow.ps1
@@ -62,6 +62,7 @@ if (-not $SkipLocalValidation) {
     & (Join-Path $PSScriptRoot 'Test-ReleaseManifest.ps1') -ManifestPath $ManifestPath -SkipSourceCheckoutValidation
     & (Join-Path $PSScriptRoot 'Test-ReleaseWorkflow.ps1') -ManifestPath $ManifestPath -WorkflowPath $WorkflowPath
     & (Join-Path $PSScriptRoot 'Test-ReleasePublishPlan.ps1')
+    & (Join-Path $PSScriptRoot 'Test-ReleaseNotes.ps1')
     & (Join-Path $PSScriptRoot 'Test-NativeForkInitializationPlan.ps1') -ManifestPath $ManifestPath
     & (Join-Path $PSScriptRoot 'Test-NativeBuildPlan.ps1') -ManifestPath $ManifestPath
     & (Join-Path $PSScriptRoot 'Test-NativePackageRidEntries.ps1') -ManifestPath $ManifestPath

--- a/.github/release-tools/Publish-Release.ps1
+++ b/.github/release-tools/Publish-Release.ps1
@@ -111,6 +111,7 @@ if ($GitHubRelease) {
 
     $args = @('release', 'create', $tag, '--repo', $Repository, '--title', "SDL3-CS $($wrapper.PackageVersion)")
     if (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf) {
+        & (Join-Path $PSScriptRoot 'Test-ReleaseNotes.ps1') -ReleaseNotesPath $releaseNotesPath
         $args += @('--notes-file', $releaseNotesPath)
     }
     else {

--- a/.github/release-tools/Test-ReleaseNotes.ps1
+++ b/.github/release-tools/Test-ReleaseNotes.ps1
@@ -1,0 +1,50 @@
+#requires -Version 7.0
+[CmdletBinding(DefaultParameterSetName = 'Directory')]
+param(
+    [Parameter(ParameterSetName = 'Directory')]
+    [string] $ReleaseNotesDir = (Join-Path $PSScriptRoot 'release-notes'),
+
+    [Parameter(Mandatory, ParameterSetName = 'File')]
+    [string] $ReleaseNotesPath
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+$notesFiles = if ($PSCmdlet.ParameterSetName -eq 'File') {
+    $path = Resolve-ReleasePath $ReleaseNotesPath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Release notes file was not found: $path"
+    }
+
+    @(Get-Item -LiteralPath $path)
+}
+else {
+    $dir = Resolve-ReleasePath $ReleaseNotesDir
+    if (-not (Test-Path -LiteralPath $dir -PathType Container)) {
+        throw "Release notes directory was not found: $dir"
+    }
+
+    @(Get-ChildItem -LiteralPath $dir -Filter '*.md' -File | Sort-Object Name)
+}
+
+$errors = New-Object System.Collections.Generic.List[string]
+foreach ($file in $notesFiles) {
+    $lines = @(Get-Content -LiteralPath $file.FullName -Encoding UTF8)
+    if ($lines.Count -eq 0 -or [string]::IsNullOrWhiteSpace(($lines -join ''))) {
+        $errors.Add("Release notes file is empty: $($file.FullName)")
+        continue
+    }
+
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match '^#\s+') {
+            $errors.Add("Release notes body must not contain a top-level H1 because GitHub renders the release title separately: $($file.FullName):$($i + 1)")
+        }
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "Release notes validation failed with $($errors.Count) error(s)."
+}
+
+Write-Host "Release notes body files do not contain top-level H1 headings."

--- a/.github/release-tools/Test-ReleasePublishPlan.ps1
+++ b/.github/release-tools/Test-ReleasePublishPlan.ps1
@@ -45,6 +45,7 @@ Assert-PublishScriptContains -Text $text -Expected '[switch] $RequireUpstreamCur
 Assert-PublishScriptContains -Text $text -Expected '$ReleaseNotesDir' -Description 'release notes directory option'
 Assert-PublishScriptContains -Text $text -Expected "'release', 'create'" -Description 'GitHub release create command'
 Assert-PublishScriptContains -Text $text -Expected "'--notes-file'" -Description 'GitHub release notes file command'
+Assert-PublishScriptContains -Text $text -Expected 'Test-ReleaseNotes.ps1' -Description 'release notes body validation'
 Assert-PublishScriptContains -Text $text -Expected 'release-notes' -Description 'default release notes directory'
 Assert-PublishScriptContains -Text $text -Expected "'--draft'" -Description 'GitHub release draft flag'
 Assert-PublishScriptContains -Text $text -Expected "'--draft=false'" -Description 'GitHub release publish command'

--- a/.github/release-tools/release-notes/v3.4.10.1.md
+++ b/.github/release-tools/release-notes/v3.4.10.1.md
@@ -1,5 +1,3 @@
-# SDL3-CS 3.4.10.1
-
 Stable SDL3-CS release for SDL 3.4.10.
 
 This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.

--- a/.github/release-tools/release-notes/v3.4.10.2.md
+++ b/.github/release-tools/release-notes/v3.4.10.2.md
@@ -1,5 +1,3 @@
-# SDL3-CS 3.4.10.2
-
 Stable SDL3-CS bugfix release for SDL 3.4.10.
 
 This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.

--- a/.github/release-tools/release-notes/v3.4.10.3.md
+++ b/.github/release-tools/release-notes/v3.4.10.3.md
@@ -1,5 +1,3 @@
-# SDL3-CS 3.4.10.3
-
 Stable SDL3-CS bugfix release for SDL 3.4.10.
 
 This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.

--- a/.github/release-tools/release-notes/v3.4.10.4.md
+++ b/.github/release-tools/release-notes/v3.4.10.4.md
@@ -1,5 +1,3 @@
-# SDL3-CS 3.4.10.4
-
 Stable SDL3-CS bugfix release for SDL 3.4.10.
 
 This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.

--- a/.github/release-tools/release-notes/v3.4.10.5.md
+++ b/.github/release-tools/release-notes/v3.4.10.5.md
@@ -1,0 +1,20 @@
+Stable SDL3-CS bugfix release for SDL 3.4.10.
+
+This release publishes the managed `SDL3-CS` wrapper and platform-specific native NuGet packages for Windows, Linux, macOS, Android, iOS, and tvOS. Native packages use `SDL3-CS.<Platform>` and `SDL3-CS.<Platform>.<Addon>` package IDs.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.10.5` |
+| `SDL3-CS.<Platform>` | `3.4.10.5` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.5` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.5` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.5` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.5` |
+
+## Changes
+
+- Fixed `TTF.GPUAtlasDrawSequence` to expose the trailing `Next` pointer from `TTF_GPUAtlasDrawSequence`, allowing callers to walk every sequence returned by `TTF.GetGPUTextDrawData`.
+- Added mirrored layout tests for `TTF.GPUAtlasDrawSequence` public fields, offsets, and native size.
+- Added and expanded project-level README documentation across the repository.

--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,16 +4,16 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Latest Release
 
-Current stable release: [`SDL3-CS 3.4.10.4`](https://github.com/edwardgushchin/SDL3-CS/releases/tag/v3.4.10.4).
+Current stable release: [`SDL3-CS 3.4.10.5`](https://github.com/edwardgushchin/SDL3-CS/releases/tag/v3.4.10.5).
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.10.4` |
-| `SDL3-CS.<Platform>` | `3.4.10.4` |
-| `SDL3-CS.<Platform>.Image` | `3.4.4.4` |
-| `SDL3-CS.<Platform>.Mixer` | `3.2.4.4` |
-| `SDL3-CS.<Platform>.TTF` | `3.2.2.4` |
-| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.4` |
+| `SDL3-CS` | `3.4.10.5` |
+| `SDL3-CS.<Platform>` | `3.4.10.5` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.5` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.5` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.5` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.5` |
 
 ## Documentation
 

--- a/SDL3-CS.Examples/Android/AndroidCircularColorFade/README.md
+++ b/SDL3-CS.Examples/Android/AndroidCircularColorFade/README.md
@@ -1,12 +1,83 @@
-# Android example
+# AndroidCircularColorFade
 
-Этот пример показывает официальный SDL3-CS Android path: `MainActivity` наследуется от `Org.Libsdl.App.SDLActivity`, загружает `SDL3` через `GetLibraries()` и запускает управляемый SDL loop в override `Main()`.
+<p align="center">
+  <strong>AndroidCircularColorFade</strong>
+</p>
 
-Bridge больше не хранится локально в примере. Пример использует project reference на `SDL3-CS.Android`, который доставляет bindings для `SDLActivity`, Java bridge SDL и базовые Android native assets в опубликованном package.
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Android" src="https://img.shields.io/badge/Android-555?style=flat-square">
+  <img alt="net10.0-android" src="https://img.shields.io/badge/net10.0-android-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
 
-Для сборки нужна Android-среда:
+AndroidCircularColorFade is the Android version of the SDL3-CS circular color fade sample. It uses the official SDLActivity bridge supplied by the Android native package and runs the render loop from managed C#.
+
+## What This Project Demonstrates
+
+- Hosting an SDL3-CS app inside `Org.Libsdl.App.SDLActivity`.
+- Loading `libSDL3.so` through `GetLibraries()`.
+- Creating an SDL window and renderer from an Android activity.
+- Animating the clear color with SDL performance counters.
+
+## Expected Result
+
+The Android activity opens a full SDL surface and smoothly cycles the background color.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: `SDL3-CS.Android` runtime and SDLActivity bridge package.
+
+## Source Files
+
+- `MainActivity.cs`
+
+## Assets
+
+- `Resources/AboutResources.txt`
+- `Resources/mipmap-hdpi/appicon.png`
+- `Resources/mipmap-hdpi/appicon_background.png`
+- `Resources/mipmap-hdpi/appicon_foreground.png`
+- `Resources/mipmap-mdpi/appicon.png`
+- `Resources/mipmap-mdpi/appicon_background.png`
+- `Resources/mipmap-mdpi/appicon_foreground.png`
+- `Resources/mipmap-xhdpi/appicon.png`
+- Additional Android resource density assets live under `Resources/`.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
 
 ```powershell
-dotnet workload restore SDL3-CS.Examples\Android\AndroidCircularColorFade\AndroidCircularColorFade.csproj
-dotnet build SDL3-CS.Examples\Android\AndroidCircularColorFade\AndroidCircularColorFade.csproj -c Release
+dotnet workload restore .\SDL3-CS.Examples\Android\AndroidCircularColorFade\AndroidCircularColorFade.csproj
+dotnet build .\SDL3-CS.Examples\Android\AndroidCircularColorFade\AndroidCircularColorFade.csproj -c Release -f net10.0-android
 ```
+
+Deploy from your IDE, from the .NET Android tooling, or by adding the usual Android publish properties for your device or emulator.
+
+## Notes
+
+- This README replaces the previous non-English Android example notes from issue #192.
+- The bridge is supplied by `SDL3-CS.Android`; it is not copied into the example source tree.
+- The Android project targets API level 23 or newer and enables full trimming in Release builds.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Asyncio/Asyncio Load Bitmaps/README.md
+++ b/SDL3-CS.Examples/Asyncio/Asyncio Load Bitmaps/README.md
@@ -1,0 +1,70 @@
+# Asyncio Load Bitmaps
+
+<p align="center">
+  <strong>Asyncio Load Bitmaps</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Asyncio" src="https://img.shields.io/badge/Asyncio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Asyncio Load Bitmaps shows how to combine SDL asynchronous I/O with image loading work in a small renderer sample.
+
+## What This Project Demonstrates
+
+- Scheduling file reads without blocking the main loop.
+- Tracking async completion state from a normal SDL event loop.
+- Turning loaded bitmap data into renderer-visible content.
+- Keeping the window responsive while assets arrive.
+
+## Expected Result
+
+The window updates as bitmap assets finish loading.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Asyncio\Asyncio Load Bitmaps\Asyncio Load Bitmaps.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Audio/Audio Load WAV/README.md
+++ b/SDL3-CS.Examples/Audio/Audio Load WAV/README.md
@@ -1,0 +1,70 @@
+# Audio Load WAV
+
+<p align="center">
+  <strong>Audio Load WAV</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Audio" src="https://img.shields.io/badge/Audio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Audio Load WAV is the smallest file-backed audio example in SDL3-CS. It loads a WAV file and plays it through SDL audio stream APIs.
+
+## What This Project Demonstrates
+
+- Loading sample audio data from `sample.wav`.
+- Opening an SDL audio device with a compatible stream.
+- Queueing decoded audio data for playback.
+- Cleaning up audio resources before shutdown.
+
+## Expected Result
+
+A short WAV clip plays once the audio device is opened.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Audio\Audio Load WAV\Audio Load WAV.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Audio/Audio Multiple Streams/README.md
+++ b/SDL3-CS.Examples/Audio/Audio Multiple Streams/README.md
@@ -1,0 +1,70 @@
+# Audio Multiple Streams
+
+<p align="center">
+  <strong>Audio Multiple Streams</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Audio" src="https://img.shields.io/badge/Audio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Audio Multiple Streams demonstrates mixing several SDL audio streams in one app, using separate source clips and shared device playback.
+
+## What This Project Demonstrates
+
+- Creating more than one audio stream.
+- Loading and queueing multiple WAV assets.
+- Letting SDL handle stream conversion into the device format.
+- Coordinating stream lifetime with the application loop.
+
+## Expected Result
+
+The sample plays multiple sound sources without a custom mixer.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Audio\Audio Multiple Streams\Audio Multiple Streams.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Audio/Audio Planar Data/README.md
+++ b/SDL3-CS.Examples/Audio/Audio Planar Data/README.md
@@ -1,0 +1,70 @@
+# Audio Planar Data
+
+<p align="center">
+  <strong>Audio Planar Data</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Audio" src="https://img.shields.io/badge/Audio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Audio Planar Data demonstrates feeding planar sample data to SDL audio APIs from managed code.
+
+## What This Project Demonstrates
+
+- Constructing audio sample buffers in C#.
+- Submitting non-interleaved channel data to SDL.
+- Managing timing without a media file on disk.
+- Using SDL cleanup paths for generated audio.
+
+## Expected Result
+
+The app generates and plays audio from managed sample data.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Audio\Audio Planar Data\Audio Planar Data.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Audio/Audio Simple Playback Callback/README.md
+++ b/SDL3-CS.Examples/Audio/Audio Simple Playback Callback/README.md
@@ -1,0 +1,70 @@
+# Audio Simple Playback Callback
+
+<p align="center">
+  <strong>Audio Simple Playback Callback</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Audio" src="https://img.shields.io/badge/Audio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Audio Simple Playback Callback demonstrates callback-driven SDL audio generation from C#.
+
+## What This Project Demonstrates
+
+- Registering a managed audio callback.
+- Producing audio on demand instead of pre-queueing a full buffer.
+- Keeping callback state alive safely.
+- Stopping playback and closing SDL audio cleanly.
+
+## Expected Result
+
+Audio is generated continuously by the callback while the process runs.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Audio\Audio Simple Playback Callback\Audio Simple Playback Callback.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Audio/Audio Simple Playback/README.md
+++ b/SDL3-CS.Examples/Audio/Audio Simple Playback/README.md
@@ -1,0 +1,70 @@
+# Audio Simple Playback
+
+<p align="center">
+  <strong>Audio Simple Playback</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Audio" src="https://img.shields.io/badge/Audio-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Audio Simple Playback is a minimal generated-audio sample for SDL3-CS.
+
+## What This Project Demonstrates
+
+- Opening default playback with SDL audio.
+- Producing sample data in managed code.
+- Writing to an SDL audio stream.
+- Keeping the event loop small while audio plays.
+
+## Expected Result
+
+A generated tone or simple waveform plays while the app runs.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Audio\Audio Simple Playback\Audio Simple Playback.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Basics/Circular Color Fade/README.md
+++ b/SDL3-CS.Examples/Basics/Circular Color Fade/README.md
@@ -1,0 +1,70 @@
+# Circular Color Fade
+
+<p align="center">
+  <strong>Circular Color Fade</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Basics" src="https://img.shields.io/badge/Basics-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Circular Color Fade is the desktop baseline for a time-based SDL renderer animation.
+
+## What This Project Demonstrates
+
+- Initializing SDL video from a console-style app.
+- Creating an SDL window and renderer.
+- Using performance counters for smooth animation.
+- Rendering a continuously changing clear color.
+
+## Expected Result
+
+The window background cycles through colors until the user closes it.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Basics\Circular Color Fade\Circular Color Fade.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Basics/Create Window/README.md
+++ b/SDL3-CS.Examples/Basics/Create Window/README.md
@@ -1,0 +1,70 @@
+# Create Window
+
+<p align="center">
+  <strong>Create Window</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Basics" src="https://img.shields.io/badge/Basics-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Create Window is the first SDL3-CS renderer example. It opens a window, creates a renderer, clears the frame, and exits cleanly.
+
+## What This Project Demonstrates
+
+- The minimum SDL initialization and shutdown sequence.
+- Using `SDL.CreateWindowAndRenderer` from C#.
+- Polling SDL events for quit requests.
+- Destroying renderer and window handles explicitly.
+
+## Expected Result
+
+A plain SDL window appears with a constant clear color.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Basics\Create Window\Create Window.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Basics/FPS Counter/README.md
+++ b/SDL3-CS.Examples/Basics/FPS Counter/README.md
@@ -1,0 +1,71 @@
+# FPS Counter
+
+<p align="center">
+  <strong>FPS Counter</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Basics" src="https://img.shields.io/badge/Basics-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+FPS Counter extends the basic renderer loop with frame timing and a small reusable counter.
+
+## What This Project Demonstrates
+
+- Measuring frame cadence with SDL timing APIs.
+- Rendering a simple animated scene while tracking FPS.
+- Separating reusable timing code into `FPSCounter.cs`.
+- Keeping per-frame work independent from event polling.
+
+## Expected Result
+
+The example reports or displays frame-rate information while rendering.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `FPSCounter.cs`
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Basics\FPS Counter\FPS Counter.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Camera/Camera Read And Draw/README.md
+++ b/SDL3-CS.Examples/Camera/Camera Read And Draw/README.md
@@ -1,0 +1,70 @@
+# Camera Read And Draw
+
+<p align="center">
+  <strong>Camera Read And Draw</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Camera" src="https://img.shields.io/badge/Camera-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Camera Read And Draw captures frames from an SDL camera and displays them through the renderer.
+
+## What This Project Demonstrates
+
+- Opening a camera device for streaming.
+- Receiving camera frames from SDL.
+- Uploading frame data to a renderer texture.
+- Handling devices that are missing or busy.
+
+## Expected Result
+
+When a camera is available, the app draws live frames in an SDL window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Camera\Camera Read And Draw\Camera Read And Draw.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Camera/Camera/README.md
+++ b/SDL3-CS.Examples/Camera/Camera/README.md
@@ -1,0 +1,70 @@
+# Camera
+
+<p align="center">
+  <strong>Camera</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Camera" src="https://img.shields.io/badge/Camera-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Camera lists and opens SDL camera devices from managed code.
+
+## What This Project Demonstrates
+
+- Initializing the SDL camera subsystem.
+- Enumerating available cameras.
+- Opening a selected camera safely.
+- Reporting device availability and shutdown results.
+
+## Expected Result
+
+The console output reflects the camera devices available on the host.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Camera\Camera\Camera.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Camera/VHS Camera/README.md
+++ b/SDL3-CS.Examples/Camera/VHS Camera/README.md
@@ -1,0 +1,71 @@
+# VHS Camera
+
+<p align="center">
+  <strong>VHS Camera</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Camera" src="https://img.shields.io/badge/Camera-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+VHS Camera is a richer camera demo that applies a stylized renderer effect to live camera frames.
+
+## What This Project Demonstrates
+
+- Combining camera capture with renderer textures.
+- Using unsafe code for pixel-level processing where needed.
+- Applying a VHS-like visual treatment in the frame loop.
+- Measuring frame rate while processing video.
+
+## Expected Result
+
+Live camera video is drawn with a retro VHS-style effect.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `FPSCounter.cs`
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Camera\VHS Camera\VHS Camera.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Demo/Demo Bytepusher/README.md
+++ b/SDL3-CS.Examples/Demo/Demo Bytepusher/README.md
@@ -1,0 +1,70 @@
+# Demo Bytepusher
+
+<p align="center">
+  <strong>Demo Bytepusher</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Demo" src="https://img.shields.io/badge/Demo-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Demo Bytepusher ports the SDL BytePusher demo to SDL3-CS.
+
+## What This Project Demonstrates
+
+- Driving a compact emulator-style render loop.
+- Updating texture data every frame.
+- Handling keyboard input for a demo workload.
+- Keeping a more involved sample within the same SDL3-CS project model.
+
+## Expected Result
+
+The window runs the BytePusher visual demo.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Demo\Demo Bytepusher\Demo Bytepusher.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Demo/Demo Infinite Monkeys/README.md
+++ b/SDL3-CS.Examples/Demo/Demo Infinite Monkeys/README.md
@@ -1,0 +1,70 @@
+# Demo Infinite Monkeys
+
+<p align="center">
+  <strong>Demo Infinite Monkeys</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Demo" src="https://img.shields.io/badge/Demo-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Demo Infinite Monkeys is a text and input demo adapted from the SDL examples set.
+
+## What This Project Demonstrates
+
+- Rendering changing demo state from managed code.
+- Handling keyboard and quit events.
+- Using deterministic update loops for sample scenes.
+- Keeping SDL resource lifetime explicit.
+
+## Expected Result
+
+The demo renders its animated scene until the window is closed.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Demo\Demo Infinite Monkeys\Demo Infinite Monkeys.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Demo/Demo Snake/README.md
+++ b/SDL3-CS.Examples/Demo/Demo Snake/README.md
@@ -1,0 +1,70 @@
+# Demo Snake
+
+<p align="center">
+  <strong>Demo Snake</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Demo" src="https://img.shields.io/badge/Demo-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Demo Snake is the classic SDL sample game ported to SDL3-CS.
+
+## What This Project Demonstrates
+
+- Implementing a complete game loop with SDL events.
+- Separating update timing from rendering.
+- Using keyboard input for movement.
+- Drawing a simple grid-based scene with SDL renderer APIs.
+
+## Expected Result
+
+A playable Snake game appears in the SDL window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Demo\Demo Snake\Demo Snake.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Demo/Demo Woodeneye 008/README.md
+++ b/SDL3-CS.Examples/Demo/Demo Woodeneye 008/README.md
@@ -1,0 +1,70 @@
+# Demo Woodeneye 008
+
+<p align="center">
+  <strong>Demo Woodeneye 008</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Demo" src="https://img.shields.io/badge/Demo-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Demo Woodeneye 008 is a larger renderer demo from the SDL examples collection.
+
+## What This Project Demonstrates
+
+- Coordinating animation, input, and rendering in one SDL loop.
+- Rendering a more complex scene than the basic samples.
+- Porting upstream SDL example structure into idiomatic C#.
+- Using common SDL3-CS shutdown paths after a demo exits.
+
+## Expected Result
+
+The window displays the Woodeneye 008 demo scene.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Demo\Demo Woodeneye 008\Demo Woodeneye 008.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Dialogs/File Dialog/README.md
+++ b/SDL3-CS.Examples/Dialogs/File Dialog/README.md
@@ -1,0 +1,70 @@
+# File Dialog
+
+<p align="center">
+  <strong>File Dialog</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Dialogs" src="https://img.shields.io/badge/Dialogs-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+File Dialog demonstrates SDL dialog APIs from SDL3-CS.
+
+## What This Project Demonstrates
+
+- Opening platform-native file dialogs through SDL.
+- Handling asynchronous dialog completion callbacks.
+- Reporting selected files back to managed code.
+- Keeping the SDL event loop alive while a dialog is open.
+
+## Expected Result
+
+The app opens a native file dialog and logs the selected path.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Dialogs\File Dialog\File Dialog.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Dialogs/Message Box/README.md
+++ b/SDL3-CS.Examples/Dialogs/Message Box/README.md
@@ -1,0 +1,70 @@
+# Message Box
+
+<p align="center">
+  <strong>Message Box</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Dialogs" src="https://img.shields.io/badge/Dialogs-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Message Box demonstrates SDL message box APIs from C#.
+
+## What This Project Demonstrates
+
+- Creating modal SDL message boxes.
+- Configuring message text, buttons, and result handling.
+- Using the dialog API without a full renderer scene.
+- Logging the selected button result.
+
+## Expected Result
+
+A native message box appears and returns the selected action.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Dialogs\Message Box\Message Box.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/GPU/GPU API Circular Color Fade/README.md
+++ b/SDL3-CS.Examples/GPU/GPU API Circular Color Fade/README.md
@@ -1,0 +1,70 @@
+# GPU API Circular Color Fade
+
+<p align="center">
+  <strong>GPU API Circular Color Fade</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="GPU" src="https://img.shields.io/badge/GPU-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+GPU API Circular Color Fade is a minimal SDL GPU API sample for SDL3-CS.
+
+## What This Project Demonstrates
+
+- Creating an SDL GPU device and swapchain path.
+- Rendering a time-based color animation through GPU APIs.
+- Handling GPU resource acquisition and release.
+- Contrasting GPU setup with the simpler renderer examples.
+
+## Expected Result
+
+The window shows the same color-fade idea through the SDL GPU pipeline.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: SDL GPU support from the base SDL runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\GPU\GPU API Circular Color Fade\GPU API Circular Color Fade.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Image/Color Quantization/README.md
+++ b/SDL3-CS.Examples/Image/Color Quantization/README.md
@@ -1,0 +1,70 @@
+# Color Quantization
+
+<p align="center">
+  <strong>Color Quantization</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Image" src="https://img.shields.io/badge/Image-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Color Quantization demonstrates SDL_image integration from SDL3-CS.
+
+## What This Project Demonstrates
+
+- Using the SDL_image native package from an example project.
+- Loading image data through SDL3-CS image bindings.
+- Applying color quantization operations.
+- Displaying or saving image-processing results through SDL surfaces or renderer textures.
+
+## Expected Result
+
+The example processes an image through SDL_image-backed APIs.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: matching `SDL3-CS.<Platform>.Image` native package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Image\Color Quantization\Color Quantization.csproj" -c Release
+```
+
+## Notes
+
+- The example opts into `SDL3CSExampleUseImage`, so `Directory.Build.targets` adds the platform-specific SDL_image package when it is run from this repository.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Input/Input Gamepad Events/README.md
+++ b/SDL3-CS.Examples/Input/Input Gamepad Events/README.md
@@ -1,0 +1,70 @@
+# Input Gamepad Events
+
+<p align="center">
+  <strong>Input Gamepad Events</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Input" src="https://img.shields.io/badge/Input-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Input Gamepad Events demonstrates event-driven gamepad input.
+
+## What This Project Demonstrates
+
+- Listening for gamepad connection and button events.
+- Opening gamepads reported by SDL.
+- Mapping SDL event payloads into managed logging.
+- Handling hot-plug and quit events in one loop.
+
+## Expected Result
+
+Connect or use a gamepad and watch events appear in the app output.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Input\Input Gamepad Events\Input Gamepad Events.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Input/Input Gamepad Polling/README.md
+++ b/SDL3-CS.Examples/Input/Input Gamepad Polling/README.md
@@ -1,0 +1,70 @@
+# Input Gamepad Polling
+
+<p align="center">
+  <strong>Input Gamepad Polling</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Input" src="https://img.shields.io/badge/Input-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Input Gamepad Polling demonstrates reading gamepad state directly each frame.
+
+## What This Project Demonstrates
+
+- Enumerating and opening an SDL gamepad.
+- Polling buttons and axes instead of waiting for events.
+- Rendering or logging live state from a frame loop.
+- Handling unavailable gamepads gracefully.
+
+## Expected Result
+
+Move a connected gamepad and observe live state updates.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Input\Input Gamepad Polling\Input Gamepad Polling.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Input/Input Gamepad Rumble/README.md
+++ b/SDL3-CS.Examples/Input/Input Gamepad Rumble/README.md
@@ -1,0 +1,70 @@
+# Input Gamepad Rumble
+
+<p align="center">
+  <strong>Input Gamepad Rumble</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Input" src="https://img.shields.io/badge/Input-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Input Gamepad Rumble demonstrates SDL haptic feedback for supported gamepads.
+
+## What This Project Demonstrates
+
+- Opening a gamepad that supports rumble.
+- Triggering low-frequency and high-frequency rumble values.
+- Handling unsupported devices safely.
+- Keeping input and feedback lifetime tied to SDL cleanup.
+
+## Expected Result
+
+A compatible controller vibrates when the example triggers rumble.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Input\Input Gamepad Rumble\Input Gamepad Rumble.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Input/Input Joystick Events/README.md
+++ b/SDL3-CS.Examples/Input/Input Joystick Events/README.md
@@ -1,0 +1,70 @@
+# Input Joystick Events
+
+<p align="center">
+  <strong>Input Joystick Events</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Input" src="https://img.shields.io/badge/Input-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Input Joystick Events demonstrates event-driven joystick input.
+
+## What This Project Demonstrates
+
+- Opening SDL joystick devices.
+- Logging axis, button, hat, and device events.
+- Handling hot-plug events from the SDL event queue.
+- Closing device handles explicitly.
+
+## Expected Result
+
+Joystick actions appear as SDL events in the output.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Input\Input Joystick Events\Input Joystick Events.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Input/Input Joystick Polling/README.md
+++ b/SDL3-CS.Examples/Input/Input Joystick Polling/README.md
@@ -1,0 +1,70 @@
+# Input Joystick Polling
+
+<p align="center">
+  <strong>Input Joystick Polling</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Input" src="https://img.shields.io/badge/Input-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Input Joystick Polling demonstrates direct joystick state reads.
+
+## What This Project Demonstrates
+
+- Enumerating joystick devices.
+- Polling axes, buttons, and hats each frame.
+- Comparing polling with event-driven input samples.
+- Handling hosts with no joystick connected.
+
+## Expected Result
+
+Joystick state is read repeatedly while the example runs.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Input\Input Joystick Polling\Input Joystick Polling.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Misc/Misc Clipboard/README.md
+++ b/SDL3-CS.Examples/Misc/Misc Clipboard/README.md
@@ -1,0 +1,70 @@
+# Misc Clipboard
+
+<p align="center">
+  <strong>Misc Clipboard</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Misc" src="https://img.shields.io/badge/Misc-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Misc Clipboard demonstrates SDL clipboard APIs from SDL3-CS.
+
+## What This Project Demonstrates
+
+- Reading and writing text clipboard content.
+- Checking SDL success and error paths.
+- Using a small utility-style SDL program without rendering.
+- Keeping platform differences behind SDL APIs.
+
+## Expected Result
+
+The output shows clipboard operations performed through SDL.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Misc\Misc Clipboard\Misc Clipboard.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Misc/Misc Locale/README.md
+++ b/SDL3-CS.Examples/Misc/Misc Locale/README.md
@@ -1,0 +1,70 @@
+# Misc Locale
+
+<p align="center">
+  <strong>Misc Locale</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Misc" src="https://img.shields.io/badge/Misc-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Misc Locale demonstrates querying user locale information through SDL.
+
+## What This Project Demonstrates
+
+- Calling SDL locale APIs from managed code.
+- Reading language and country values.
+- Handling empty or unsupported locale data.
+- Printing platform-provided locale results.
+
+## Expected Result
+
+The console output lists locale values reported by SDL.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Misc\Misc Locale\Misc Locale.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Misc/Misc Power/README.md
+++ b/SDL3-CS.Examples/Misc/Misc Power/README.md
@@ -1,0 +1,70 @@
+# Misc Power
+
+<p align="center">
+  <strong>Misc Power</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Misc" src="https://img.shields.io/badge/Misc-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Misc Power demonstrates SDL power and battery status APIs.
+
+## What This Project Demonstrates
+
+- Querying battery state through SDL.
+- Reading percent and remaining time when available.
+- Handling desktop systems without battery data.
+- Using SDL for platform-neutral system information.
+
+## Expected Result
+
+The output reports current power state and battery details when available.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Misc\Misc Power\Misc Power.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Mixer/Mixer Track Playback/README.md
+++ b/SDL3-CS.Examples/Mixer/Mixer Track Playback/README.md
@@ -1,0 +1,70 @@
+# Mixer Track Playback
+
+<p align="center">
+  <strong>Mixer Track Playback</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Mixer" src="https://img.shields.io/badge/Mixer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Mixer Track Playback demonstrates SDL_mixer track playback through SDL3-CS.
+
+## What This Project Demonstrates
+
+- Using the SDL_mixer native package from an example project.
+- Loading `test.mp3` as an example asset.
+- Opening mixer output and playing a track.
+- Stopping playback and freeing mixer resources cleanly.
+
+## Expected Result
+
+The bundled MP3 track plays through SDL_mixer.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: matching `SDL3-CS.<Platform>.Mixer` native package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- `test.mp3`
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Mixer\Mixer Track Playback\Mixer Track Playback.csproj" -c Release
+```
+
+## Notes
+
+- The example opts into `SDL3CSExampleUseMixer`, so `Directory.Build.targets` adds the platform-specific SDL_mixer package when it is run from this repository.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Pen/Pen Drawing Lines/README.md
+++ b/SDL3-CS.Examples/Pen/Pen Drawing Lines/README.md
@@ -1,0 +1,70 @@
+# Pen Drawing Lines
+
+<p align="center">
+  <strong>Pen Drawing Lines</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Pen" src="https://img.shields.io/badge/Pen-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Pen Drawing Lines demonstrates SDL pen or tablet input by drawing strokes into a renderer window.
+
+## What This Project Demonstrates
+
+- Receiving SDL pen events.
+- Tracking pen coordinates and pressure-oriented input where available.
+- Drawing input paths with renderer primitives.
+- Handling pointer devices that do not expose pen data.
+
+## Expected Result
+
+Use a pen device or compatible pointer to draw lines in the SDL window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Pen\Pen Drawing Lines\Pen Drawing Lines.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Affine Textures/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Affine Textures/README.md
@@ -1,0 +1,70 @@
+# Renderer Affine Textures
+
+<p align="center">
+  <strong>Renderer Affine Textures</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Affine Textures demonstrates affine texture rendering through SDL renderer APIs.
+
+## What This Project Demonstrates
+
+- Creating a reusable sample texture.
+- Rendering texture corners through affine transforms.
+- Animating texture placement each frame.
+- Using the shared renderer example runner.
+
+## Expected Result
+
+The sample texture is transformed with affine rendering.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Affine Textures\Renderer Affine Textures.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Blending/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Blending/README.md
@@ -1,0 +1,70 @@
+# Renderer Blending
+
+<p align="center">
+  <strong>Renderer Blending</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Blending demonstrates SDL renderer blend modes.
+
+## What This Project Demonstrates
+
+- Configuring draw colors with alpha.
+- Switching renderer blend behavior.
+- Compositing overlapping primitives.
+- Using the shared renderer example runner.
+
+## Expected Result
+
+Overlapping colors combine according to SDL blend settings.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Blending\Renderer Blending.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Clear/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Clear/README.md
@@ -1,0 +1,70 @@
+# Renderer Clear
+
+<p align="center">
+  <strong>Renderer Clear</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Clear is the smallest shared-runner renderer example.
+
+## What This Project Demonstrates
+
+- Creating a renderer-backed window.
+- Clearing the frame to a fixed color.
+- Presenting frames through SDL.
+- Using the common example runner infrastructure.
+
+## Expected Result
+
+The window clears to a simple color every frame.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Clear\Renderer Clear.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Cliprect/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Cliprect/README.md
@@ -1,0 +1,70 @@
+# Renderer Cliprect
+
+<p align="center">
+  <strong>Renderer Cliprect</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Cliprect demonstrates clipping renderer output to a rectangular region.
+
+## What This Project Demonstrates
+
+- Setting a clip rectangle on the renderer.
+- Drawing primitives inside and outside the clipped area.
+- Resetting renderer state after a frame.
+- Using the shared renderer example runner.
+
+## Expected Result
+
+Only the portion inside the clip rectangle is drawn.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Cliprect\Renderer Cliprect.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Color Mods/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Color Mods/README.md
@@ -1,0 +1,70 @@
+# Renderer Color Mods
+
+<p align="center">
+  <strong>Renderer Color Mods</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Color Mods demonstrates per-texture color and alpha modulation.
+
+## What This Project Demonstrates
+
+- Creating and reusing a sample texture.
+- Changing texture color modulation over time.
+- Changing alpha modulation independently.
+- Rendering the same texture with different visual output.
+
+## Expected Result
+
+The sample texture changes tint and transparency as it moves.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Color Mods\Renderer Color Mods.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Debug Text/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Debug Text/README.md
@@ -1,0 +1,70 @@
+# Renderer Debug Text
+
+<p align="center">
+  <strong>Renderer Debug Text</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Debug Text demonstrates SDL debug text rendering.
+
+## What This Project Demonstrates
+
+- Drawing simple text without a font asset.
+- Combining debug text with renderer primitives.
+- Using the renderer for diagnostics-style overlays.
+- Keeping text rendering self-contained in SDL.
+
+## Expected Result
+
+The window shows text drawn directly by SDL renderer helpers.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Debug Text\Renderer Debug Text.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Geometry/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Geometry/README.md
@@ -1,0 +1,70 @@
+# Renderer Geometry
+
+<p align="center">
+  <strong>Renderer Geometry</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Geometry demonstrates SDL renderer geometry submission.
+
+## What This Project Demonstrates
+
+- Building vertex data from managed code.
+- Submitting colored geometry to the renderer.
+- Animating custom triangles or quads.
+- Using SDL renderer APIs beyond rectangles and textures.
+
+## Expected Result
+
+Colored geometry is drawn and animated in the SDL window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Geometry\Renderer Geometry.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Lines/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Lines/README.md
@@ -1,0 +1,70 @@
+# Renderer Lines
+
+<p align="center">
+  <strong>Renderer Lines</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Lines demonstrates line drawing with SDL renderer APIs.
+
+## What This Project Demonstrates
+
+- Drawing individual and connected lines.
+- Animating line positions over time.
+- Using draw colors and presentation order.
+- Keeping renderer state explicit.
+
+## Expected Result
+
+Animated lines move across the window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Lines\Renderer Lines.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Points/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Points/README.md
@@ -1,0 +1,70 @@
+# Renderer Points
+
+<p align="center">
+  <strong>Renderer Points</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Points demonstrates point drawing with SDL renderer APIs.
+
+## What This Project Demonstrates
+
+- Drawing individual points from managed arrays.
+- Animating point clouds or point positions.
+- Using color changes frame by frame.
+- Keeping the shared runner loop small.
+
+## Expected Result
+
+The window displays animated points.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Points\Renderer Points.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Primitives/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Primitives/README.md
@@ -1,0 +1,70 @@
+# Renderer Primitives
+
+<p align="center">
+  <strong>Renderer Primitives</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Primitives demonstrates the basic SDL renderer primitive set.
+
+## What This Project Demonstrates
+
+- Drawing points, lines, and rectangles together.
+- Using colors and alpha in a simple scene.
+- Presenting renderer output each frame.
+- Building toward the more specialized renderer samples.
+
+## Expected Result
+
+The scene combines several primitive draw calls.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Primitives\Renderer Primitives.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Read Pixels/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Read Pixels/README.md
@@ -1,0 +1,70 @@
+# Renderer Read Pixels
+
+<p align="center">
+  <strong>Renderer Read Pixels</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Read Pixels demonstrates reading pixels back from renderer output.
+
+## What This Project Demonstrates
+
+- Rendering a frame normally.
+- Calling SDL pixel readback APIs.
+- Handling returned pixel data from managed code.
+- Understanding the cost and shape of readback paths.
+
+## Expected Result
+
+The example renders a scene and reads part of the output back.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Read Pixels\Renderer Read Pixels.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Rectangles/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Rectangles/README.md
@@ -1,0 +1,70 @@
+# Renderer Rectangles
+
+<p align="center">
+  <strong>Renderer Rectangles</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Rectangles demonstrates filled and outlined rectangles.
+
+## What This Project Demonstrates
+
+- Drawing `SDL.FRect` values.
+- Mixing filled and outlined rectangle calls.
+- Animating sizes or positions.
+- Using draw color state carefully.
+
+## Expected Result
+
+Several rectangles are drawn and animated in the window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Rectangles\Renderer Rectangles.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Rotating Textures/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Rotating Textures/README.md
@@ -1,0 +1,70 @@
+# Renderer Rotating Textures
+
+<p align="center">
+  <strong>Renderer Rotating Textures</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Rotating Textures demonstrates texture rotation.
+
+## What This Project Demonstrates
+
+- Creating a reusable sample texture.
+- Rendering with angle and center arguments.
+- Animating rotation over time.
+- Cleaning up texture handles after the runner exits.
+
+## Expected Result
+
+The sample texture rotates around its center.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Rotating Textures\Renderer Rotating Textures.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Scaling Textures/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Scaling Textures/README.md
@@ -1,0 +1,70 @@
+# Renderer Scaling Textures
+
+<p align="center">
+  <strong>Renderer Scaling Textures</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Scaling Textures demonstrates texture scaling.
+
+## What This Project Demonstrates
+
+- Changing destination rectangle size.
+- Rendering the same texture at multiple scales.
+- Animating scale factors over time.
+- Keeping source and destination rectangles explicit.
+
+## Expected Result
+
+The texture grows, shrinks, or appears at different sizes.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Scaling Textures\Renderer Scaling Textures.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Streaming Textures/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Streaming Textures/README.md
@@ -1,0 +1,70 @@
+# Renderer Streaming Textures
+
+<p align="center">
+  <strong>Renderer Streaming Textures</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Streaming Textures demonstrates updating texture pixels dynamically.
+
+## What This Project Demonstrates
+
+- Creating a streaming texture.
+- Locking or updating pixel data from managed code.
+- Animating generated pixels each frame.
+- Presenting updated texture content through the renderer.
+
+## Expected Result
+
+The texture content changes every frame.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Streaming Textures\Renderer Streaming Textures.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Textures/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Textures/README.md
@@ -1,0 +1,70 @@
+# Renderer Textures
+
+<p align="center">
+  <strong>Renderer Textures</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Textures demonstrates the standard SDL texture rendering path.
+
+## What This Project Demonstrates
+
+- Creating a reusable texture with shared helper code.
+- Rendering one texture in multiple destination rectangles.
+- Animating texture placement over time.
+- Cleaning up renderer-owned texture resources.
+
+## Expected Result
+
+The same sample texture moves through three positions in the window.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Textures\Renderer Textures.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.Examples/Renderer/Renderer Viewport/README.md
+++ b/SDL3-CS.Examples/Renderer/Renderer Viewport/README.md
@@ -1,0 +1,70 @@
+# Renderer Viewport
+
+<p align="center">
+  <strong>Renderer Viewport</strong>
+</p>
+
+<p align="center">
+  <img alt="SDL3-CS example" src="https://img.shields.io/badge/SDL3-CS%20example-555?style=flat-square">
+  <img alt="Renderer" src="https://img.shields.io/badge/Renderer-555?style=flat-square">
+  <img alt="net10.0" src="https://img.shields.io/badge/net10.0-555?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23%2014-555?style=flat-square">
+</p>
+
+Renderer Viewport demonstrates renderer viewport state.
+
+## What This Project Demonstrates
+
+- Setting a viewport before draw calls.
+- Rendering different content regions in one window.
+- Resetting viewport state after drawing.
+- Comparing viewport behavior with clip rectangles.
+
+## Expected Result
+
+Draw calls are constrained to viewport regions.
+
+## Project Model
+
+This project is part of the SDL3-CS examples tree. The common example configuration lives in [`../../Directory.Build.props`](../../Directory.Build.props) and [`../../Directory.Build.targets`](../../Directory.Build.targets):
+
+- examples default to `net10.0`, `Exe`, nullable reference types, implicit usings, and C# 14;
+- local source builds reference [`SDL3-CS`](../../../SDL3-CS/SDL3-CS.csproj) directly;
+- desktop examples receive the matching native runtime package for Windows, Linux, or macOS;
+- optional SDL companion runtimes are added only when an example opts into them.
+
+Runtime dependency for this example: base `SDL3-CS.<Platform>` native runtime package.
+
+## Source Files
+
+- `Program.cs`
+
+## Assets
+
+- No project-specific data assets are required.
+
+## Requirements
+
+- .NET 10 SDK.
+- A platform supported by the SDL3-CS native packages.
+- For desktop examples: Windows, Linux, or macOS with a graphics environment available.
+- For device-specific examples: the matching device or host capability, such as camera, gamepad, joystick, pen, or audio output.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet run --project ".\SDL3-CS.Examples\Renderer\Renderer Viewport\Renderer Viewport.csproj" -c Release
+```
+
+## Notes
+
+- The example follows the shared SDL3-CS examples build model and keeps native runtime selection in common MSBuild targets.
+
+## Related Documentation
+
+- [Repository README](../../../README.md)
+- [Examples inventory](../../UPSTREAM-SDL3-EXAMPLES.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL examples](https://examples.libsdl.org/SDL3/)

--- a/SDL3-CS.NativePackages/SDL3-CS.Android.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android.Image/README.md
@@ -1,23 +1,40 @@
 # SDL3-CS.Android.Image
 
-`SDL3-CS.Android.Image` contains native SDL_image runtime libraries for SDL3-CS on Android.
+<p align="center">
+  <img alt="Android native package" src="https://img.shields.io/badge/platform-Android-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Android.Image` contains SDL_image native runtime libraries for image loading and saving APIs for Android applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Android and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Android` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Android`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Android.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to Android and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `android-arm`
 - `android-arm64`
 - `android-x86`
 - `android-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Android.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: Android ABI-specific native libraries and, for the base package, SDLActivity bridge bindings.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -25,4 +42,36 @@ dotnet add package SDL3-CS.Android
 dotnet add package SDL3-CS.Android.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Android`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Android.Image\SDL3-CS.Android.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Android native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Android.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android.Mixer/README.md
@@ -1,23 +1,40 @@
 # SDL3-CS.Android.Mixer
 
-`SDL3-CS.Android.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on Android.
+<p align="center">
+  <img alt="Android native package" src="https://img.shields.io/badge/platform-Android-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Android.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for Android applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Android and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Android` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Android`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Android.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to Android and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `android-arm`
 - `android-arm64`
 - `android-x86`
 - `android-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Android.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: Android ABI-specific native libraries and, for the base package, SDLActivity bridge bindings.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -25,4 +42,36 @@ dotnet add package SDL3-CS.Android
 dotnet add package SDL3-CS.Android.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Android`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Android.Mixer\SDL3-CS.Android.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Android native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Android.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android.Shadercross/README.md
@@ -1,23 +1,40 @@
 # SDL3-CS.Android.Shadercross
 
-`SDL3-CS.Android.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on Android.
+<p align="center">
+  <img alt="Android native package" src="https://img.shields.io/badge/platform-Android-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Android.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for Android applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Android and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Android` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Android`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Android.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to Android and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `android-arm`
 - `android-arm64`
 - `android-x86`
 - `android-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Android.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: Android ABI-specific native libraries and, for the base package, SDLActivity bridge bindings.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -25,4 +42,36 @@ dotnet add package SDL3-CS.Android
 dotnet add package SDL3-CS.Android.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Android`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Android.Shadercross\SDL3-CS.Android.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Android native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Android.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android.TTF/README.md
@@ -1,23 +1,40 @@
 # SDL3-CS.Android.TTF
 
-`SDL3-CS.Android.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on Android.
+<p align="center">
+  <img alt="Android native package" src="https://img.shields.io/badge/platform-Android-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Android.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for Android applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Android and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Android` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Android`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Android.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to Android and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `android-arm`
 - `android-arm64`
 - `android-x86`
 - `android-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Android.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: Android ABI-specific native libraries and, for the base package, SDLActivity bridge bindings.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -25,4 +42,36 @@ dotnet add package SDL3-CS.Android
 dotnet add package SDL3-CS.Android.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Android`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Android.TTF\SDL3-CS.Android.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Android native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Android/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android/README.md
@@ -1,28 +1,80 @@
 # SDL3-CS.Android
 
-`SDL3-CS.Android` contains native SDL runtime libraries for SDL3-CS on Android.
+<p align="center">
+  <img alt="Android native package" src="https://img.shields.io/badge/platform-Android-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Android` contains base SDL runtime libraries required by SDL3-CS applications for Android applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Android and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Android` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Android` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to Android and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `android-arm`
 - `android-arm64`
 - `android-x86`
 - `android-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Android.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: Android ABI-specific native libraries and, for the base package, SDLActivity bridge bindings.
+
+## Android Bridge
+
+The base Android package also includes the SDL Java bridge binding. Android apps can inherit from `Org.Libsdl.App.SDLActivity`, override `GetLibraries()` to load `SDL3`, and run managed SDL code from the activity `Main()` override. See the Android example README under [`../../SDL3-CS.Examples/Android/AndroidCircularColorFade`](../../SDL3-CS.Examples/Android/AndroidCircularColorFade/README.md).
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.Android
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for Android.
-Android applications should use `MainActivity : Org.Libsdl.App.SDLActivity` and override managed `Main()`. This package also carries the SDL Android Java bridge.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Android` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Android.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Android.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Android.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Android.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Android\SDL3-CS.Android.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Android native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux.Image/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.Linux.Image
 
-`SDL3-CS.Linux.Image` contains native SDL_image runtime libraries for SDL3-CS on Linux.
+<p align="center">
+  <img alt="Linux native package" src="https://img.shields.io/badge/platform-Linux-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Linux.Image` contains SDL_image native runtime libraries for image loading and saving APIs for Linux applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Linux and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Linux` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Linux`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Linux.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to Linux and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `linux-x64`
 - `linux-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Linux.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.Linux
 dotnet add package SDL3-CS.Linux.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Linux`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Linux.Image\SDL3-CS.Linux.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Linux native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux.Mixer/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.Linux.Mixer
 
-`SDL3-CS.Linux.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on Linux.
+<p align="center">
+  <img alt="Linux native package" src="https://img.shields.io/badge/platform-Linux-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Linux.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for Linux applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Linux and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Linux` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Linux`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Linux.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to Linux and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `linux-x64`
 - `linux-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Linux.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.Linux
 dotnet add package SDL3-CS.Linux.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Linux`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Linux.Mixer\SDL3-CS.Linux.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Linux native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux.Shadercross/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.Linux.Shadercross
 
-`SDL3-CS.Linux.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on Linux.
+<p align="center">
+  <img alt="Linux native package" src="https://img.shields.io/badge/platform-Linux-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Linux.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for Linux applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Linux and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Linux` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Linux`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Linux.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to Linux and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `linux-x64`
 - `linux-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Linux.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.Linux
 dotnet add package SDL3-CS.Linux.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Linux`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Linux.Shadercross\SDL3-CS.Linux.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Linux native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux.TTF/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.Linux.TTF
 
-`SDL3-CS.Linux.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on Linux.
+<p align="center">
+  <img alt="Linux native package" src="https://img.shields.io/badge/platform-Linux-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Linux.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for Linux applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Linux and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Linux` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Linux`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Linux.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to Linux and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `linux-x64`
 - `linux-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Linux.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.Linux
 dotnet add package SDL3-CS.Linux.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Linux`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Linux.TTF\SDL3-CS.Linux.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Linux native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux/README.md
@@ -1,25 +1,74 @@
 # SDL3-CS.Linux
 
-`SDL3-CS.Linux` contains native SDL runtime libraries for SDL3-CS on Linux.
+<p align="center">
+  <img alt="Linux native package" src="https://img.shields.io/badge/platform-Linux-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Linux` contains base SDL runtime libraries required by SDL3-CS applications for Linux applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Linux and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Linux` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Linux` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to Linux and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `linux-x64`
 - `linux-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Linux.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.Linux
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for Linux.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Linux` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Linux.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Linux.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Linux.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Linux.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Linux\SDL3-CS.Linux.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Linux native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.MacOS.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.MacOS.Image/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.MacOS.Image
 
-`SDL3-CS.MacOS.Image` contains native SDL_image runtime libraries for SDL3-CS on MacOS.
+<p align="center">
+  <img alt="macOS native package" src="https://img.shields.io/badge/platform-macOS-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.MacOS.Image` contains SDL_image native runtime libraries for image loading and saving APIs for macOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets macOS and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.MacOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.MacOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.MacOS.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to MacOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `osx-x64`
 - `osx-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.MacOS.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.MacOS
 dotnet add package SDL3-CS.MacOS.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.MacOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.MacOS.Image\SDL3-CS.MacOS.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching macOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.MacOS.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.MacOS.Mixer/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.MacOS.Mixer
 
-`SDL3-CS.MacOS.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on MacOS.
+<p align="center">
+  <img alt="macOS native package" src="https://img.shields.io/badge/platform-macOS-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.MacOS.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for macOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets macOS and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.MacOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.MacOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.MacOS.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to MacOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `osx-x64`
 - `osx-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.MacOS.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.MacOS
 dotnet add package SDL3-CS.MacOS.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.MacOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.MacOS.Mixer\SDL3-CS.MacOS.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching macOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.MacOS.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.MacOS.Shadercross/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.MacOS.Shadercross
 
-`SDL3-CS.MacOS.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on MacOS.
+<p align="center">
+  <img alt="macOS native package" src="https://img.shields.io/badge/platform-macOS-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.MacOS.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for macOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets macOS and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.MacOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.MacOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.MacOS.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to MacOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `osx-x64`
 - `osx-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.MacOS.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.MacOS
 dotnet add package SDL3-CS.MacOS.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.MacOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.MacOS.Shadercross\SDL3-CS.MacOS.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching macOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.MacOS.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.MacOS.TTF/README.md
@@ -1,21 +1,38 @@
 # SDL3-CS.MacOS.TTF
 
-`SDL3-CS.MacOS.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on MacOS.
+<p align="center">
+  <img alt="macOS native package" src="https://img.shields.io/badge/platform-macOS-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.MacOS.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for macOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets macOS and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.MacOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.MacOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.MacOS.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to MacOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `osx-x64`
 - `osx-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.MacOS.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -23,4 +40,36 @@ dotnet add package SDL3-CS.MacOS
 dotnet add package SDL3-CS.MacOS.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.MacOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.MacOS.TTF\SDL3-CS.MacOS.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching macOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.MacOS/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.MacOS/README.md
@@ -1,25 +1,74 @@
 # SDL3-CS.MacOS
 
-`SDL3-CS.MacOS` contains native SDL runtime libraries for SDL3-CS on MacOS.
+<p align="center">
+  <img alt="macOS native package" src="https://img.shields.io/badge/platform-macOS-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.MacOS` contains base SDL runtime libraries required by SDL3-CS applications for macOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets macOS and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.MacOS` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.MacOS` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to MacOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `osx-x64`
 - `osx-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.MacOS.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.MacOS
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for MacOS.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.MacOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.MacOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.MacOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.MacOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.MacOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.MacOS\SDL3-CS.MacOS.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching macOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows.Image/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.Windows.Image
 
-`SDL3-CS.Windows.Image` contains native SDL_image runtime libraries for SDL3-CS on Windows.
+<p align="center">
+  <img alt="Windows native package" src="https://img.shields.io/badge/platform-Windows-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Windows.Image` contains SDL_image native runtime libraries for image loading and saving APIs for Windows applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Windows and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Windows` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Windows`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Windows.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to Windows and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `win-x86`
 - `win-x64`
 - `win-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Windows.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.Windows
 dotnet add package SDL3-CS.Windows.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Windows`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Windows.Image\SDL3-CS.Windows.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Windows native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows.Mixer/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.Windows.Mixer
 
-`SDL3-CS.Windows.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on Windows.
+<p align="center">
+  <img alt="Windows native package" src="https://img.shields.io/badge/platform-Windows-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Windows.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for Windows applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Windows and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Windows` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Windows`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Windows.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to Windows and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `win-x86`
 - `win-x64`
 - `win-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Windows.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.Windows
 dotnet add package SDL3-CS.Windows.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Windows`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Windows.Mixer\SDL3-CS.Windows.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Windows native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows.Shadercross/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.Windows.Shadercross
 
-`SDL3-CS.Windows.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on Windows.
+<p align="center">
+  <img alt="Windows native package" src="https://img.shields.io/badge/platform-Windows-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Windows.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for Windows applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Windows and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Windows` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Windows`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Windows.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to Windows and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `win-x86`
 - `win-x64`
 - `win-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Windows.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.Windows
 dotnet add package SDL3-CS.Windows.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Windows`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Windows.Shadercross\SDL3-CS.Windows.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Windows native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows.TTF/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.Windows.TTF
 
-`SDL3-CS.Windows.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on Windows.
+<p align="center">
+  <img alt="Windows native package" src="https://img.shields.io/badge/platform-Windows-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Windows.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for Windows applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Windows and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Windows` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.Windows`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Windows.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to Windows and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `win-x86`
 - `win-x64`
 - `win-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Windows.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.Windows
 dotnet add package SDL3-CS.Windows.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.Windows`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Windows.TTF\SDL3-CS.Windows.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Windows native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows/README.md
@@ -1,26 +1,75 @@
 # SDL3-CS.Windows
 
-`SDL3-CS.Windows` contains native SDL runtime libraries for SDL3-CS on Windows.
+<p align="center">
+  <img alt="Windows native package" src="https://img.shields.io/badge/platform-Windows-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.Windows` contains base SDL runtime libraries required by SDL3-CS applications for Windows applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets Windows and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.Windows` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.Windows` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to Windows and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `win-x86`
 - `win-x64`
 - `win-arm64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.Windows.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: dynamic native libraries copied from the NuGet runtime assets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.Windows
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for Windows.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.Windows` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.Windows.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.Windows.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.Windows.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.Windows.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.Windows\SDL3-CS.Windows.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching Windows native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.iOS.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.iOS.Image/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.iOS.Image
 
-`SDL3-CS.iOS.Image` contains native SDL_image runtime libraries for SDL3-CS on iOS.
+<p align="center">
+  <img alt="iOS native package" src="https://img.shields.io/badge/platform-iOS-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.iOS.Image` contains SDL_image native runtime libraries for image loading and saving APIs for iOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets iOS and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.iOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.iOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.iOS.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to iOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `ios-arm64`
 - `iossimulator-arm64`
 - `iossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.iOS.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.iOS
 dotnet add package SDL3-CS.iOS.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.iOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.iOS.Image\SDL3-CS.iOS.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching iOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.iOS.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.iOS.Mixer/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.iOS.Mixer
 
-`SDL3-CS.iOS.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on iOS.
+<p align="center">
+  <img alt="iOS native package" src="https://img.shields.io/badge/platform-iOS-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.iOS.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for iOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets iOS and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.iOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.iOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.iOS.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to iOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `ios-arm64`
 - `iossimulator-arm64`
 - `iossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.iOS.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.iOS
 dotnet add package SDL3-CS.iOS.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.iOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.iOS.Mixer\SDL3-CS.iOS.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching iOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.iOS.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.iOS.Shadercross/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.iOS.Shadercross
 
-`SDL3-CS.iOS.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on iOS.
+<p align="center">
+  <img alt="iOS native package" src="https://img.shields.io/badge/platform-iOS-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.iOS.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for iOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets iOS and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.iOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.iOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.iOS.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to iOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `ios-arm64`
 - `iossimulator-arm64`
 - `iossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.iOS.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.iOS
 dotnet add package SDL3-CS.iOS.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.iOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.iOS.Shadercross\SDL3-CS.iOS.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching iOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.iOS.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.iOS.TTF/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.iOS.TTF
 
-`SDL3-CS.iOS.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on iOS.
+<p align="center">
+  <img alt="iOS native package" src="https://img.shields.io/badge/platform-iOS-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.iOS.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for iOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets iOS and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.iOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.iOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.iOS.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to iOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `ios-arm64`
 - `iossimulator-arm64`
 - `iossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.iOS.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.iOS
 dotnet add package SDL3-CS.iOS.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.iOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.iOS.TTF\SDL3-CS.iOS.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching iOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.iOS/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.iOS/README.md
@@ -1,26 +1,75 @@
 # SDL3-CS.iOS
 
-`SDL3-CS.iOS` contains native SDL runtime libraries for SDL3-CS on iOS.
+<p align="center">
+  <img alt="iOS native package" src="https://img.shields.io/badge/platform-iOS-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.iOS` contains base SDL runtime libraries required by SDL3-CS applications for iOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets iOS and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.iOS` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.iOS` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to iOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `ios-arm64`
 - `iossimulator-arm64`
 - `iossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.iOS.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.iOS
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for iOS.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.iOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.iOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.iOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.iOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.iOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.iOS\SDL3-CS.iOS.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching iOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.tvOS.Image/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.tvOS.Image/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.tvOS.Image
 
-`SDL3-CS.tvOS.Image` contains native SDL_image runtime libraries for SDL3-CS on tvOS.
+<p align="center">
+  <img alt="tvOS native package" src="https://img.shields.io/badge/platform-tvOS-555?style=flat-square">
+  <img alt="SDL_image" src="https://img.shields.io/badge/component-SDL_image-239120?style=flat-square">
+  <img alt="SDL_image 3.4.4" src="https://img.shields.io/badge/native-SDL_image%203.4.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.tvOS.Image` contains SDL_image native runtime libraries for image loading and saving APIs for tvOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets tvOS and needs image format detection, image loading, animation loading, and image saving through `SDL3.Image`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.tvOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.tvOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.tvOS.Image` | `SDL_image 3.4.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | `3.4.4.x` |
 
-## Platform Support
-
-This package is scoped to tvOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `tvos-arm64`
 - `tvossimulator-arm64`
 - `tvossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.tvOS.Image.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.tvOS
 dotnet add package SDL3-CS.tvOS.Image
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.tvOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.tvOS.Image\SDL3-CS.tvOS.Image.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching tvOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.tvOS.Mixer/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.tvOS.Mixer/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.tvOS.Mixer
 
-`SDL3-CS.tvOS.Mixer` contains native SDL_mixer runtime libraries for SDL3-CS on tvOS.
+<p align="center">
+  <img alt="tvOS native package" src="https://img.shields.io/badge/platform-tvOS-555?style=flat-square">
+  <img alt="SDL_mixer" src="https://img.shields.io/badge/component-SDL_mixer-239120?style=flat-square">
+  <img alt="SDL_mixer 3.2.4" src="https://img.shields.io/badge/native-SDL_mixer%203.2.4-004880?style=flat-square">
+</p>
+
+`SDL3-CS.tvOS.Mixer` contains SDL_mixer native runtime libraries for music, tracks, and mixer playback APIs for tvOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets tvOS and needs higher-level audio mixing through `SDL3.Mixer`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.tvOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.tvOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.tvOS.Mixer` | `SDL_mixer 3.2.4` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | `3.2.4.x` |
 
-## Platform Support
-
-This package is scoped to tvOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `tvos-arm64`
 - `tvossimulator-arm64`
 - `tvossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.tvOS.Mixer.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.tvOS
 dotnet add package SDL3-CS.tvOS.Mixer
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.tvOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.tvOS.Mixer\SDL3-CS.tvOS.Mixer.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching tvOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.tvOS.Shadercross/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.tvOS.Shadercross/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.tvOS.Shadercross
 
-`SDL3-CS.tvOS.Shadercross` contains native SDL_shadercross runtime libraries for SDL3-CS on tvOS.
+<p align="center">
+  <img alt="tvOS native package" src="https://img.shields.io/badge/platform-tvOS-555?style=flat-square">
+  <img alt="SDL_shadercross" src="https://img.shields.io/badge/component-SDL_shadercross-239120?style=flat-square">
+  <img alt="SDL_shadercross 3.0.0" src="https://img.shields.io/badge/native-SDL_shadercross%203.0.0-004880?style=flat-square">
+</p>
+
+`SDL3-CS.tvOS.Shadercross` contains SDL_shadercross native runtime libraries for shader translation APIs for tvOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets tvOS and needs shader conversion workflows through `SDL3.ShaderCross`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.tvOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.tvOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.tvOS.Shadercross` | `SDL_shadercross 3.0.0` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | `3.0.0.x` |
 
-## Platform Support
-
-This package is scoped to tvOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `tvos-arm64`
 - `tvossimulator-arm64`
 - `tvossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.tvOS.Shadercross.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.tvOS
 dotnet add package SDL3-CS.tvOS.Shadercross
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.tvOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.tvOS.Shadercross\SDL3-CS.tvOS.Shadercross.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching tvOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.tvOS.TTF/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.tvOS.TTF/README.md
@@ -1,22 +1,39 @@
 # SDL3-CS.tvOS.TTF
 
-`SDL3-CS.tvOS.TTF` contains native SDL_ttf runtime libraries for SDL3-CS on tvOS.
+<p align="center">
+  <img alt="tvOS native package" src="https://img.shields.io/badge/platform-tvOS-555?style=flat-square">
+  <img alt="SDL_ttf" src="https://img.shields.io/badge/component-SDL_ttf-239120?style=flat-square">
+  <img alt="SDL_ttf 3.2.2" src="https://img.shields.io/badge/native-SDL_ttf%203.2.2-004880?style=flat-square">
+</p>
+
+`SDL3-CS.tvOS.TTF` contains SDL_ttf native runtime libraries for TrueType/OpenType font and text APIs for tvOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets tvOS and needs font loading, glyph metrics, and rendered text through `SDL3.TTF`. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.tvOS` with native packages from another platform family. This add-on package is not a replacement for the base runtime package. Install it together with `SDL3-CS` and `SDL3-CS.tvOS`.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.tvOS.TTF` | `SDL_ttf 3.2.2` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | `3.2.2.x` |
 
-## Platform Support
-
-This package is scoped to tvOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `tvos-arm64`
 - `tvossimulator-arm64`
 - `tvossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.tvOS.TTF.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
@@ -24,4 +41,36 @@ dotnet add package SDL3-CS.tvOS
 dotnet add package SDL3-CS.tvOS.TTF
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. Use it with the base platform package `SDL3-CS.tvOS`.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.tvOS.TTF\SDL3-CS.tvOS.TTF.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching tvOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.NativePackages/SDL3-CS.tvOS/README.md
+++ b/SDL3-CS.NativePackages/SDL3-CS.tvOS/README.md
@@ -1,26 +1,75 @@
 # SDL3-CS.tvOS
 
-`SDL3-CS.tvOS` contains native SDL runtime libraries for SDL3-CS on tvOS.
+<p align="center">
+  <img alt="tvOS native package" src="https://img.shields.io/badge/platform-tvOS-555?style=flat-square">
+  <img alt="SDL3" src="https://img.shields.io/badge/component-SDL3-239120?style=flat-square">
+  <img alt="SDL 3.4.10" src="https://img.shields.io/badge/native-SDL%203.4.10-004880?style=flat-square">
+</p>
+
+`SDL3-CS.tvOS` contains base SDL runtime libraries required by SDL3-CS applications for tvOS applications that use SDL3-CS.
+
+## When To Use This Package
+
+Use this package when a .NET application targets tvOS and needs windowing, events, rendering, audio, input, files, threading, timers, and the rest of the core SDL3 API. Keep all SDL3-CS packages in the same application on the same platform family; do not mix `SDL3-CS.tvOS` with native packages from another platform family.
 
 ## Native Version
 
-| Package | Native library version |
-| --- | --- |
-| `SDL3-CS.tvOS` | `SDL 3.4.10` |
+| Package | Native library version | Package line |
+|---------|------------------------|--------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | `3.4.10.x` |
 
-## Platform Support
-
-This package is scoped to tvOS and contains native artifacts only for these RIDs:
+## Supported Runtime Identifiers
 
 - `tvos-arm64`
 - `tvossimulator-arm64`
 - `tvossimulator-x64`
 
-## Usage
+## Package Contents
+
+- `runtimes/<rid>/native/` assets for each supported runtime identifier.
+- `buildTransitive/SDL3-CS.tvOS.targets` for package-time native asset integration.
+- `README.md`, `LICENSE`, and the SDL3-CS package icon for NuGet display.
+- No application entry point and no managed SDL wrapper API beyond any bridge bindings required by the platform.
+
+Native asset mode: static native libraries linked through buildTransitive targets.
+
+## Installation
 
 ```powershell
 dotnet add package SDL3-CS
 dotnet add package SDL3-CS.tvOS
 ```
 
-Use the same platform family for every SDL3-CS native package in one application. This is the base native runtime package for tvOS.
+## Companion Packages
+
+| Package | Native component | Use when you need |
+|---------|------------------|-------------------|
+| `SDL3-CS.tvOS` | SDL 3.4.10 | Core SDL3 runtime assets. |
+| `SDL3-CS.tvOS.Image` | SDL_image 3.4.4 | Image loading and saving. |
+| `SDL3-CS.tvOS.TTF` | SDL_ttf 3.2.2 | Font and text rendering APIs. |
+| `SDL3-CS.tvOS.Mixer` | SDL_mixer 3.2.4 | Music and mixer playback APIs. |
+| `SDL3-CS.tvOS.Shadercross` | SDL_shadercross 3.0.0 | Shader translation APIs. |
+
+## Build From This Repository
+
+From the repository root:
+
+```powershell
+dotnet pack .\SDL3-CS.NativePackages\SDL3-CS.tvOS\SDL3-CS.tvOS.csproj -c Release
+```
+
+The release pipeline populates the `lib/<rid>/` folders before packaging. A local pack without those native assets is useful only for metadata validation.
+
+## Verification Checklist
+
+- The package RID list matches the release manifest and native artifact layout.
+- `PackageReadmeFile` points to this README.
+- `buildTransitive` targets are packed under `buildTransitive/$(PackageId).targets`.
+- Applications reference `SDL3-CS` plus the matching tvOS native package family.
+
+## Related Documentation
+
+- [Repository README](../../README.md)
+- [Managed wrapper project](../../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [NuGet package search](https://www.nuget.org/profiles/edwardgushchin)

--- a/SDL3-CS.Tests/README.md
+++ b/SDL3-CS.Tests/README.md
@@ -1,0 +1,59 @@
+# SDL3-CS Tests
+
+<p align="center">
+  <img alt="test project" src="https://img.shields.io/badge/project-tests-555?style=flat-square">
+  <img alt=".NET 8" src="https://img.shields.io/badge/.NET-8.0-512BD4?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23-14-239120?style=flat-square">
+</p>
+
+`SDL3-CS.Tests` is the focused verification project for the managed wrapper. It is intentionally separate from the shipped package and mirrors the wrapper source tree so each wrapper function can be tested close to its public API location.
+
+## What This Project Covers
+
+- Metadata and ABI checks for generated or native entry-point bindings.
+- Managed wrapper behavior for success, failure, null, invalid input, marshalling, and ownership paths.
+- Struct layout, enum values, callback lifetimes, and helper APIs that must match SDL ABI expectations.
+- Regression tests for GitHub issues and release audits.
+
+## Project Model
+
+| Setting | Value |
+|---------|-------|
+| Target framework | `net8.0` |
+| Output type | `Exe` |
+| Language | C# 14 |
+| Unsafe code | enabled |
+| Main dependency | [`SDL3-CS`](../SDL3-CS/README.md) project reference |
+
+The test layout should mirror wrapper source paths. For example, tests for `SDL3-CS/Mixer/PInvoke.cs` belong in `SDL3-CS.Tests/Mixer/PInvoke.cs`.
+
+## Run
+
+From the repository root:
+
+```powershell
+dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release
+dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build
+```
+
+For wrapper documentation work, also run:
+
+```powershell
+pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
+```
+
+## Coverage Expectations
+
+Repository policy requires every C# method declaration in the wrapper project to have meaningful automated coverage. Tests should prove behavior, ABI shape, or native metadata rather than only assigning delegates or checking that a method exists.
+
+When a direct native call is unsafe on a developer workstation, prefer metadata, signature, marshalling, and controlled failure-path assertions that still prove the wrapper contract.
+
+## Native Runtime Notes
+
+Some tests can execute without native SDL libraries because they inspect metadata or managed behavior. Runtime tests that call SDL need compatible native binaries available to the test output for the current host platform.
+
+## Related Documentation
+
+- [Repository README](../README.md)
+- [Managed wrapper project](../SDL3-CS/README.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)

--- a/SDL3-CS.Tests/TTF/GPUAtlasDrawSequence.cs
+++ b/SDL3-CS.Tests/TTF/GPUAtlasDrawSequence.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using SDL3.Tests;
+
+namespace SDL3.Tests.TTF;
+
+internal static class GPUAtlasDrawSequenceTests
+{
+    public static void RunAll()
+    {
+        PublicFields_MatchSdlTtfHeader();
+        Layout_MatchesNativeStructure();
+    }
+
+    public static void PublicFields_MatchSdlTtfHeader()
+    {
+        FieldInfo[] fields = typeof(SDL3.TTF.GPUAtlasDrawSequence).GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        string[] names = fields.Select(static field => field.Name).ToArray();
+
+        TestAssert.Equal(
+            "AtlasTexture, XY, UV, NumVertices, Indices, NumIndices, ImageType, Next",
+            string.Join(", ", names),
+            "TTF.GPUAtlasDrawSequence must expose every SDL_ttf draw sequence field.");
+        TestAssert.Equal(typeof(IntPtr), typeof(SDL3.TTF.GPUAtlasDrawSequence).GetField(nameof(SDL3.TTF.GPUAtlasDrawSequence.Next))!.FieldType, "TTF.GPUAtlasDrawSequence.Next must be a native pointer.");
+    }
+
+    public static void Layout_MatchesNativeStructure()
+    {
+        int pointerSize = IntPtr.Size;
+        int alignedAfterNumVertices = Align(pointerSize * 3 + sizeof(int), pointerSize);
+        int numIndicesOffset = alignedAfterNumVertices + pointerSize;
+        int imageTypeOffset = numIndicesOffset + sizeof(int);
+        int nextOffset = Align(imageTypeOffset + sizeof(int), pointerSize);
+        int expectedSize = nextOffset + pointerSize;
+
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.AtlasTexture), 0);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.XY), pointerSize);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.UV), pointerSize * 2);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.NumVertices), pointerSize * 3);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.Indices), alignedAfterNumVertices);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.NumIndices), numIndicesOffset);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.ImageType), imageTypeOffset);
+        AssertOffset(nameof(SDL3.TTF.GPUAtlasDrawSequence.Next), nextOffset);
+        TestAssert.Equal(expectedSize, Marshal.SizeOf<SDL3.TTF.GPUAtlasDrawSequence>(), "TTF.GPUAtlasDrawSequence size must include the native next pointer.");
+    }
+
+    private static int Align(int value, int alignment)
+    {
+        return (value + alignment - 1) / alignment * alignment;
+    }
+
+    private static void AssertOffset(string fieldName, int expected)
+    {
+        int actual = Marshal.OffsetOf<SDL3.TTF.GPUAtlasDrawSequence>(fieldName).ToInt32();
+        TestAssert.Equal(expected, actual, $"TTF.GPUAtlasDrawSequence.{fieldName} offset must match SDL_ttf layout.");
+    }
+}

--- a/SDL3-CS.Tests/TTF/PInvoke.cs
+++ b/SDL3-CS.Tests/TTF/PInvoke.cs
@@ -98,6 +98,7 @@ internal static class PInvokeTests
 
     public static void RunAll()
     {
+        GPUAtlasDrawSequenceTests.RunAll();
         NativeEntryPoints_KeepExpectedLibraryImportMetadata();
         PropertyConstants_MatchSdlTtf322Header();
         VersionAndInitFunctions_ForwardOutputsAndReturnNativeValues();

--- a/SDL3-CS/README.md
+++ b/SDL3-CS/README.md
@@ -1,0 +1,79 @@
+# SDL3-CS Managed Wrapper Project
+
+<p align="center">
+  <img alt=".NET 7, 8, 9, and 10" src="https://img.shields.io/badge/.NET-7.0%20%7C%208.0%20%7C%209.0%20%7C%2010.0-512BD4?style=flat-square">
+  <img alt="C# 14" src="https://img.shields.io/badge/C%23-14-239120?style=flat-square">
+  <img alt="SDL target 3.4.10" src="https://img.shields.io/badge/SDL3%20target-3.4.10-239120?style=flat-square">
+  <img alt="NuGet package SDL3-CS" src="https://img.shields.io/badge/NuGet-SDL3--CS-004880?style=flat-square">
+</p>
+
+`SDL3-CS` is the managed C# binding project for SDL3 and the companion SDL_image, SDL_ttf, SDL_mixer, and SDL_shadercross APIs exposed by this repository. It provides the public `SDL3` namespace that application and example projects consume.
+
+## What This Project Contains
+
+- P/Invoke declarations and managed convenience wrappers for SDL3 core APIs.
+- Add-on bindings for Image, TTF, Mixer, and ShaderCross namespaces.
+- C# representations of SDL enums, flags, structs, callbacks, opaque handles, and constants.
+- XML documentation generated from upstream SDL documentation and kept warning-clean by repository checks.
+- NuGet package metadata for the managed `SDL3-CS` package.
+
+## What This Project Does Not Ship
+
+The managed wrapper package does not carry platform native binaries. Applications should pair it with exactly one native runtime package family for their target platform, such as `SDL3-CS.Windows`, `SDL3-CS.Linux`, `SDL3-CS.MacOS`, `SDL3-CS.Android`, `SDL3-CS.iOS`, or `SDL3-CS.tvOS`.
+
+## Target Frameworks
+
+| Target | Purpose |
+|--------|---------|
+| `net7.0` | Long-running applications that still target .NET 7. |
+| `net8.0` | Current LTS-friendly applications and the test runner baseline. |
+| `net9.0` | Applications on the .NET 9 line. |
+| `net10.0` | Latest SDK and example project line in this repository. |
+
+## Build
+
+From the repository root:
+
+```powershell
+dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release
+```
+
+To create the managed NuGet package locally:
+
+```powershell
+dotnet pack .\SDL3-CS\SDL3-CS.csproj -c Release
+```
+
+## Consumer Usage
+
+```powershell
+dotnet add package SDL3-CS
+dotnet add package SDL3-CS.Windows
+```
+
+Replace `Windows` with the native package family for the platform that will run the application. Add companion native packages such as `SDL3-CS.Windows.Image` only when the application uses those companion bindings.
+
+## Source Layout
+
+- `SDL/` contains core SDL3 namespaces grouped by upstream SDL header categories.
+- `Image/`, `TTF/`, `Mixer/`, and `ShaderCross/` contain companion library bindings.
+- Public wrapper methods carry XML documentation; private native entry points stay implementation-focused.
+- Unsafe and fixed-buffer shapes are used where SDL ABI compatibility requires them.
+
+## Verification
+
+Use these checks when changing this project:
+
+```powershell
+dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release
+pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
+```
+
+Wrapper behavior is covered from the mirrored test project in [`../SDL3-CS.Tests`](../SDL3-CS.Tests/README.md).
+
+## Related Documentation
+
+- [Repository README](../README.md)
+- [NuGet README](../README-nuget.md)
+- [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki)
+- [Official SDL3 Wiki](https://wiki.libsdl.org/SDL3/FrontPage)

--- a/SDL3-CS/TTF/GPUAtlasDrawSequence.cs
+++ b/SDL3-CS/TTF/GPUAtlasDrawSequence.cs
@@ -69,5 +69,10 @@ public static partial class TTF
         /// The image type of this draw sequence
         /// </summary>
         public ImageType ImageType;
+
+        /// <summary>
+        /// The next sequence, or <c>null</c> in case of the last sequence
+        /// </summary>
+        public IntPtr Next;
     }
 }


### PR DESCRIPTION
## Summary
- Exposes `TTF.GPUAtlasDrawSequence.Next` so callers can walk the linked list returned by `TTF.GetGPUTextDrawData`.
- Adds mirrored layout coverage for `GPUAtlasDrawSequence` fields, offsets, and native size.
- Prepares `3.4.10.5` release notes and NuGet README, and carries the release notes body validation from the accepted release tooling cleanup.

## Checks
- `dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build`
- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- `pwsh .\.github\release-tools\Test-ReleaseNotes.ps1`
- `pwsh .\.github\release-tools\Test-PackageVersioning.ps1 -PackageRevision 5`
- `pwsh .\.github\release-tools\Test-ReleasePublishPlan.ps1`
- `pwsh .\.github\release-tools\Test-ReleaseWorkflow.ps1`
- `pwsh .\.github\release-tools\Publish-Release.ps1 -PackageRevision 5 -GitHubRelease -NuGetPush -DryRun`
- `pwsh .\.github\release-tools\Test-ReleaseReadiness.ps1 -PackageRevision 5 -SkipToolchainValidation -SkipNativeArtifactValidation -SkipNativeBuildReceiptValidation -FailOnError`
- `pwsh .\.github\release-tools\Invoke-GitHubReleaseWorkflow.ps1 -PackageRevision 5 -BuildParallelLevel 2 -PublishGitHub -PublishNuGet`

Fixes #193.