### PR TITLE
Fix SetRenderViewport ABI and prepare managed release 3.4.12.2

### DIFF
--- a/.github/release-tools/Invoke-ManagedReleaseWorkflow.ps1
+++ b/.github/release-tools/Invoke-ManagedReleaseWorkflow.ps1
@@ -1,0 +1,163 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [int] $PackageRevision = 2,
+    [int] $NativePackageRevision = 1,
+    [string] $BaseReleaseRef = 'v3.4.12.1',
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $WorkflowPath = (Join-Path (Join-Path $PSScriptRoot '..') 'workflows\release-managed-package.yml'),
+    [string] $Branch,
+    [string] $Repository,
+    [switch] $PublishGitHub,
+    [switch] $PublishNuGet,
+    [switch] $SkipLocalValidation,
+    [switch] $SkipRemoteStateCheck,
+    [switch] $Run
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+$managedPackages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision | Where-Object { $_.Kind -eq 'managed' })
+if ($managedPackages.Count -ne 1 -or $managedPackages[0].Id -ne 'SDL3-CS') {
+    throw "Managed workflow dispatch requires exactly one SDL3-CS package, got $($managedPackages.Count)."
+}
+$releaseNotesRelativePath = ".github/release-tools/release-notes/v$($managedPackages[0].PackageVersion).md"
+
+function Invoke-ManagedReleaseGit {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [switch] $AllowFailure
+    )
+
+    $repoRoot = Get-ReleaseRepoRoot
+    $output = & git -C $repoRoot @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0 -and -not $AllowFailure) {
+        throw "git $($Arguments -join ' ') failed with exit code $LASTEXITCODE`: $($output | Out-String)"
+    }
+
+    return (($output | Out-String).Trim())
+}
+
+if (-not $SkipLocalValidation) {
+    & (Join-Path $PSScriptRoot 'Test-ManagedReleaseWorkflow.ps1') -WorkflowPath $WorkflowPath
+    & (Join-Path $PSScriptRoot 'Test-ManagedReleaseScope.Tests.ps1') -ManifestPath $ManifestPath
+    & (Join-Path $PSScriptRoot 'Test-ManagedReleaseScope.ps1') `
+        -PackageRevision $PackageRevision `
+        -NativePackageRevision $NativePackageRevision `
+        -BaseRef $BaseReleaseRef `
+        -ManifestPath $ManifestPath `
+        -CheckNuGet
+    & (Join-Path $PSScriptRoot 'Test-PackageVersioning.ps1') -PackageRevision $PackageRevision -ManifestPath $ManifestPath
+    & (Join-Path $PSScriptRoot 'Test-ReleasePublishPlan.ps1')
+    & (Join-Path $PSScriptRoot 'Test-ReleaseNotes.ps1') -ReleaseNotesPath $releaseNotesRelativePath
+}
+
+$workflowFile = Resolve-ReleasePath $WorkflowPath
+if (-not (Test-Path -LiteralPath $workflowFile -PathType Leaf)) {
+    throw "Managed release workflow was not found: $workflowFile"
+}
+$workflowRelativePath = Get-ReleaseRepoRelativePath -Path $workflowFile
+$workflowId = Split-Path -Leaf $workflowRelativePath
+$currentBranch = Invoke-ManagedReleaseGit -Arguments @('rev-parse', '--abbrev-ref', 'HEAD')
+if (-not $Branch) {
+    $Branch = $currentBranch
+}
+
+$remoteProblems = New-Object System.Collections.Generic.List[string]
+if (-not $SkipRemoteStateCheck) {
+    if ($Branch -ne $currentBranch) {
+        $remoteProblems.Add("Requested branch '$Branch' is not the checked-out branch '$currentBranch'.")
+    }
+
+    $requiredPaths = @(
+        $workflowRelativePath,
+        'SDL3-CS',
+        'SDL3-CS.Tests',
+        'README.md',
+        'README-nuget.md',
+        '.github/release-tools/Invoke-ManagedReleaseWorkflow.ps1',
+        '.github/release-tools/Pack-NuGet.ps1',
+        '.github/release-tools/Publish-Release.ps1',
+        '.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1',
+        '.github/release-tools/Test-ManagedReleaseScope.ps1',
+        '.github/release-tools/Test-ManagedReleaseScope.Tests.ps1',
+        '.github/release-tools/Test-ManagedReleaseWorkflow.ps1',
+        '.github/release-tools/Test-NuGetPackageContents.ps1',
+        '.github/release-tools/Test-ReleasePublishState.ps1',
+        $releaseNotesRelativePath
+    ) | Sort-Object -Unique
+
+    foreach ($path in $requiredPaths) {
+        $tracked = Invoke-ManagedReleaseGit -Arguments @('ls-files', '--', $path) -AllowFailure
+        if (-not $tracked) {
+            $remoteProblems.Add("Required managed release path is not tracked: $path")
+        }
+    }
+
+    $status = Invoke-ManagedReleaseGit -Arguments (@('status', '--porcelain', '--') + $requiredPaths) -AllowFailure
+    if ($status) {
+        $remoteProblems.Add("Required managed release paths have uncommitted changes:`n$status")
+    }
+
+    $upstream = Invoke-ManagedReleaseGit -Arguments @('rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}') -AllowFailure
+    if (-not $upstream) {
+        $remoteProblems.Add("Current branch '$currentBranch' has no upstream branch.")
+    }
+    else {
+        $aheadBehind = Invoke-ManagedReleaseGit -Arguments @('rev-list', '--left-right', '--count', "$upstream...HEAD") -AllowFailure
+        $parts = @($aheadBehind -split '\s+')
+        if ($parts.Count -ge 2 -and [int] $parts[1] -gt 0) {
+            $remoteProblems.Add("Current branch '$currentBranch' is $($parts[1]) commit(s) ahead of '$upstream'; push before dispatch.")
+        }
+    }
+}
+
+$args = @(
+    'workflow', 'run', $workflowId,
+    '--ref', $Branch,
+    '-f', "package_revision=$PackageRevision",
+    '-f', "native_package_revision=$NativePackageRevision",
+    '-f', "base_release_ref=$BaseReleaseRef",
+    '-f', "publish_github=$($PublishGitHub.IsPresent.ToString().ToLowerInvariant())",
+    '-f', "publish_nuget=$($PublishNuGet.IsPresent.ToString().ToLowerInvariant())"
+)
+if ($Repository) {
+    $args += @('--repo', $Repository)
+}
+
+[pscustomobject]@{
+    Workflow = $workflowId
+    Branch = $Branch
+    PackageRevision = $PackageRevision
+    NativePackageRevision = $NativePackageRevision
+    BaseReleaseRef = $BaseReleaseRef
+    PublishGitHub = $PublishGitHub.IsPresent
+    PublishNuGet = $PublishNuGet.IsPresent
+    Run = $Run.IsPresent
+} | Format-List
+
+if ($remoteProblems.Count -gt 0) {
+    $remoteProblems | ForEach-Object { Write-Warning $_ }
+    if ($Run) {
+        throw "Managed release dispatch preflight failed with $($remoteProblems.Count) remote state problem(s)."
+    }
+}
+
+if (-not $Run) {
+    Write-Host "[dry-run] gh $($args -join ' ')"
+    Write-Host 'Pass -Run only after commit, push and mainline parity are complete.'
+    return
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI was not found. Install 'gh' before dispatching the workflow."
+}
+
+& gh auth status
+if ($LASTEXITCODE -ne 0) {
+    throw "GitHub CLI is not authenticated. Run 'gh auth login' before dispatching the workflow."
+}
+
+Invoke-ReleaseCommand -FilePath 'gh' -Arguments $args
+Write-Host "Managed release workflow dispatch requested for $Branch."

