### PR TITLE
Harden GitHub repository configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default ownership for repository changes.
+* @edwardgushchin
+
+# Release and automation changes require maintainer review.
+/.github/workflows/ @edwardgushchin
+/.github/release-tools/ @edwardgushchin
+/SDL3-CS.Native*/ @edwardgushchin

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,108 @@
+name: Bug report
+description: Report a reproducible problem in SDL3-CS bindings or packages.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a problem. Search existing issues first and do not include security-sensitive information here.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: This is not a security vulnerability. I will use the private reporting process for security issues.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of SDL3-CS is affected?
+      options:
+        - SDL core bindings
+        - Render or GPU
+        - SDL_image
+        - SDL_mixer
+        - SDL_ttf
+        - SDL_shadercross
+        - Native packages
+        - Release tooling
+        - Examples or documentation
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: SDL3-CS version
+      description: Provide the exact NuGet package version or commit SHA.
+      placeholder: "3.4.12.3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the OS, architecture, .NET version, target framework, RID, and native packages.
+      placeholder: |
+        OS: Windows 11 x64
+        .NET SDK/runtime: 10.0.x
+        Target framework: net10.0
+        RID: win-x64
+        Native packages: SDL3-CS.Windows 3.4.12.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: Explain what happened and why it appears to be a defect.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest code sample and exact steps that reproduce the issue.
+      render: csharp
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or error output
+      description: Paste complete, redacted logs or compiler output if available.
+      render: shell
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add links, screenshots, upstream SDL references, or other useful context.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Usage questions and troubleshooting
+    url: https://github.com/edwardgushchin/SDL3-CS/discussions
+    about: Ask the community for help using SDL3-CS.
+  - name: Security vulnerability
+    url: https://github.com/edwardgushchin/SDL3-CS/security/advisories/new
+    about: Report suspected vulnerabilities privately. Do not open a public issue.
+  - name: SDL3-CS documentation
+    url: https://github.com/edwardgushchin/SDL3-CS/wiki
+    about: Read setup, platform, and API guidance.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,79 @@
+name: Feature or binding request
+description: Propose a managed binding, package, tooling, or documentation improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user need and the smallest useful change. For new bindings, link the exact upstream declaration and version.
+
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      options:
+        - label: I searched the existing issues and discussions for this request.
+          required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - SDL core bindings
+        - Render or GPU
+        - SDL_image
+        - SDL_mixer
+        - SDL_ttf
+        - SDL_shadercross
+        - Native packages
+        - Release tooling
+        - Examples or documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and what is currently missing?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the API or behavior you would like to see.
+    validations:
+      required: true
+
+  - type: input
+    id: upstream
+    attributes:
+      label: Upstream reference
+      description: Link the relevant SDL declaration, documentation, release, commit, or issue when applicable.
+      placeholder: "https://github.com/libsdl-org/SDL/..."
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or alternative designs you considered.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add code examples, ABI notes, screenshots, or compatibility constraints.
+
+  - type: checkboxes
+    id: conduct
+    attributes:
+      label: Code of Conduct
+      options:
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- Explain the problem and the approach taken. -->
+
+## Related issue
+
+<!-- Use Fixes #123, Closes #123, or Refs #123 when applicable. -->
+
+## Changes
+
+- <!-- Describe each material change. -->
+
+## Verification
+
+<!-- List the exact commands and manual checks you ran. -->
+
+- [ ] The relevant managed project builds in `Release` configuration.
+- [ ] Focused tests cover the changed behavior and pass locally.
+- [ ] Public wrapper XML documentation passes the repository audit when bindings changed.
+- [ ] Native ABI, ownership, and marshalling behavior were checked when applicable.
+- [ ] User-facing documentation was updated when behavior or setup changed.
+- [ ] No generated output, secrets, or unrelated changes are included.
+
+## Compatibility and release impact
+
+<!-- Note breaking changes, affected platforms/RIDs, native rebuild needs, package revisions, or write "None". -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope
+
+  - package-ecosystem: nuget
+    directory: /
+    schedule:
+      interval: monthly
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build
+      include: scope

