### PR TITLE
Sync release-3.4.10 into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@
   <a href="#-license">License</a>
 </p>
 
+<p align="center">⭐ <a href="https://github.com/edwardgushchin/SDL3-CS">Star us on GitHub</a> - it motivates us a lot!</p>
+
 ## 🚀 About
 
 SDL3# is a C# wrapper and native package set for SDL3. It gives .NET applications direct access to SDL3 APIs while keeping native runtime distribution predictable across desktop, mobile, and Apple TV targets.

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -1,5 +1,7 @@
 using SDL3;
 
+SDL3.Tests.Repository.FileNameTests.TrackedFilePaths_DoNotContainCyrillicCharacters();
+Console.WriteLine("Repository tracked file path Cyrillic guard test passed.");
 SDL3.Tests.SDL.Basics.Assert.PInvokeTests.ReportAssertion_ForwardsDataStringsAndLine();
 Console.WriteLine("SDL.ReportAssertion binding test passed.");
 SDL3.Tests.SDL.Basics.Assert.PInvokeTests.SetAssertionHandler_ForwardsHandlerAndUserdata();

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -2,6 +2,10 @@ using SDL3;
 
 SDL3.Tests.Repository.FileNameTests.TrackedFilePaths_DoNotContainCyrillicCharacters();
 Console.WriteLine("Repository tracked file path Cyrillic guard test passed.");
+SDL3.Tests.Repository.FileNameTests.TrackedCSharpIdentifiers_DoNotContainCyrillicCharacters();
+Console.WriteLine("Repository tracked C# identifier Cyrillic guard test passed.");
+SDL3.Tests.Repository.FileNameTests.WrapperSourceFiles_DoNotContainCyrillicCharacters();
+Console.WriteLine("Repository wrapper source Cyrillic guard test passed.");
 SDL3.Tests.SDL.Basics.Assert.PInvokeTests.ReportAssertion_ForwardsDataStringsAndLine();
 Console.WriteLine("SDL.ReportAssertion binding test passed.");
 SDL3.Tests.SDL.Basics.Assert.PInvokeTests.SetAssertionHandler_ForwardsHandlerAndUserdata();

