### PR TITLE
Update NuGet badge for SDL3-CS 3.4.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.nuget.org/packages/SDL3-CS">
-    <img alt="NuGet SDL3-CS version" src="https://img.shields.io/nuget/v/SDL3-CS?style=flat-square">
+  <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.1">
+    <img alt="NuGet SDL3-CS 3.4.12.1" src="https://img.shields.io/badge/nuget-v3.4.12.1-004880?style=flat-square">
   </a>
   <a href="https://www.nuget.org/packages/SDL3-CS">
     <img alt="NuGet SDL3-CS downloads" src="https://img.shields.io/nuget/dt/SDL3-CS?style=flat-square">


### PR DESCRIPTION
## Summary

- point the root README NuGet badge and link at the published `SDL3-CS 3.4.12.1` package
- use a release-pinned badge so NuGet indexing and Shields cache delays cannot show the previous `3.4.12` version

## Verification

- `git diff --check`
- badge endpoint returns HTTP 200 with `image/svg+xml`

The `SDL3 target 3.4.12` badge remains unchanged because it describes the upstream native SDL version, not the SDL3-CS package revision.