--- a/.github/workflows/build-sdl.yml
+++ b/.github/workflows/build-sdl.yml
@@ -3,6 +3,9 @@ name: Build SDL
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SDL for ${{ matrix.os }} (${{ matrix.arch_label }})
@@ -44,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout SDL
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL
           ref: release-3.4.2
@@ -126,7 +129,7 @@ jobs:
 
       # ---------- Artifacts ----------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL-${{ matrix.os }}-${{ matrix.arch_label }}
           path: |

--- a/.github/workflows/build-sdl_image.yml
+++ b/.github/workflows/build-sdl_image.yml
@@ -3,6 +3,9 @@ name: Build SDL_image
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SDL_image for ${{ matrix.os }} (${{ matrix.arch_label }})
@@ -45,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout SDL
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL
           fetch-depth: 1
@@ -53,7 +56,7 @@ jobs:
           path: SDL
 
       - name: Checkout SDL_image
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL_image
           fetch-depth: 1
@@ -197,7 +200,7 @@ jobs:
 
       # ---------- Artifacts ----------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL_image-${{ matrix.os }}-${{ matrix.arch_label }}
           path: |

--- a/.github/workflows/build-sdl_mixer.yml
+++ b/.github/workflows/build-sdl_mixer.yml
@@ -3,6 +3,9 @@ name: Build SDL_mixer
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SDL_mixer for ${{ matrix.os }} (${{ matrix.arch_label }})
@@ -45,7 +48,7 @@ jobs:
     steps:
       # ---------- Sources ----------
       - name: Checkout SDL
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL
           fetch-depth: 1
@@ -53,7 +56,7 @@ jobs:
           path: SDL
 
       - name: Checkout SDL_mixer
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL_mixer
           fetch-depth: 1
@@ -174,7 +177,7 @@ jobs:
 
       # ---------- Artifacts ----------
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL_mixer-${{ matrix.os }}-${{ matrix.arch_label }}
           path: |

--- a/.github/workflows/build-sdl_shadercross.yml
+++ b/.github/workflows/build-sdl_shadercross.yml
@@ -3,6 +3,9 @@ name: Build SDL_shadercross
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SDL_shadercross for ${{ matrix.os }} (${{ matrix.arch_label }})
@@ -47,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout SDL (your fork)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL
           fetch-depth: 1
@@ -55,7 +58,7 @@ jobs:
           path: SDL
 
       - name: Checkout SDL_shadercross
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL_shadercross
           fetch-depth: 1
@@ -281,7 +284,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL_shadercross-${{ matrix.os }}-${{ matrix.arch_label }}
           path: |

--- a/.github/workflows/build-sdl_ttf.yml
+++ b/.github/workflows/build-sdl_ttf.yml
@@ -3,6 +3,9 @@ name: Build SDL_ttf
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build SDL_ttf for ${{ matrix.os }} (${{ matrix.arch_label }})
@@ -51,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout SDL
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL
           fetch-depth: 1
@@ -59,7 +62,7 @@ jobs:
           path: SDL
 
       - name: Checkout SDL_ttf
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: edwardgushchin/SDL_ttf
           fetch-depth: 1
@@ -91,7 +94,7 @@ jobs:
 
       # ---------- Cache ----------
       - name: Cache install prefix
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.INSTALL_PREFIX }}
           key: install-prefix-ttf-${{ matrix.os }}-${{ matrix.arch_label }}-v2
@@ -189,7 +192,7 @@ jobs:
 
       # ---------- Artifacts (raw) ----------
       - name: Upload raw artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL_ttf-${{ matrix.os }}-${{ matrix.arch_label }}
           path: |
@@ -207,7 +210,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
 
       - name: Prepare directory structure
         run: |
@@ -245,7 +248,7 @@ jobs:
         run: zip -r SDL_ttf-libs.zip lib
 
       - name: Upload final packed archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: SDL_ttf-libs
           path: SDL_ttf-libs.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release-*"