--- a/SDL3-CS.Tests/Repository/FileNameTests.cs
+++ b/SDL3-CS.Tests/Repository/FileNameTests.cs
@@ -7,7 +7,59 @@ internal static class FileNameTests
     public static void TrackedFilePaths_DoNotContainCyrillicCharacters()
     {
         string repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+        string[] trackedPaths = GetTrackedPaths(repositoryRoot);
 
+        string[] pathsWithCyrillic = trackedPaths
+            .Where(ContainsCyrillic)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        TestAssert.Equal(
+            0,
+            pathsWithCyrillic.Length,
+            "Tracked file paths must not contain Cyrillic characters: "
+            + string.Join(", ", pathsWithCyrillic));
+    }
+
+    public static void TrackedCSharpIdentifiers_DoNotContainCyrillicCharacters()
+    {
+        string repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+
+        string[] identifiersWithCyrillic = GetTrackedPaths(repositoryRoot)
+            .Where(path => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(path => FindCyrillicIdentifiers(repositoryRoot, path))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        TestAssert.Equal(
+            0,
+            identifiersWithCyrillic.Length,
+            "Tracked C# identifiers must not contain Cyrillic characters:"
+            + Environment.NewLine
+            + FormatViolations(identifiersWithCyrillic));
+    }
+
+    public static void WrapperSourceFiles_DoNotContainCyrillicCharacters()
+    {
+        string repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+
+        string[] sourceLinesWithCyrillic = GetTrackedPaths(repositoryRoot)
+            .Where(path => path.StartsWith("SDL3-CS/", StringComparison.Ordinal))
+            .Where(path => path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .SelectMany(path => FindCyrillicSourceLines(repositoryRoot, path))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        TestAssert.Equal(
+            0,
+            sourceLinesWithCyrillic.Length,
+            "Wrapper source files must not contain Cyrillic characters:"
+            + Environment.NewLine
+            + FormatViolations(sourceLinesWithCyrillic));
+    }
+
+    private static string[] GetTrackedPaths(string repositoryRoot)
+    {
         using Process process = StartGitLsFiles(repositoryRoot);
 
         string output = process.StandardOutput.ReadToEnd();
@@ -19,17 +71,31 @@ internal static class FileNameTests
             process.ExitCode,
             $"git ls-files failed while checking tracked file paths. stderr: {error}");
 
-        string[] pathsWithCyrillic = output
-            .Split('\0', StringSplitOptions.RemoveEmptyEntries)
-            .Where(ContainsCyrillic)
-            .Order(StringComparer.Ordinal)
-            .ToArray();
+        return output
+            .Split('\0', StringSplitOptions.RemoveEmptyEntries);
+    }
 
-        TestAssert.Equal(
-            0,
-            pathsWithCyrillic.Length,
-            "Tracked file paths must not contain Cyrillic characters: "
-            + string.Join(", ", pathsWithCyrillic));
+    private static IEnumerable<string> FindCyrillicIdentifiers(string repositoryRoot, string relativePath)
+    {
+        string text = File.ReadAllText(GetFullPath(repositoryRoot, relativePath));
+        var scanner = new CSharpIdentifierScanner(relativePath, text);
+
+        return scanner.FindCyrillicIdentifiers();
+    }
+
+    private static IEnumerable<string> FindCyrillicSourceLines(string repositoryRoot, string relativePath)
+    {
+        string fullPath = GetFullPath(repositoryRoot, relativePath);
+        int lineNumber = 0;
+
+        foreach (string line in File.ReadLines(fullPath))
+        {
+            lineNumber++;
+            if (ContainsCyrillic(line))
+            {
+                yield return $"{relativePath}:{lineNumber}: {line.Trim()}";
+            }
+        }
     }
 
     private static Process StartGitLsFiles(string repositoryRoot)
@@ -72,5 +138,288 @@ internal static class FileNameTests
     private static bool ContainsCyrillic(string value)
     {
         return value.Any(character => character is >= '\u0400' and <= '\u04FF');
+    }
+
+    private static string GetFullPath(string repositoryRoot, string relativePath)
+    {
+        return Path.Combine(repositoryRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+    }
+
+    private static string FormatViolations(IReadOnlyCollection<string> violations)
+    {
+        const int maxDisplayedViolations = 30;
+
+        string message = string.Join(Environment.NewLine, violations.Take(maxDisplayedViolations));
+        if (violations.Count > maxDisplayedViolations)
+        {
+            message += Environment.NewLine
+                + $"...and {violations.Count - maxDisplayedViolations} more violation(s).";
+        }
+
+        return message;
+    }
+
+    private sealed class CSharpIdentifierScanner(string path, string text)
+    {
+        private readonly List<string> violations = [];
+        private int index;
+        private int line = 1;
+        private int column = 1;
+
+        public string[] FindCyrillicIdentifiers()
+        {
+            while (index < text.Length)
+            {
+                if (TrySkipTriviaOrLiteral())
+                {
+                    continue;
+                }
+
+                if (IsIdentifierStart(Current) || IsVerbatimIdentifierStart())
+                {
+                    ScanIdentifier();
+                    continue;
+                }
+
+                Advance();
+            }
+
+            return [.. violations];
+        }
+
+        private bool TrySkipTriviaOrLiteral()
+        {
+            if (Current == '/' && Peek(1) == '/')
+            {
+                SkipLineComment();
+                return true;
+            }
+
+            if (Current == '/' && Peek(1) == '*')
+            {
+                SkipBlockComment();
+                return true;
+            }
+
+            if (Current == '$' && Peek(1) == '@' && Peek(2) == '"')
+            {
+                Advance();
+                Advance();
+                SkipVerbatimString();
+                return true;
+            }
+
+            if (Current == '@' && Peek(1) == '$' && Peek(2) == '"')
+            {
+                Advance();
+                Advance();
+                SkipVerbatimString();
+                return true;
+            }
+
+            if (Current == '@' && Peek(1) == '"')
+            {
+                Advance();
+                SkipVerbatimString();
+                return true;
+            }
+
+            if (Current == '$' && Peek(1) == '"')
+            {
+                Advance();
+                SkipRegularString();
+                return true;
+            }
+
+            if (Current == '"')
+            {
+                SkipRegularString();
+                return true;
+            }
+
+            if (Current == '\'')
+            {
+                SkipCharacterLiteral();
+                return true;
+            }
+
+            return false;
+        }
+
+        private void ScanIdentifier()
+        {
+            int startLine = line;
+            int startColumn = column;
+            int startIndex = index;
+
+            if (Current == '@')
+            {
+                Advance();
+            }
+
+            while (index < text.Length && IsIdentifierPart(Current))
+            {
+                Advance();
+            }
+
+            string identifier = text[startIndex..index];
+            if (ContainsCyrillic(identifier))
+            {
+                violations.Add($"{path}:{startLine}:{startColumn}: {identifier}");
+            }
+        }
+
+        private void SkipLineComment()
+        {
+            while (index < text.Length && Current is not '\r' and not '\n')
+            {
+                Advance();
+            }
+        }
+
+        private void SkipBlockComment()
+        {
+            Advance();
+            Advance();
+
+            while (index < text.Length)
+            {
+                if (Current == '*' && Peek(1) == '/')
+                {
+                    Advance();
+                    Advance();
+                    return;
+                }
+
+                Advance();
+            }
+        }
+
+        private void SkipRegularString()
+        {
+            Advance();
+
+            while (index < text.Length)
+            {
+                if (Current == '\\')
+                {
+                    Advance();
+                    if (index < text.Length)
+                    {
+                        Advance();
+                    }
+
+                    continue;
+                }
+
+                if (Current == '"')
+                {
+                    Advance();
+                    return;
+                }
+
+                Advance();
+            }
+        }
+
+        private void SkipVerbatimString()
+        {
+            Advance();
+
+            while (index < text.Length)
+            {
+                if (Current == '"' && Peek(1) == '"')
+                {
+                    Advance();
+                    Advance();
+                    continue;
+                }
+
+                if (Current == '"')
+                {
+                    Advance();
+                    return;
+                }
+
+                Advance();
+            }
+        }
+
+        private void SkipCharacterLiteral()
+        {
+            Advance();
+
+            while (index < text.Length)
+            {
+                if (Current == '\\')
+                {
+                    Advance();
+                    if (index < text.Length)
+                    {
+                        Advance();
+                    }
+
+                    continue;
+                }
+
+                if (Current == '\'')
+                {
+                    Advance();
+                    return;
+                }
+
+                Advance();
+            }
+        }
+
+        private bool IsVerbatimIdentifierStart()
+        {
+            return Current == '@' && IsIdentifierStart(Peek(1));
+        }
+
+        private static bool IsIdentifierStart(char character)
+        {
+            return character == '_' || char.IsLetter(character);
+        }
+
+        private static bool IsIdentifierPart(char character)
+        {
+            return character == '_' || char.IsLetterOrDigit(character);
+        }
+
+        private char Current => index < text.Length ? text[index] : '\0';
+
+        private char Peek(int offset)
+        {
+            int position = index + offset;
+            return position < text.Length ? text[position] : '\0';
+        }
+
+        private void Advance()
+        {
+            if (Current == '\r')
+            {
+                index++;
+                if (Current == '\n')
+                {
+                    index++;
+                }
+
+                line++;
+                column = 1;
+                return;
+            }
+
+            if (Current == '\n')
+            {
+                index++;
+                line++;
+                column = 1;
+                return;
+            }
+
+            index++;
+            column++;
+        }
     }
 }

--- a/SDL3-CS.Tests/Repository/FileNameTests.cs
+++ b/SDL3-CS.Tests/Repository/FileNameTests.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace SDL3.Tests.Repository;
+
+internal static class FileNameTests
+{
+    public static void TrackedFilePaths_DoNotContainCyrillicCharacters()
+    {
+        string repositoryRoot = FindRepositoryRoot(AppContext.BaseDirectory);
+
+        using Process process = StartGitLsFiles(repositoryRoot);
+
+        string output = process.StandardOutput.ReadToEnd();
+        string error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        TestAssert.Equal(
+            0,
+            process.ExitCode,
+            $"git ls-files failed while checking tracked file paths. stderr: {error}");
+
+        string[] pathsWithCyrillic = output
+            .Split('\0', StringSplitOptions.RemoveEmptyEntries)
+            .Where(ContainsCyrillic)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        TestAssert.Equal(
+            0,
+            pathsWithCyrillic.Length,
+            "Tracked file paths must not contain Cyrillic characters: "
+            + string.Join(", ", pathsWithCyrillic));
+    }
+
+    private static Process StartGitLsFiles(string repositoryRoot)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = repositoryRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        startInfo.ArgumentList.Add("ls-files");
+        startInfo.ArgumentList.Add("--full-name");
+        startInfo.ArgumentList.Add("-z");
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Unable to start git ls-files.");
+    }
+
+    private static string FindRepositoryRoot(string startPath)
+    {
+        var directory = new DirectoryInfo(startPath);
+
+        while (directory is not null)
+        {
+            string gitPath = Path.Combine(directory.FullName, ".git");
+            if (Directory.Exists(gitPath) || File.Exists(gitPath))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException($"Unable to find repository root from {startPath}.");
+    }
+
+    private static bool ContainsCyrillic(string value)
+    {
+        return value.Any(character => character is >= '\u0400' and <= '\u04FF');
+    }
+}

--- a/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
@@ -3291,8 +3291,8 @@ public partial class SDL
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_GPUTextureSupportsSampleCount"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    private static partial bool SDL_GPUTextureSupportsSampleCount(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleСount);
-    private delegate bool GPUTextureSupportsSampleCountNativeDelegate(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleСount);
+    private static partial bool SDL_GPUTextureSupportsSampleCount(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleCount);
+    private delegate bool GPUTextureSupportsSampleCountNativeDelegate(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleCount);
     private static GPUTextureSupportsSampleCountNativeDelegate GPUTextureSupportsSampleCountNativeFunction = SDL_GPUTextureSupportsSampleCount;
 
     /// <code>extern SDL_DECLSPEC bool SDLCALL SDL_GPUTextureSupportsSampleCount(SDL_GPUDevice *device, SDL_GPUTextureFormat format, SDL_GPUSampleCount sample_count);</code>
@@ -3301,12 +3301,12 @@ public partial class SDL
     /// </summary>
     /// <param name="device">a GPU context.</param>
     /// <param name="format">the texture format to check.</param>
-    /// <param name="sampleСount">the sample count to check.</param>
+    /// <param name="sampleCount">the sample count to check.</param>
     /// <returns>whether the sample count is supported for this texture format.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    public static bool GPUTextureSupportsSampleCount(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleСount)
+    public static bool GPUTextureSupportsSampleCount(IntPtr device, GPUTextureFormat format, GPUSampleCount sampleCount)
     {
-        return GPUTextureSupportsSampleCountNativeFunction(device, format, sampleСount);
+        return GPUTextureSupportsSampleCountNativeFunction(device, format, sampleCount);
     }
 
 

--- a/SDL3-CS/SDL/Video/video/GLAttr.cs
+++ b/SDL3-CS/SDL/Video/video/GLAttr.cs
@@ -157,7 +157,7 @@ public static partial class SDL
         FrameBufferSRGBCapable,
         
         /// <summary>
-        /// sets context the release behavior. See <see cref="GLСontextReleaseFlag"/>; defaults to <see cref="GLСontextReleaseFlag.Flush"/>.
+        /// sets context the release behavior. See <see cref="GLContextReleaseFlag"/>; defaults to <see cref="GLContextReleaseFlag.Flush"/>.
         /// </summary>
         ContextReleaseBehavior,
         

--- a/SDL3-CS/SDL/Video/video/GLContextReleaseFlag.cs
+++ b/SDL3-CS/SDL/Video/video/GLContextReleaseFlag.cs
@@ -31,7 +31,7 @@ public static partial class SDL
     /// </summary>
     /// <since>This datatype is available since SDL 3.2.0</since>
     [Flags]
-    public enum GLСontextReleaseFlag
+    public enum GLContextReleaseFlag
     {
         None   = 0x0000,
         Flush  = 0x0001

--- a/SDL3-CS/SDL/WCharStringMarshaller.cs
+++ b/SDL3-CS/SDL/WCharStringMarshaller.cs
@@ -149,7 +149,7 @@ public static class WCharStringMarshaller
     }
 
 
-    // Выбираем реализацию в зависимости от платформы
+    // Choose the runtime-specific implementation.
     /// <summary>
     /// Converts a managed string to an unmanaged null-terminated wide-character buffer for the current runtime.
     /// </summary>


### PR DESCRIPTION
## Summary

Syncs the post-3.4.10 release branch fixes into main before starting the SDL 3.4.12 preparation work.

Included commits:

- 69eda479 docs: add readme star prompt
- 44a24419 fix: remove cyrillic character from GLContextReleaseFlag
- 6d106a8c fix: block cyrillic identifiers in wrapper source

## Notes

- No new commits were created for this PR.
- Release workflows were not run manually.
- This PR is the required PR-only path for mainline parity before continuing SDL 3.4.12 work.