--- a/.github/release-tools/Pack-NuGet.ps1
+++ b/.github/release-tools/Pack-NuGet.ps1
@@ -10,6 +10,7 @@ param(
     [switch] $SkipNativeArtifactValidation,
     [switch] $SkipNativeBuildReceiptValidation,
     [switch] $SkipNuGetPackageContentValidation,
+    [switch] $ManagedOnly,
     [switch] $DryRun
 )
 
@@ -27,7 +28,12 @@ if (-not $OutputDir) {
 }
 $OutputDir = Resolve-ReleasePath $OutputDir
 
-Write-Host "Native RID validation scope: $($Rids -join ', ')"
+if ($ManagedOnly) {
+    Write-Host 'Package scope: managed-only'
+}
+else {
+    Write-Host "Native RID validation scope: $($Rids -join ', ')"
+}
 
 & (Join-Path $PSScriptRoot 'Test-PackageVersioning.ps1') -PackageRevision $PackageRevision -ManifestPath $ManifestPath
 
@@ -35,15 +41,21 @@ if (-not $DryRun) {
     New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 }
 
-if (-not $DryRun -and -not $SkipNativeArtifactValidation) {
+if (-not $ManagedOnly -and -not $DryRun -and -not $SkipNativeArtifactValidation) {
     & (Join-Path $PSScriptRoot 'Test-NativePackageArtifacts.ps1') -ManifestPath $ManifestPath -Rids $Rids
 }
 
-if (-not $DryRun -and -not $SkipNativeBuildReceiptValidation) {
+if (-not $ManagedOnly -and -not $DryRun -and -not $SkipNativeBuildReceiptValidation) {
     & (Join-Path $PSScriptRoot 'Test-NativeBuildReceipts.ps1') -ManifestPath $ManifestPath -Rids $Rids
 }
 
 $packages = Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision
+if ($ManagedOnly) {
+    $packages = @($packages | Where-Object { $_.Kind -eq 'managed' })
+}
+if (@($packages).Count -eq 0) {
+    throw 'Selected NuGet package scope is empty.'
+}
 foreach ($package in $packages) {
     $projectPath = Resolve-ReleasePath $package.Project
     $expectedPackagePath = Get-ReleaseNuGetPackagePath -PackageDir $OutputDir -Package $package
@@ -93,5 +105,6 @@ if (-not $DryRun -and -not $SkipNuGetPackageContentValidation) {
         -PackageRevision $PackageRevision `
         -ManifestPath $ManifestPath `
         -PackageDir $OutputDir `
-        -Rids $Rids
+        -Rids $Rids `
+        -ManagedOnly:$ManagedOnly
 }

--- a/.github/release-tools/Publish-Release.ps1
+++ b/.github/release-tools/Publish-Release.ps1
@@ -2,6 +2,8 @@
 [CmdletBinding()]
 param(
     [int] $PackageRevision = -1,
+    [int] $NativePackageRevision = -1,
+    [string] $BaseReleaseRef,
     [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
     [string] $ReleaseNotesDir = (Join-Path $PSScriptRoot 'release-notes'),
     [string] $PackageDir,
@@ -16,6 +18,7 @@ param(
     [switch] $AllowExistingNuGetPackages,
     [switch] $KeepGitHubReleaseDraft,
     [switch] $RequireUpstreamCurrent,
+    [switch] $ManagedOnly,
     [switch] $DryRun
 )
 
@@ -25,6 +28,12 @@ $manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
 if ($PackageRevision -lt 0) {
     $PackageRevision = [int] $manifest.versioning.packageRevisionDefault
 }
+if ($ManagedOnly -and [string]::IsNullOrWhiteSpace($BaseReleaseRef)) {
+    throw 'BaseReleaseRef is required for managed-only publication.'
+}
+if ($ManagedOnly -and $NativePackageRevision -lt 0) {
+    throw 'NativePackageRevision is required for managed-only publication.'
+}
 if (-not $PackageDir) {
     $PackageDir = Join-Path (Resolve-ReleasePath $manifest.artifactsRoot) 'nuget'
 }
@@ -33,6 +42,9 @@ $PackageDir = Resolve-ReleasePath $PackageDir
 & (Join-Path $PSScriptRoot 'Test-PackageVersioning.ps1') -PackageRevision $PackageRevision -ManifestPath $ManifestPath
 
 $packages = Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision
+if ($ManagedOnly) {
+    $packages = @($packages | Where-Object { $_.Kind -eq 'managed' })
+}
 $wrapper = @($packages | Where-Object { $_.Id -eq 'SDL3-CS' })[0]
 $tag = "v$($wrapper.PackageVersion)"
 $releaseNotesDirPath = Resolve-ReleasePath $ReleaseNotesDir
@@ -58,7 +70,8 @@ elseif (-not $DryRun -or $ValidateReadinessInDryRun) {
     & (Join-Path $PSScriptRoot 'Test-NuGetPackageContents.ps1') `
         -PackageRevision $PackageRevision `
         -ManifestPath $ManifestPath `
-        -PackageDir $PackageDir
+        -PackageDir $PackageDir `
+        -ManagedOnly:$ManagedOnly
 }
 else {
     Write-Host "[dry-run] NuGet package content validation skipped. Pass -ValidateReadinessInDryRun to validate package contents during dry-run."
@@ -82,22 +95,34 @@ if (-not $SkipPublishStateValidation -and $missingPackagePaths.Count -eq 0) {
         -NuGetPush:$NuGetPush `
         -SkipExternalStateCheck:$skipExternalStateCheck `
         -AllowExistingGitHubRelease:$AllowExistingGitHubRelease `
-        -AllowExistingNuGetPackages:$AllowExistingNuGetPackages
+        -AllowExistingNuGetPackages:$AllowExistingNuGetPackages `
+        -ManagedOnly:$ManagedOnly
 }
 elseif ($SkipPublishStateValidation) {
     Write-Host "Release publish state validation skipped."
 }
 
 if (-not $SkipReadinessValidation -and (-not $DryRun -or $ValidateReadinessInDryRun)) {
-    & (Join-Path $PSScriptRoot 'Test-ReleaseReadiness.ps1') `
-        -PackageRevision $PackageRevision `
-        -ManifestPath $ManifestPath `
-        -FetchForks `
-        -RequireForksUpToDate `
-        -CheckUpstream `
-        -RequireUpstreamCurrent:$RequireUpstreamCurrent `
-        -SkipToolchainValidation `
-        -FailOnError
+    if ($ManagedOnly) {
+        & (Join-Path $PSScriptRoot 'Test-ManagedReleaseScope.ps1') `
+            -PackageRevision $PackageRevision `
+            -NativePackageRevision $NativePackageRevision `
+            -BaseRef $BaseReleaseRef `
+            -ManifestPath $ManifestPath `
+            -CheckNuGet
+        & (Join-Path $PSScriptRoot 'Test-PublicWrapperXmlDocs.ps1') -SourceRoot (Resolve-ReleasePath 'SDL3-CS')
+    }
+    else {
+        & (Join-Path $PSScriptRoot 'Test-ReleaseReadiness.ps1') `
+            -PackageRevision $PackageRevision `
+            -ManifestPath $ManifestPath `
+            -FetchForks `
+            -RequireForksUpToDate `
+            -CheckUpstream `
+            -RequireUpstreamCurrent:$RequireUpstreamCurrent `
+            -SkipToolchainValidation `
+            -FailOnError
+    }
 }
 elseif ($DryRun -and -not $ValidateReadinessInDryRun) {
     Write-Host "[dry-run] readiness validation skipped. Pass -ValidateReadinessInDryRun to run strict publish readiness during dry-run."

--- a/.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1
+++ b/.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1
@@ -1,0 +1,136 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [int] $NativePackageRevision = 1,
+    [string] $Rid = 'win-x64',
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $Destination = 'SDL3-CS.Tests/bin/Release/net8.0',
+    [string] $PackageCacheDir = 'artifacts/release/managed-test-runtime',
+    [switch] $DryRun
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+function Get-ArchiveEntrySha256 {
+    param([Parameter(Mandatory)][object] $Entry)
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $stream = $Entry.Open()
+        try {
+            return [System.Convert]::ToHexString($sha256.ComputeHash($stream))
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+Get-ReleaseRid -Manifest $manifest -Rid $Rid | Out-Null
+$packages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $NativePackageRevision |
+    Where-Object { $_.Kind -eq 'native' -and @($_.Rids) -contains $Rid } |
+    Sort-Object Id)
+
+$expectedComponentCount = @($manifest.components).Count
+if ($packages.Count -ne $expectedComponentCount) {
+    throw "Expected $expectedComponentCount native package(s) for $Rid, got $($packages.Count)."
+}
+
+$destinationPath = Resolve-ReleasePath $Destination
+$cachePath = Resolve-ReleasePath $PackageCacheDir
+$rows = @($packages | ForEach-Object {
+    $lowerId = $_.Id.ToLowerInvariant()
+    $lowerVersion = (Get-ReleaseNormalizedNuGetVersion -PackageVersion $_.PackageVersion).ToLowerInvariant()
+    [pscustomobject]@{
+        Package = $_
+        Uri = "https://api.nuget.org/v3-flatcontainer/$lowerId/$lowerVersion/$lowerId.$lowerVersion.nupkg"
+        PackagePath = Join-Path $cachePath (Get-ReleaseNuGetPackageFileName -Package $_)
+    }
+})
+
+$rows | ForEach-Object {
+    [pscustomobject]@{
+        Package = $_.Package.Id
+        Version = $_.Package.PackageVersion
+        Rid = $Rid
+        Uri = $_.Uri
+    }
+} | Format-Table -AutoSize
+
+if ($DryRun) {
+    Write-Host "[dry-run] Would restore $($packages.Count) published native package(s) into $destinationPath."
+    return
+}
+
+New-Item -ItemType Directory -Force -Path $destinationPath | Out-Null
+New-Item -ItemType Directory -Force -Path $cachePath | Out-Null
+$destinationRoot = [System.IO.Path]::GetFullPath($destinationPath).TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
+$writtenEntries = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$restoredCount = 0
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+foreach ($row in $rows) {
+    Invoke-WebRequest -Uri $row.Uri -OutFile $row.PackagePath
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($row.PackagePath)
+    try {
+        $runtimePrefix = "runtimes/$Rid/native/"
+        $runtimeEntries = @($archive.Entries | Where-Object {
+            $_.FullName.StartsWith($runtimePrefix, [System.StringComparison]::Ordinal) -and
+            -not $_.FullName.EndsWith('/', [System.StringComparison]::Ordinal)
+        })
+        if ($runtimeEntries.Count -eq 0) {
+            throw "$($row.Package.Id) $($row.Package.PackageVersion) contains no $runtimePrefix entries."
+        }
+
+        foreach ($entry in $runtimeEntries) {
+            $relativePath = $entry.FullName.Substring($runtimePrefix.Length).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+            if ([System.IO.Path]::IsPathRooted($relativePath) -or @($relativePath -split '[\\/]') -contains '..') {
+                throw "Unsafe runtime package entry: $($entry.FullName)"
+            }
+
+            $targetPath = [System.IO.Path]::GetFullPath((Join-Path $destinationPath $relativePath))
+            if (-not $targetPath.StartsWith($destinationRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                throw "Runtime package entry escapes destination: $($entry.FullName)"
+            }
+
+            $entryHash = Get-ArchiveEntrySha256 -Entry $entry
+            if ($writtenEntries.ContainsKey($targetPath)) {
+                if ($writtenEntries[$targetPath] -ne $entryHash) {
+                    throw "Published native packages contain conflicting runtime entry: $relativePath"
+                }
+                continue
+            }
+
+            New-Item -ItemType Directory -Force -Path (Split-Path -Parent $targetPath) | Out-Null
+            $source = $entry.Open()
+            try {
+                $target = [System.IO.File]::Open($targetPath, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+                try {
+                    $source.CopyTo($target)
+                }
+                finally {
+                    $target.Dispose()
+                }
+            }
+            finally {
+                $source.Dispose()
+            }
+
+            $writtenEntries[$targetPath] = $entryHash
+            $restoredCount++
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+if ($Rid.StartsWith('win-', [System.StringComparison]::Ordinal) -and -not (Test-Path -LiteralPath (Join-Path $destinationPath 'SDL3.dll') -PathType Leaf)) {
+    throw "Restored Windows test runtime is missing SDL3.dll in $destinationPath."
+}
+
+Write-Host "Restored $restoredCount native runtime file(s) from $($packages.Count) published package(s) for $Rid."

--- a/.github/release-tools/Test-ManagedReleaseScope.Tests.ps1
+++ b/.github/release-tools/Test-ManagedReleaseScope.Tests.ps1
@@ -1,0 +1,108 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json')
+)
+
+$scopeScript = Join-Path $PSScriptRoot 'Test-ManagedReleaseScope.ps1'
+if (-not (Test-Path -LiteralPath $scopeScript -PathType Leaf)) {
+    throw "Managed release scope helper was not found: $scopeScript"
+}
+
+function Invoke-TestGit {
+    param(
+        [Parameter(Mandatory)][string] $RepositoryRoot,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $output = & git -C $RepositoryRoot @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $($output | Out-String)"
+    }
+}
+
+function Assert-ScopeFails {
+    param(
+        [Parameter(Mandatory)][string] $Description,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $failed = $false
+    try {
+        & $Action
+    }
+    catch {
+        $failed = $true
+    }
+
+    if (-not $failed) {
+        throw "Expected managed release scope validation to fail: $Description"
+    }
+}
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = Join-Path $tempBase "sdl3-cs-managed-release-scope-$([guid]::NewGuid().ToString('N'))"
+$tempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe temporary repository path: $tempRoot"
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $tempRoot 'SDL3-CS') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $tempRoot 'SDL3-CS.NativePackages/Test') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $tempRoot '.github/release-tools') | Out-Null
+
+try {
+    Set-Content -LiteralPath (Join-Path $tempRoot 'SDL3-CS/Wrapper.cs') -Value 'managed-v1' -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $tempRoot 'SDL3-CS.NativePackages/Test/payload.txt') -Value 'native-v1' -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $tempRoot '.github/release-tools/release-manifest.json') -Value '{"native":"v1"}' -Encoding UTF8
+
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('init', '--initial-branch=main')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('config', 'user.email', 'managed-release-tests@example.invalid')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('config', 'user.name', 'Managed Release Tests')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('add', '.')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('commit', '-m', 'base')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('tag', 'base-release')
+
+    Set-Content -LiteralPath (Join-Path $tempRoot 'SDL3-CS/Wrapper.cs') -Value 'managed-v2' -Encoding UTF8
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('add', 'SDL3-CS/Wrapper.cs')
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('commit', '-m', 'managed change')
+
+    & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'base-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+
+    Assert-ScopeFails -Description 'missing base ref' -Action {
+        & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'missing-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+    }
+
+    Set-Content -LiteralPath (Join-Path $tempRoot '.github/release-tools/release-manifest.json') -Value '{"native":"dirty"}' -Encoding UTF8
+    Assert-ScopeFails -Description 'unstaged native release manifest change' -Action {
+        & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'base-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+    }
+    Set-Content -LiteralPath (Join-Path $tempRoot '.github/release-tools/release-manifest.json') -Value '{"native":"v1"}' -Encoding UTF8
+
+    Set-Content -LiteralPath (Join-Path $tempRoot 'SDL3-CS.NativePackages/Test/payload.txt') -Value 'native-dirty' -Encoding UTF8
+    Assert-ScopeFails -Description 'unstaged native package change' -Action {
+        & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'base-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+    }
+
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('add', 'SDL3-CS.NativePackages/Test/payload.txt')
+    Assert-ScopeFails -Description 'staged native package change' -Action {
+        & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'base-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+    }
+
+    Invoke-TestGit -RepositoryRoot $tempRoot -Arguments @('commit', '-m', 'native change')
+    Assert-ScopeFails -Description 'committed native package change' -Action {
+        & $scopeScript -RepositoryRoot $tempRoot -BaseRef 'base-release' -ManifestPath $ManifestPath -PackageRevision 2 -NativePackageRevision 1
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-managed-release-scope-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary repository path: $resolvedTempRoot"
+        }
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Managed release scope tests passed.'

--- a/.github/release-tools/Test-ManagedReleaseScope.ps1
+++ b/.github/release-tools/Test-ManagedReleaseScope.ps1
@@ -1,0 +1,158 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [int] $PackageRevision = -1,
+    [int] $NativePackageRevision = -1,
+    [Parameter(Mandatory)]
+    [string] $BaseRef,
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $RepositoryRoot,
+    [switch] $CheckNuGet
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+function Invoke-ScopeGit {
+    param(
+        [Parameter(Mandatory)][string[]] $Arguments,
+        [switch] $AllowFailure
+    )
+
+    $output = & git -C $script:repositoryRoot @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -and -not $AllowFailure) {
+        throw "git $($Arguments -join ' ') failed with exit code $exitCode`: $($output | Out-String)"
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output = (($output | Out-String).Trim())
+    }
+}
+
+function Test-NativeSensitivePath {
+    param([Parameter(Mandatory)][string] $Path)
+
+    $normalized = $Path.Replace('\', '/')
+    while ($normalized.StartsWith('./', [System.StringComparison]::Ordinal)) {
+        $normalized = $normalized.Substring(2)
+    }
+    $normalized = $normalized.TrimStart('/')
+    return $normalized.StartsWith('SDL3-CS.NativePackages/', [System.StringComparison]::Ordinal) -or
+        $normalized.Equals('SDL3-CS.NativePackages', [System.StringComparison]::Ordinal) -or
+        $normalized.StartsWith('native-forks/', [System.StringComparison]::Ordinal) -or
+        $normalized.Equals('native-forks', [System.StringComparison]::Ordinal) -or
+        $normalized.Equals('.github/release-tools/release-manifest.json', [System.StringComparison]::Ordinal)
+}
+
+function Add-ChangedPaths {
+    param(
+        [Parameter(Mandatory)][string] $Source,
+        [AllowEmptyString()][string] $Text
+    )
+
+    foreach ($line in @($Text -split "`r?`n")) {
+        $path = $line.Trim()
+        if (-not $path) {
+            continue
+        }
+
+        $key = "$Source`0$path"
+        if ($script:changeKeys.Add($key)) {
+            $script:changes.Add([pscustomobject]@{ Source = $Source; Path = $path })
+        }
+    }
+}
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+if ($PackageRevision -lt 0) {
+    $PackageRevision = [int] $manifest.versioning.packageRevisionDefault
+}
+if ($NativePackageRevision -lt 0) {
+    throw 'NativePackageRevision must identify the already published native package matrix.'
+}
+if ($PackageRevision -lt 0) {
+    throw 'PackageRevision must be zero or greater.'
+}
+
+if (-not $RepositoryRoot) {
+    $RepositoryRoot = Get-ReleaseRepoRoot
+}
+$script:repositoryRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+if (-not (Test-Path -LiteralPath $script:repositoryRoot -PathType Container)) {
+    throw "Repository root was not found: $script:repositoryRoot"
+}
+
+$insideWorkTree = Invoke-ScopeGit -Arguments @('rev-parse', '--is-inside-work-tree') -AllowFailure
+if ($insideWorkTree.ExitCode -ne 0 -or $insideWorkTree.Output -ne 'true') {
+    throw "Managed release scope requires a Git worktree: $script:repositoryRoot"
+}
+
+$baseState = Invoke-ScopeGit -Arguments @('rev-parse', '--verify', "$BaseRef^{commit}") -AllowFailure
+if ($baseState.ExitCode -ne 0 -or -not $baseState.Output) {
+    throw "Managed release base ref does not exist: $BaseRef"
+}
+$baseCommit = $baseState.Output
+$headCommit = (Invoke-ScopeGit -Arguments @('rev-parse', 'HEAD')).Output
+$ancestorState = Invoke-ScopeGit -Arguments @('merge-base', '--is-ancestor', $baseCommit, $headCommit) -AllowFailure
+if ($ancestorState.ExitCode -ne 0) {
+    throw "Managed release base ref '$BaseRef' ($baseCommit) is not an ancestor of HEAD ($headCommit)."
+}
+
+$script:changes = New-Object System.Collections.Generic.List[object]
+$script:changeKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+Add-ChangedPaths -Source 'committed' -Text (Invoke-ScopeGit -Arguments @('diff', '--name-only', '--diff-filter=ACDMRTUXB', "$baseCommit..$headCommit", '--')).Output
+Add-ChangedPaths -Source 'staged' -Text (Invoke-ScopeGit -Arguments @('diff', '--cached', '--name-only', '--diff-filter=ACDMRTUXB', '--')).Output
+Add-ChangedPaths -Source 'unstaged' -Text (Invoke-ScopeGit -Arguments @('diff', '--name-only', '--diff-filter=ACDMRTUXB', '--')).Output
+Add-ChangedPaths -Source 'untracked' -Text (Invoke-ScopeGit -Arguments @('ls-files', '--others', '--exclude-standard')).Output
+
+$nativeChanges = @($script:changes | Where-Object { Test-NativeSensitivePath -Path $_.Path })
+if ($nativeChanges.Count -gt 0) {
+    $nativeChanges | Sort-Object Source, Path | Format-Table -AutoSize
+    throw "Managed-only release is blocked by $($nativeChanges.Count) native-sensitive changed path(s). Use the full native release workflow."
+}
+
+$targetPackages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision | Where-Object { $_.Kind -eq 'managed' })
+if ($targetPackages.Count -ne 1 -or $targetPackages[0].Id -ne 'SDL3-CS') {
+    throw "Managed-only release requires exactly one managed SDL3-CS package, got $($targetPackages.Count)."
+}
+
+$nativePackages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $NativePackageRevision | Where-Object { $_.Kind -eq 'native' })
+if ($nativePackages.Count -eq 0) {
+    throw "Native package revision $NativePackageRevision produced no reusable native packages."
+}
+
+$rows = New-Object System.Collections.Generic.List[object]
+foreach ($package in $nativePackages) {
+    $status = 'not-checked'
+    $detail = 'NuGet check disabled'
+    if ($CheckNuGet) {
+        $lowerId = $package.Id.ToLowerInvariant()
+        $lowerVersion = (Get-ReleaseNormalizedNuGetVersion -PackageVersion $package.PackageVersion).ToLowerInvariant()
+        $uri = "https://api.nuget.org/v3-flatcontainer/$lowerId/$lowerVersion/$lowerId.$lowerVersion.nupkg"
+        try {
+            $response = Invoke-WebRequest -Uri $uri -Method Head -TimeoutSec 30 -SkipHttpErrorCheck
+            $statusCode = [int] $response.StatusCode
+            $status = if ($statusCode -eq 200) { 'published' } else { 'missing' }
+            $detail = "HTTP $statusCode"
+        }
+        catch {
+            $status = 'error'
+            $detail = $_.Exception.Message
+        }
+
+        if ($status -ne 'published') {
+            throw "Reusable native package is not available on NuGet: $($package.Id) $($package.PackageVersion) ($detail)."
+        }
+    }
+
+    $rows.Add([pscustomobject]@{
+        Package = $package.Id
+        Version = $package.PackageVersion
+        Status = $status
+        Detail = $detail
+    })
+}
+
+$rows | Sort-Object Package | Format-Table -AutoSize
+Write-Host "Managed release scope is valid: $($targetPackages[0].Id) $($targetPackages[0].PackageVersion); reusable native packages $($nativePackages.Count); native-sensitive changes 0."

--- a/.github/release-tools/Test-ManagedReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ManagedReleaseWorkflow.ps1
@@ -1,0 +1,133 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $WorkflowPath = '.github/workflows/release-managed-package.yml'
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+function Add-ManagedWorkflowError {
+    param([Parameter(Mandatory)][string] $Message)
+    $script:errors.Add($Message)
+}
+
+function Assert-TextContains {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Text,
+        [Parameter(Mandatory)][string] $Expected,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if (-not $Text.Contains($Expected, [System.StringComparison]::Ordinal)) {
+        Add-ManagedWorkflowError "$Description is missing expected text: $Expected"
+    }
+}
+
+function Assert-TextExcludes {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Text,
+        [Parameter(Mandatory)][string] $Forbidden,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if ($Text.Contains($Forbidden, [System.StringComparison]::Ordinal)) {
+        Add-ManagedWorkflowError "$Description contains forbidden text: $Forbidden"
+    }
+}
+
+$errors = New-Object System.Collections.Generic.List[string]
+$workflowFile = Resolve-ReleasePath $WorkflowPath
+$workflowText = ''
+if (-not (Test-Path -LiteralPath $workflowFile -PathType Leaf)) {
+    Add-ManagedWorkflowError "Managed release workflow was not found: $workflowFile"
+}
+else {
+    $workflowText = Get-Content -LiteralPath $workflowFile -Raw -Encoding UTF8
+}
+
+foreach ($expected in @(
+    'workflow_dispatch:',
+    'package_revision:',
+    'native_package_revision:',
+    'base_release_ref:',
+    'publish_github:',
+    'publish_nuget:',
+    'fetch-depth: 0',
+    './.github/release-tools/Test-ManagedReleaseScope.ps1',
+    '-CheckNuGet',
+    './.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1',
+    'dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release',
+    'dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release',
+    'dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore',
+    './.github/release-tools/Test-PublicWrapperXmlDocs.ps1',
+    './.github/release-tools/Pack-NuGet.ps1',
+    '-ManagedOnly',
+    'name: managed-nuget-package',
+    'path: artifacts/release/nuget/SDL3-CS.*.nupkg',
+    'uses: NuGet/login@v1',
+    'environment: production',
+    "NATIVE_PACKAGE_REVISION: `${{ inputs.native_package_revision }}",
+    "BASE_RELEASE_REF: `${{ inputs.base_release_ref }}",
+    'NativePackageRevision = [int]$env:NATIVE_PACKAGE_REVISION',
+    'BaseReleaseRef = $env:BASE_RELEASE_REF',
+    'ManagedOnly = $true',
+    './.github/release-tools/Publish-Release.ps1 @params'
+)) {
+    Assert-TextContains -Text $workflowText -Expected $expected -Description 'managed release workflow'
+}
+
+foreach ($publishInput in @('publish_github', 'publish_nuget')) {
+    if ($workflowText -notmatch "(?ms)^\s{6}$publishInput\s*:\s*\r?\n.*?^\s{8}default:\s+false\s*$") {
+        Add-ManagedWorkflowError "Workflow input '$publishInput' must default to false."
+    }
+}
+
+foreach ($forbidden in @(
+    'native_matrix',
+    'Invoke-NativeHostBuild.ps1',
+    'Initialize-NativeForks.ps1',
+    'native-bundle-',
+    'dotnet workload install android',
+    'dotnet workload install ios',
+    'dotnet workload install tvos',
+    'Test-AppleConsumerPackageBuild.ps1',
+    'Test-AndroidConsumerPackageBuild.ps1',
+    "NativePackageRevision = [int]'`${{ inputs.native_package_revision }}'",
+    "BaseReleaseRef = '`${{ inputs.base_release_ref }}'"
+)) {
+    Assert-TextExcludes -Text $workflowText -Forbidden $forbidden -Description 'managed release workflow'
+}
+
+$scriptExpectations = [ordered]@{
+    'Pack-NuGet.ps1' = @('[switch] $ManagedOnly', "`$_.Kind -eq 'managed'", '-ManagedOnly:$ManagedOnly')
+    'Test-NuGetPackageContents.ps1' = @('[switch] $ManagedOnly', 'lib/net7.0/SDL3-CS.dll', 'lib/net10.0/SDL3-CS.xml', "StartsWith('runtimes/'")
+    'Test-ReleasePublishState.ps1' = @('[switch] $ManagedOnly', "`$_.Kind -eq 'managed'")
+    'Publish-Release.ps1' = @('[switch] $ManagedOnly', '-ManagedOnly:$ManagedOnly', 'Test-ManagedReleaseScope.ps1')
+    'Test-ManagedReleaseScope.ps1' = @('SDL3-CS.NativePackages/', 'native-forks/', 'release-manifest.json', '[switch] $CheckNuGet')
+    'Restore-ManagedReleaseTestRuntime.ps1' = @('runtimes/$Rid/native/', 'Invoke-WebRequest', '[switch] $DryRun')
+    'Invoke-ManagedReleaseWorkflow.ps1' = @('release-managed-package.yml', 'base_release_ref=', 'native_package_revision=', '[switch] $Run')
+}
+
+foreach ($scriptName in $scriptExpectations.Keys) {
+    $scriptPath = Join-Path $PSScriptRoot $scriptName
+    if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+        Add-ManagedWorkflowError "Managed release helper was not found: $scriptPath"
+        continue
+    }
+
+    $scriptText = Get-Content -LiteralPath $scriptPath -Raw -Encoding UTF8
+    foreach ($expected in $scriptExpectations[$scriptName]) {
+        Assert-TextContains -Text $scriptText -Expected $expected -Description $scriptName
+    }
+}
+
+if ($workflowText.Contains('${{ secrets.NUGET_API_KEY }}', [System.StringComparison]::Ordinal)) {
+    Add-ManagedWorkflowError 'Managed workflow must use NuGet Trusted Publishing instead of a repository API key secret.'
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "Managed release workflow validation failed with $($errors.Count) error(s)."
+}
+
+Write-Host 'Managed release workflow is isolated from native builds and uses the required validation and publication gates.'

--- a/.github/release-tools/Test-NuGetPackageContents.ps1
+++ b/.github/release-tools/Test-NuGetPackageContents.ps1
@@ -5,7 +5,8 @@ param(
     [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
     [string] $PackageDir,
     [string[]] $Components,
-    [string[]] $Rids
+    [string[]] $Rids,
+    [switch] $ManagedOnly
 )
 
 . (Join-Path $PSScriptRoot 'Release.Common.ps1')
@@ -76,6 +77,42 @@ foreach ($rid in $Rids) {
 $errors = New-Object System.Collections.Generic.List[string]
 $rows = New-Object System.Collections.Generic.List[object]
 $packages = Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision
+if ($ManagedOnly) {
+    $packages = @($packages | Where-Object { $_.Kind -eq 'managed' })
+}
+
+function Get-ZipEntryText {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $EntryName
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $entry = $zip.GetEntry($EntryName)
+        if (-not $entry) {
+            return $null
+        }
+
+        $stream = $entry.Open()
+        try {
+            $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true)
+            try {
+                return $reader.ReadToEnd()
+            }
+            finally {
+                $reader.Dispose()
+            }
+        }
+        finally {
+            $stream.Dispose()
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
 
 foreach ($package in $packages) {
     $component = $null
@@ -117,6 +154,85 @@ foreach ($package in $packages) {
     })
 
     if ($package.Kind -ne 'native') {
+        $managedExpectedEntries = @(
+            'SDL3-CS.nuspec',
+            'CODE_OF_CONDUCT.md',
+            'LICENSE',
+            'README-nuget.md',
+            'README.md',
+            'SDL3-CS.xml',
+            'logo.png',
+            'lib/net7.0/SDL3-CS.dll',
+            'lib/net7.0/SDL3-CS.xml',
+            'lib/net8.0/SDL3-CS.dll',
+            'lib/net8.0/SDL3-CS.xml',
+            'lib/net9.0/SDL3-CS.dll',
+            'lib/net9.0/SDL3-CS.xml',
+            'lib/net10.0/SDL3-CS.dll',
+            'lib/net10.0/SDL3-CS.xml'
+        )
+        foreach ($expectedEntry in $managedExpectedEntries) {
+            $status = if ($entrySet.Contains($expectedEntry)) { 'present' } else { 'missing' }
+            if ($status -eq 'missing') {
+                Add-ContentError "$($package.Id) package is missing managed entry: $expectedEntry"
+            }
+            $rows.Add([pscustomobject]@{
+                PackageId = $package.Id
+                Scope = 'managed'
+                Expected = $expectedEntry
+                Count = if ($status -eq 'present') { 1 } else { 0 }
+                Status = $status
+            })
+        }
+
+        $runtimeEntries = @($entryNames | Where-Object { $_.StartsWith('runtimes/', [System.StringComparison]::Ordinal) })
+        foreach ($runtimeEntry in $runtimeEntries) {
+            Add-ContentError "$($package.Id) managed package must not contain runtime entry: $runtimeEntry"
+        }
+        $rows.Add([pscustomobject]@{
+            PackageId = $package.Id
+            Scope = 'managed-runtime'
+            Expected = 'no runtimes/* entries'
+            Count = $runtimeEntries.Count
+            Status = if ($runtimeEntries.Count -eq 0) { 'absent' } else { 'unexpected' }
+        })
+
+        try {
+            [xml] $nuspec = Get-ZipEntryText -Path $packagePath -EntryName 'SDL3-CS.nuspec'
+            $actualId = [string] $nuspec.package.metadata.id
+            $actualVersion = [string] $nuspec.package.metadata.version
+            $expectedVersion = Get-ReleaseNormalizedNuGetVersion -PackageVersion $package.PackageVersion
+            if ($actualId -ne $package.Id) {
+                Add-ContentError "$($package.Id) nuspec id '$actualId' does not match expected '$($package.Id)'."
+            }
+            if ($actualVersion -ne $expectedVersion) {
+                Add-ContentError "$($package.Id) nuspec version '$actualVersion' does not match expected '$expectedVersion'."
+            }
+            $rows.Add([pscustomobject]@{
+                PackageId = $package.Id
+                Scope = 'managed-metadata'
+                Expected = "$($package.Id) $expectedVersion"
+                Count = 1
+                Status = if ($actualId -eq $package.Id -and $actualVersion -eq $expectedVersion) { 'valid' } else { 'mismatch' }
+            })
+        }
+        catch {
+            Add-ContentError "$($package.Id) nuspec metadata could not be validated: $($_.Exception.Message)"
+        }
+
+        $readmeText = Get-ZipEntryText -Path $packagePath -EntryName 'README-nuget.md'
+        $releaseMarker = "SDL3-CS $($package.PackageVersion)"
+        $readmeIsCurrent = $readmeText -and $readmeText.Contains($releaseMarker, [System.StringComparison]::Ordinal)
+        if (-not $readmeIsCurrent) {
+            Add-ContentError "$($package.Id) package README does not identify managed release $($package.PackageVersion)."
+        }
+        $rows.Add([pscustomobject]@{
+            PackageId = $package.Id
+            Scope = 'managed-readme'
+            Expected = $releaseMarker
+            Count = if ($readmeIsCurrent) { 1 } else { 0 }
+            Status = if ($readmeIsCurrent) { 'valid' } else { 'mismatch' }
+        })
         continue
     }
 

--- a/.github/release-tools/Test-ReleasePublishState.ps1
+++ b/.github/release-tools/Test-ReleasePublishState.ps1
@@ -9,7 +9,8 @@ param(
     [switch] $NuGetPush,
     [switch] $SkipExternalStateCheck,
     [switch] $AllowExistingGitHubRelease,
-    [switch] $AllowExistingNuGetPackages
+    [switch] $AllowExistingNuGetPackages,
+    [switch] $ManagedOnly
 )
 
 . (Join-Path $PSScriptRoot 'Release.Common.ps1')
@@ -153,6 +154,9 @@ $PackageDir = Resolve-ReleasePath $PackageDir
 $errors = New-Object System.Collections.Generic.List[string]
 $rows = New-Object System.Collections.Generic.List[object]
 $packages = Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision
+if ($ManagedOnly) {
+    $packages = @($packages | Where-Object { $_.Kind -eq 'managed' })
+}
 $wrapper = @($packages | Where-Object { $_.Id -eq 'SDL3-CS' })[0]
 if (-not $wrapper) {
     throw "Managed wrapper package SDL3-CS was not found in release manifest."

--- a/.github/release-tools/release-notes/v3.4.12.2.md
+++ b/.github/release-tools/release-notes/v3.4.12.2.md
@@ -1,0 +1,22 @@
+Stable managed SDL3-CS hotfix release for SDL 3.4.12.
+
+This release publishes only the managed `SDL3-CS` wrapper. The native packages are unchanged and remain compatible with this wrapper release.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.12.2` |
+| `SDL3-CS.<Platform>` | `3.4.12.1` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.7` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.7` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.7` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.7` |
+
+## Changes
+
+- Fixed [Issue #203](https://github.com/edwardgushchin/SDL3-CS/issues/203) by passing the typed `SDL_SetRenderViewport` rectangle as `in Rect`, matching the native `const SDL_Rect *` ABI.
+- Added cross-platform ABI metadata coverage, managed forwarding coverage, and a native software-renderer regression test.
+- Added a managed-only release workflow so wrapper hotfixes can be validated and published without rebuilding or republishing unchanged native packages.
+
+Applications should update `SDL3-CS` to `3.4.12.2` and keep their existing platform-native package versions shown above.

--- a/.github/workflows/release-managed-package.yml
+++ b/.github/workflows/release-managed-package.yml
@@ -1,0 +1,183 @@
+name: Release managed package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_revision:
+        description: Managed SDL3-CS package revision.
+        required: true
+        default: "2"
+      native_package_revision:
+        description: Already published native package revision used by tests and consumers.
+        required: true
+        default: "1"
+      base_release_ref:
+        description: Previous release ref used to prove that native inputs did not change.
+        required: true
+        default: "v3.4.12.1"
+      publish_github:
+        description: Create the managed-only GitHub release.
+        required: true
+        type: boolean
+        default: false
+      publish_nuget:
+        description: Push the managed package to NuGet.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  DOTNET_NOLOGO: "1"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+
+jobs:
+  build:
+    name: Build and validate managed package
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout SDL3-CS with release history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
+            7.0.x
+
+      - name: Validate managed-only release scope
+        shell: pwsh
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+          NATIVE_PACKAGE_REVISION: ${{ inputs.native_package_revision }}
+          BASE_RELEASE_REF: ${{ inputs.base_release_ref }}
+        run: |
+          ./.github/release-tools/Test-ManagedReleaseScope.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -NativePackageRevision ([int]$env:NATIVE_PACKAGE_REVISION) `
+            -BaseRef $env:BASE_RELEASE_REF `
+            -CheckNuGet
+
+      - name: Restore managed projects
+        shell: pwsh
+        run: |
+          dotnet restore .\SDL3-CS\SDL3-CS.csproj --force --no-cache
+          dotnet restore .\SDL3-CS.Tests\SDL3-CS.Tests.csproj --force --no-cache
+
+      - name: Build managed wrapper and tests
+        shell: pwsh
+        run: |
+          dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore /p:GeneratePackageOnBuild=false
+          dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore
+
+      - name: Restore published native runtime for managed tests
+        shell: pwsh
+        env:
+          NATIVE_PACKAGE_REVISION: ${{ inputs.native_package_revision }}
+        run: |
+          ./.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1 `
+            -NativePackageRevision ([int]$env:NATIVE_PACKAGE_REVISION) `
+            -Rid win-x64 `
+            -Destination 'SDL3-CS.Tests/bin/Release/net8.0'
+
+      - name: Run managed wrapper tests
+        shell: pwsh
+        run: dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore
+
+      - name: Audit public wrapper XML documentation
+        shell: pwsh
+        run: ./.github/release-tools/Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
+
+      - name: Pack managed NuGet package
+        shell: pwsh
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+        run: |
+          ./.github/release-tools/Pack-NuGet.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -OutputDir 'artifacts/release/nuget' `
+            -ManagedOnly `
+            -NoBuild
+
+      - name: Validate managed NuGet package contents
+        shell: pwsh
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+        run: |
+          ./.github/release-tools/Test-NuGetPackageContents.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -PackageDir 'artifacts/release/nuget' `
+            -ManagedOnly
+
+      - name: Upload managed NuGet package
+        uses: actions/upload-artifact@v4
+        with:
+          name: managed-nuget-package
+          path: artifacts/release/nuget/SDL3-CS.*.nupkg
+          if-no-files-found: error
+
+  publish:
+    name: Publish managed package
+    needs: build
+    if: ${{ inputs.publish_github || inputs.publish_nuget }}
+    runs-on: windows-2025
+    environment: production
+
+    steps:
+      - name: Checkout SDL3-CS with release history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download managed NuGet package
+        uses: actions/download-artifact@v4
+        with:
+          name: managed-nuget-package
+          path: artifacts/release/nuget
+
+      - name: NuGet trusted publishing login
+        if: ${{ inputs.publish_nuget }}
+        uses: NuGet/login@v1
+        id: nuget_login
+        with:
+          user: edwardgushchin
+
+      - name: Publish selected targets
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+          NATIVE_PACKAGE_REVISION: ${{ inputs.native_package_revision }}
+          BASE_RELEASE_REF: ${{ inputs.base_release_ref }}
+          PUBLISH_GITHUB: ${{ inputs.publish_github }}
+          PUBLISH_NUGET: ${{ inputs.publish_nuget }}
+        run: |
+          $params = @{
+            PackageRevision = [int]$env:PACKAGE_REVISION
+            NativePackageRevision = [int]$env:NATIVE_PACKAGE_REVISION
+            BaseReleaseRef = $env:BASE_RELEASE_REF
+            PackageDir = 'artifacts/release/nuget'
+            ManagedOnly = $true
+          }
+          if ($env:PUBLISH_GITHUB -eq 'true') {
+            $params.GitHubRelease = $true
+          }
+          if ($env:PUBLISH_NUGET -eq 'true') {
+            $params.NuGetPush = $true
+          }
+
+          ./.github/release-tools/Publish-Release.ps1 @params

--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,11 +4,11 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Latest Release
 
-Current stable release: [`SDL3-CS 3.4.12.1`](https://www.nuget.org/packages/SDL3-CS/3.4.12.1).
+Current stable release: [`SDL3-CS 3.4.12.2`](https://www.nuget.org/packages/SDL3-CS/3.4.12.2).
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.12.1` |
+| `SDL3-CS` | `3.4.12.2` |
 | `SDL3-CS.<Platform>` | `3.4.12.1` |
 | `SDL3-CS.<Platform>.Image` | `3.4.4.7` |
 | `SDL3-CS.<Platform>.Mixer` | `3.2.4.7` |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 </p>
 
 <p align="center">
-  <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.1">
-    <img alt="NuGet SDL3-CS 3.4.12.1" src="https://img.shields.io/badge/nuget-v3.4.12.1-004880?style=flat-square">
+  <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.2">
+    <img alt="NuGet SDL3-CS 3.4.12.2" src="https://img.shields.io/badge/nuget-v3.4.12.2-004880?style=flat-square">
   </a>
   <a href="https://www.nuget.org/packages/SDL3-CS">
     <img alt="NuGet SDL3-CS downloads" src="https://img.shields.io/nuget/dt/SDL3-CS?style=flat-square">

--- a/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
@@ -164,6 +164,7 @@ internal static class PInvokeTests
         RenderTargetLogicalPresentationAndCoordinates_ForwardInputsOutputsAndReturnNativeValues();
         ConvertEventToRenderCoordinates_ForwardsRendererAndRefEvent();
         ViewportClipAndScaleFunctions_ForwardInputsOutputsAndReturnNativeValues();
+        SetRenderViewportRect_UsesPointerAbiWithNativeSoftwareRenderer();
         DrawColorBlendAndClearFunctions_ForwardInputsOutputsAndReturnNativeValues();
         PrimitiveRenderingFunctions_ForwardCoordinatesPointersArraysAndRects();
         TextureRenderingFunctions_ForwardTextureRectsRotationCenterAndFlip();
@@ -245,7 +246,17 @@ internal static class PInvokeTests
         AssertNativeBoolImport(GetNativeMethod("SDL_RenderCoordinatesToWindow"), "SDL_RenderCoordinatesToWindow");
         AssertNativeBoolDllImport(GetNativeMethod("SDL_ConvertEventToRenderCoordinates"), "SDL_ConvertEventToRenderCoordinates");
         AssertNativeBoolImport(GetNativeMethod("SDL_SetRenderViewportPointer"), "SDL_SetRenderViewport");
-        AssertNativeBoolImport(GetNativeMethod("SDL_SetRenderViewportRect"), "SDL_SetRenderViewport");
+        MethodInfo setRenderViewportRect = GetNativeMethod("SDL_SetRenderViewportRect");
+        AssertNativeBoolImport(setRenderViewportRect, "SDL_SetRenderViewport");
+        AssertInRectParameter(setRenderViewportRect, 1, "SDL_SetRenderViewportRect");
+
+        Type? setRenderViewportDelegate = typeof(SDL3.SDL).GetNestedType("SetRenderViewportRectNativeDelegate", BindingFlags.NonPublic);
+        TestAssert.NotNull(setRenderViewportDelegate, "SDL.SetRenderViewportRectNativeDelegate must remain available for the native hook.");
+        MethodInfo? setRenderViewportInvoke = setRenderViewportDelegate!.GetMethod("Invoke");
+        TestAssert.NotNull(setRenderViewportInvoke, "SDL.SetRenderViewportRectNativeDelegate.Invoke must exist.");
+        AssertInRectParameter(setRenderViewportInvoke!, 1, "SetRenderViewportRectNativeDelegate.Invoke");
+
+        AssertInRectParameter(GetPublicSetRenderViewportRectMethod(), 1, "SetRenderViewport(IntPtr, in Rect)");
         AssertNativeBoolImport(GetNativeMethod("SDL_GetRenderViewport"), "SDL_GetRenderViewport");
         AssertNativeBoolImport(GetNativeMethod("SDL_RenderViewportSet"), "SDL_RenderViewportSet");
         AssertNativeBoolImport(GetNativeMethod("SDL_GetRenderSafeArea"), "SDL_GetRenderSafeArea");
@@ -1075,11 +1086,18 @@ internal static class PInvokeTests
         nextBool = true;
         using (NativeHookScope _ = NativeHookScope.Install("SetRenderViewportRectNativeFunction", nameof(CaptureSetRenderViewportRect)))
         {
-            bool result = SDL3.SDL.SetRenderViewport((IntPtr)0x6011, viewport);
+            bool result = SDL3.SDL.SetRenderViewport((IntPtr)0x6011, in viewport);
 
-            TestAssert.Equal(true, result, "SDL.SetRenderViewport(Rect) must return the native hook value.");
-            TestAssert.Equal((IntPtr)0x6011, capturedRenderer, "SDL.SetRenderViewport(Rect) must forward renderer.");
-            AssertRect(viewport, capturedRect, "SDL.SetRenderViewport(Rect) must forward rect.");
+            TestAssert.Equal(true, result, "SDL.SetRenderViewport(in Rect) must return the native hook success value.");
+            TestAssert.Equal((IntPtr)0x6011, capturedRenderer, "SDL.SetRenderViewport(in Rect) must forward renderer.");
+            AssertRect(viewport, capturedRect, "SDL.SetRenderViewport(in Rect) must forward rect.");
+
+            nextBool = false;
+            result = SDL3.SDL.SetRenderViewport((IntPtr)0x6012, in viewport);
+
+            TestAssert.Equal(false, result, "SDL.SetRenderViewport(in Rect) must return the native hook failure value.");
+            TestAssert.Equal((IntPtr)0x6012, capturedRenderer, "SDL.SetRenderViewport(in Rect) must forward renderer on failure.");
+            AssertRect(viewport, capturedRect, "SDL.SetRenderViewport(in Rect) must forward rect on failure.");
         }
 
         ResetCaptureState();
@@ -1183,6 +1201,37 @@ internal static class PInvokeTests
         TestAssert.Equal((IntPtr)0x60A1, capturedRenderer, "SDL.GetRenderScale must forward renderer.");
         TestAssert.Equal(3.5f, scalex, "SDL.GetRenderScale must output x scale.");
         TestAssert.Equal(4.5f, scaley, "SDL.GetRenderScale must output y scale.");
+    }
+
+    public static void SetRenderViewportRect_UsesPointerAbiWithNativeSoftwareRenderer()
+    {
+        IntPtr surface = SDL3.SDL.CreateSurface(64, 64, SDL3.SDL.PixelFormat.ARGB8888);
+        TestAssert.True(surface != IntPtr.Zero, $"SDL.CreateSurface must succeed for the SetRenderViewport native ABI test: {SDL3.SDL.GetError()}");
+
+        try
+        {
+            IntPtr renderer = SDL3.SDL.CreateSoftwareRenderer(surface);
+            TestAssert.True(renderer != IntPtr.Zero, $"SDL.CreateSoftwareRenderer must succeed for the SetRenderViewport native ABI test: {SDL3.SDL.GetError()}");
+
+            try
+            {
+                SDL3.SDL.Rect expected = CreateRect(1, 2, 30, 40);
+                bool setResult = SDL3.SDL.SetRenderViewport(renderer, in expected);
+                TestAssert.True(setResult, $"SDL.SetRenderViewport(in Rect) must succeed against native SDL: {SDL3.SDL.GetError()}");
+
+                bool getResult = SDL3.SDL.GetRenderViewport(renderer, out SDL3.SDL.Rect actual);
+                TestAssert.True(getResult, $"SDL.GetRenderViewport must succeed after the native typed call: {SDL3.SDL.GetError()}");
+                AssertRect(expected, actual, "SDL.SetRenderViewport(in Rect) must pass a native pointer to all Rect fields.");
+            }
+            finally
+            {
+                SDL3.SDL.DestroyRenderer(renderer);
+            }
+        }
+        finally
+        {
+            SDL3.SDL.DestroySurface(surface);
+        }
     }
 
     public static void DrawColorBlendAndClearFunctions_ForwardInputsOutputsAndReturnNativeValues()
@@ -2776,7 +2825,7 @@ internal static class PInvokeTests
         return nextBool;
     }
 
-    private static bool CaptureSetRenderViewportRect(IntPtr renderer, SDL3.SDL.Rect rect)
+    private static bool CaptureSetRenderViewportRect(IntPtr renderer, in SDL3.SDL.Rect rect)
     {
         capturedRenderer = renderer;
         capturedRect = rect;
@@ -4150,6 +4199,25 @@ internal static class PInvokeTests
         MethodInfo? method = typeof(SDL3.SDL).GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
         TestAssert.NotNull(method, $"SDL.{methodName} method must be private static.");
         return method!;
+    }
+
+    private static MethodInfo GetPublicSetRenderViewportRectMethod()
+    {
+        MethodInfo? method = typeof(SDL3.SDL).GetMethod(
+            nameof(SDL3.SDL.SetRenderViewport),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: [typeof(IntPtr), typeof(SDL3.SDL.Rect).MakeByRefType()],
+            modifiers: null);
+        TestAssert.NotNull(method, "SDL.SetRenderViewport(IntPtr, in Rect) must expose a by-ref Rect parameter.");
+        return method!;
+    }
+
+    private static void AssertInRectParameter(MethodInfo method, int index, string memberName)
+    {
+        ParameterInfo parameter = method.GetParameters()[index];
+        TestAssert.Equal(typeof(SDL3.SDL.Rect).MakeByRefType(), parameter.ParameterType, $"SDL.{memberName} rect parameter must be by-ref.");
+        TestAssert.True(parameter.IsIn, $"SDL.{memberName} rect parameter must keep in metadata.");
     }
 
     private static void AssertNativeImport(MethodInfo method, string entryPoint)

--- a/SDL3-CS/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/render/PInvoke.cs
@@ -2156,8 +2156,8 @@ public static partial class SDL
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_SetRenderViewport"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    private static partial bool SDL_SetRenderViewportRect(IntPtr renderer, Rect rect);
-    private delegate bool SetRenderViewportRectNativeDelegate(IntPtr renderer, Rect rect);
+    private static partial bool SDL_SetRenderViewportRect(IntPtr renderer, in Rect rect);
+    private delegate bool SetRenderViewportRectNativeDelegate(IntPtr renderer, in Rect rect);
     private static SetRenderViewportRectNativeDelegate SetRenderViewportRectNativeFunction = SDL_SetRenderViewportRect;
 
     /// <code>extern SDL_DECLSPEC bool SDLCALL SDL_SetRenderViewport(SDL_Renderer *renderer, const SDL_Rect *rect);</code>
@@ -2169,17 +2169,16 @@ public static partial class SDL
     /// <para>The area's width and height must be >= 0.</para>
     /// </summary>
     /// <param name="renderer">the rendering context.</param>
-    /// <param name="rect">the <see cref="Rect"/> structure representing the drawing area, or <c>null</c>
-    /// to set the viewport to the entire target.</param>
+    /// <param name="rect">the <see cref="Rect"/> structure representing the drawing area.</param>
     /// <returns><c>true</c> on success or <c>false</c> on failure; call <see cref="GetError"/> for more
     /// information.</returns>
     /// <threadsafety>This function should only be called on the main thread.</threadsafety>
     /// <since>This function is available since SDL 3.2.0</since>
     /// <seealso cref="GetRenderViewport"/>
     /// <seealso cref="RenderViewportSet"/>
-    public static bool SetRenderViewport(IntPtr renderer, Rect rect)
+    public static bool SetRenderViewport(IntPtr renderer, in Rect rect)
     {
-        return SetRenderViewportRectNativeFunction(renderer, rect);
+        return SetRenderViewportRectNativeFunction(renderer, in rect);
     }
 
 


### PR DESCRIPTION
## Summary

- fix the `SDL_SetRenderViewport` typed overload ABI by passing `Rect` by readonly reference
- add a managed-only GitHub Actions release path for wrapper hotfixes
- reuse the published native package matrix instead of rebuilding or republishing native packages
- prepare release notes and package metadata for `SDL3-CS 3.4.12.2`

## Validation

- wrapper Release build for net7.0, net8.0, net9.0, and net10.0: 0 warnings, 0 errors
- full managed test runner: passed
- public wrapper XML documentation audit: passed
- managed release workflow and scope tests: passed
- actionlint for managed and full release workflows: passed
- all 30 reusable native packages available on NuGet
- managed package content validation: 18 expected entries, no runtimes/* payload
- strict publish dry-run: draft GitHub Release, NuGet push, then public GitHub Release

Fixes #203.