+  push:
+    branches:
+      - main
+      - "release-*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: "1"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+
+jobs:
+  managed:
+    name: Managed build and tests
+    runs-on: windows-2025
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout SDL3-CS
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET SDKs
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: |
+            10.0.x
+            9.0.x
+            8.0.x
+            7.0.x
+
+      - name: Restore managed projects
+        shell: pwsh
+        run: |
+          dotnet restore .\SDL3-CS\SDL3-CS.csproj --force --no-cache
+          dotnet restore .\SDL3-CS.Tests\SDL3-CS.Tests.csproj --force --no-cache
+
+      - name: Build managed wrapper and tests
+        shell: pwsh
+        run: |
+          dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore /p:GeneratePackageOnBuild=false
+          dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore
+
+      - name: Restore published native runtime for managed tests
+        shell: pwsh
+        run: |
+          ./.github/release-tools/Restore-ManagedReleaseTestRuntime.ps1 `
+            -NativePackageRevision 1 `
+            -Rid win-x64 `
+            -Destination 'SDL3-CS.Tests/bin/Release/net8.0'
+
+      - name: Run managed wrapper tests
+        shell: pwsh
+        run: dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore
+
+      - name: Audit public wrapper XML documentation
+        shell: pwsh
+        run: ./.github/release-tools/Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build matrix from release manifest
         id: native-matrix
@@ -91,10 +91,10 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -217,7 +217,7 @@ jobs:
             -InstallRoot 'artifacts/release/native/SDL_shadercross/${{ matrix.rid }}/install'
 
       - name: Upload native bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: native-bundle-${{ matrix.rid }}
           path: artifacts/release/bundles/native-all-components-${{ matrix.rid }}.zip
@@ -233,10 +233,10 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -253,7 +253,7 @@ jobs:
         run: ./.github/release-tools/Initialize-NativeForks.ps1 -Depth 1 -Retries 3
 
       - name: Download native bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: native-bundle-*
           path: artifacts/release/bundles
@@ -322,14 +322,14 @@ jobs:
             -StatePath 'artifacts/release/release-assembly-state.zip'
 
       - name: Upload NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nuget-packages
           path: artifacts/release/nuget/*.nupkg
           if-no-files-found: error
 
       - name: Upload release assembly state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-assembly-state
           path: artifacts/release/release-assembly-state.zip
@@ -354,10 +354,10 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -379,7 +379,7 @@ jobs:
           dotnet workload install ios tvos --source https://api.nuget.org/v3/index.json
 
       - name: Download NuGet packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: nuget-packages
           path: artifacts/release/nuget
@@ -402,10 +402,10 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -420,7 +420,7 @@ jobs:
           dotnet workload install android --source https://api.nuget.org/v3/index.json
 
       - name: Download NuGet packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: nuget-packages
           path: artifacts/release/nuget
@@ -448,10 +448,10 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -464,7 +464,7 @@ jobs:
         run: ./.github/release-tools/Initialize-NativeForks.ps1 -Depth 1 -Retries 3
 
       - name: Download release assembly state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: release-assembly-state
           path: artifacts/release/state
@@ -499,7 +499,7 @@ jobs:
 
       - name: NuGet trusted publishing login
         if: ${{ inputs.publish_nuget }}
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: nuget_login
         with:
           user: edwardgushchin
@@ -531,12 +531,12 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS with release history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDKs
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.0.x
@@ -609,7 +609,7 @@ jobs:
             -ManagedOnly
 
       - name: Upload managed NuGet package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: managed-nuget-package
           path: artifacts/release/nuget/SDL3-CS.*.nupkg
@@ -626,24 +626,24 @@ jobs:
 
     steps:
       - name: Checkout SDL3-CS with release history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: 10.0.x
 
       - name: Download managed NuGet package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: managed-nuget-package
           path: artifacts/release/nuget
 
       - name: NuGet trusted publishing login
         if: ${{ inputs.publish_nuget }}
-        uses: NuGet/login@v1
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
         id: managed_nuget_login
         with:
           user: edwardgushchin

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**artak[at]aregtech.com**.
+**eduardgushchin[at]yandex.ru**.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to SDL3-CS
+
+Thank you for helping improve SDL3-CS. Contributions are welcome for managed bindings, native packages, examples, documentation, tests, and release tooling.
+
+## Before You Start
+
+- Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+- Search the [existing issues](https://github.com/edwardgushchin/SDL3-CS/issues) and [discussions](https://github.com/edwardgushchin/SDL3-CS/discussions) before opening a new report.
+- Use [GitHub Discussions](https://github.com/edwardgushchin/SDL3-CS/discussions) for usage questions. The [support guide](SUPPORT.md) explains where each type of request belongs.
+- Report suspected vulnerabilities privately as described in the [security policy](SECURITY.md).
+- For a substantial API, ABI, packaging, or release change, open an issue first so the scope and upstream SDL baseline can be agreed on.
+
+## Development Setup
+
+The managed wrapper supports .NET 7, .NET 8, .NET 9, and .NET 10. Install the matching .NET SDKs and PowerShell 7. Native-package work can also require CMake and the platform toolchains used by the relevant workflow.
+
+Clone your fork and restore the managed projects:
+
+```powershell
+git clone https://github.com/YOUR-USER/SDL3-CS.git
+cd SDL3-CS
+dotnet restore .\SDL3-CS\SDL3-CS.csproj
+dotnet restore .\SDL3-CS.Tests\SDL3-CS.Tests.csproj
+```
+
+Create a focused branch from the active development branch. Unless an issue or maintainer says otherwise, pull requests should target the current `release-*` branch; release branches are subsequently integrated into `main`.
+
+## Binding Changes
+
+Keep bindings aligned with the exact upstream SDL, SDL_image, SDL_mixer, SDL_ttf, or SDL_shadercross declaration used by the active release line.
+
+- Follow the structure, naming, marshalling, and XML documentation style of neighboring APIs.
+- Preserve the original C declaration in the public wrapper XML documentation.
+- Put upstream API documentation on the public managed member, not a private native entry point.
+- Add meaningful mirrored tests in `SDL3-CS.Tests/` using the same relative path as the wrapper source.
+- Cover success and failure behavior, marshalling, ownership, overloads, and native metadata where applicable.
+- Avoid unrelated formatting or refactoring in the same pull request.
+
+## Tests and Checks
+
+Run the narrowest relevant test first. Before submitting a managed wrapper change, run at least:
+
+```powershell
+dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false
+dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release
+pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
+```
+
+The test runner needs matching native libraries. On Windows, restore the published runtime for the active release line, then run it:
+
+```powershell
+pwsh .\.github\release-tools\Restore-ManagedReleaseTestRuntime.ps1 `
+  -NativePackageRevision 1 `
+  -Rid win-x64 `
+  -Destination SDL3-CS.Tests\bin\Release\net8.0
+
+dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore
+```
+
+If the active release uses another native package revision, pass that published revision instead. Native packaging and release-tool changes require the focused checks documented alongside the affected scripts and workflows.
+
+## Commits and Pull Requests
+
+- Write commit subjects and bodies in English.
+- Keep each commit reviewable and limited to one coherent concern.
+- Link the related issue with `Fixes #123`, `Closes #123`, or `Refs #123` when appropriate.
+- Complete the pull request template and list the exact commands you ran.
+- Include tests for behavior changes and update public documentation when users need new instructions.
+- Do not include generated build output, local IDE settings, credentials, tokens, or native build artifacts.
+
+By contributing, you agree that your work will be distributed under the repository's [zlib license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/edwardgushchin/SDL3-CS/actions/workflows/ci.yml">
+    <img alt="CI" src="https://github.com/edwardgushchin/SDL3-CS/actions/workflows/ci.yml/badge.svg?branch=main">
+  </a>
   <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.3">
     <img alt="NuGet SDL3-CS 3.4.12.3" src="https://img.shields.io/badge/nuget-v3.4.12.3-004880?style=flat-square">
   </a>
