### PR TITLE
build: Bump SDL3-CS.Linux.Mixer from 3.2.4.1 to 3.2.4.7

### DIFF
--- a/SDL3-CS.Examples/Directory.Build.props
+++ b/SDL3-CS.Examples/Directory.Build.props
@@ -9,7 +9,7 @@
     <LangVersion Condition="'$(LangVersion)' == ''">14</LangVersion>
     <SDL3CSVersion>3.4.12.1</SDL3CSVersion>
     <SDL3CSImageVersion>3.4.4.7</SDL3CSImageVersion>
-    <SDL3CSMixerVersion>3.2.4.1</SDL3CSMixerVersion>
+    <SDL3CSMixerVersion>3.2.4.7</SDL3CSMixerVersion>
     <SDL3CSTTFVersion>3.2.2.1</SDL3CSTTFVersion>
     <SDL3CSShadercrossVersion>3.0.0.1</SDL3CSShadercrossVersion>
   </PropertyGroup>


### PR DESCRIPTION
Replaces #217, whose Dependabot branch conflicts with the shared version file after #215 and #218 were merged.

This pull request preserves the original dependency update on top of the current `main`:

- `SDL3-CS.Linux.Mixer`: `3.2.4.1` -> `3.2.4.7`

The diff is limited to `SDL3-CS.Examples/Directory.Build.props`.