@@ -209,7 +212,9 @@ More examples can be found in [SDL3-CS.Examples](https://github.com/edwardgushch
 
 Found a bug or have an idea? Open an [issue](https://github.com/edwardgushchin/SDL3-CS/issues) or start a [discussion](https://github.com/edwardgushchin/SDL3-CS/discussions).
 
-Please follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all project interactions.
+Before contributing, read the [contribution guide](CONTRIBUTING.md). Please follow the [Code of Conduct](CODE_OF_CONDUCT.md) in all project interactions.
+
+For usage help, see the [support guide](SUPPORT.md). Report suspected vulnerabilities privately according to the [security policy](SECURITY.md); do not disclose them in a public issue.
 
 You can contact the maintainer at [eduardgushchin@yandex.ru](mailto:eduardgushchin@yandex.ru) or join the [Telegram chat](https://t.me/sdl3cs) for questions and feedback.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest published SDL3-CS release line. Older release lines may not receive patches.
+
+| Release line | Supported |
+| --- | --- |
+| `3.4.12.x` | Yes |
+| Earlier releases | No |
+
+## Reporting a Vulnerability
+
+Do not open a public issue, discussion, or pull request for a suspected vulnerability.
+
+Use [GitHub private vulnerability reporting](https://github.com/edwardgushchin/SDL3-CS/security/advisories/new) to send the maintainer:
+
+- the affected package, version, platform, and runtime identifier;
+- a clear description of the impact and attack scenario;
+- minimal reproduction steps or a proof of concept;
+- any known mitigation or upstream SDL advisory;
+- whether the report or proof of concept has been disclosed elsewhere.
+
+You should receive an initial acknowledgement within 72 hours. The maintainer will validate the report, coordinate with upstream projects when necessary, and provide progress updates at least weekly while the report remains active. Release timing depends on severity, upstream availability, and the affected native package matrix.
+
+Please allow a reasonable remediation period before public disclosure. Credit will be offered unless you prefer to remain anonymous.
+
+## Scope
+
+This policy covers the managed SDL3-CS bindings, repository-owned release tooling, and native NuGet packages published from this repository. Vulnerabilities in upstream SDL projects should also be reported through the applicable upstream security process, but reports involving SDL3-CS packaging or bindings are still welcome here.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,11 @@
+# Support
+
+Choose the channel that best matches your request:
+
+- Read the [SDL3-CS Wiki](https://github.com/edwardgushchin/SDL3-CS/wiki), [examples](SDL3-CS.Examples), and [upstream SDL documentation](https://wiki.libsdl.org/SDL3/FrontPage) for setup and API guidance.
+- Start a [GitHub Discussion](https://github.com/edwardgushchin/SDL3-CS/discussions) for usage questions, design ideas, troubleshooting, and help choosing packages.
+- Open an [issue](https://github.com/edwardgushchin/SDL3-CS/issues/new/choose) for a reproducible bug or a concrete feature request.
+- Follow the [security policy](SECURITY.md) for suspected vulnerabilities. Never disclose security-sensitive details in a public issue.
+- Use the [Telegram community chat](https://t.me/sdl3cs) for informal community conversation.
+
+When asking for help, include the SDL3-CS package version, target framework, operating system, runtime identifier, relevant native packages, a minimal code sample, and the complete error message. Support is provided on a best-effort basis; well-scoped reports with a reproduction are easier to resolve.


### PR DESCRIPTION
## Summary

- add complete community health documentation, Issue Forms, a pull request template, CODEOWNERS, and Dependabot configuration;
- add managed PR/push CI and pin every external GitHub Action to a verified immutable commit SHA;
- declare least-privilege workflow permissions and update README/community/security links;
- correct the Code of Conduct enforcement contact.

## Repository settings applied

The repository metadata, topics, Projects visibility, vulnerability alerts, Dependabot security updates, private vulnerability reporting, CodeQL default setup, Actions allow-list, and a solo-maintainer-safe `Protect main` ruleset were configured through the GitHub API.

## Verification

- `python`/PyYAML parsed all 11 `.github/**/*.yml` files;
- `actionlint 1.7.12` passed;
- all pinned Action SHAs match their documented major tags, including the dereferenced annotated `NuGet/login@v1` tag;
- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore /p:GeneratePackageOnBuild=false` passed with 0 warnings and 0 errors;
- `dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore` passed with 0 warnings and 0 errors;
- the full managed binding runner passed with the published `win-x64` native runtime;
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS` passed;
- CodeQL default setup completed successfully for C# and GitHub Actions: https://github.com/edwardgushchin/SDL3-CS/actions/runs/29461304197.

## Follow-up after merge

- make `CI / Managed build and tests` a required status check in the `Protect main` ruleset;
- enable repository-level immutable Action SHA enforcement;
- verify GitHub Community Profile reaches 100% on the default branch.
