### PR TITLE
fix: add GPU render state create info binding

### DIFF
--- a/SDL3-CS.Tests/SDL/Video/render/GPURenderStateCreateInfo.cs
+++ b/SDL3-CS.Tests/SDL/Video/render/GPURenderStateCreateInfo.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using SDL3.Tests;
+
+namespace SDL3.Tests.SDL.Video.Render;
+
+internal static class GPURenderStateCreateInfoTests
+{
+    public static void Layout_MatchesSdl3412Abi()
+    {
+        Type type = typeof(SDL3.SDL.GPURenderStateCreateInfo);
+        StructLayoutAttribute? layout = type.StructLayoutAttribute;
+
+        TestAssert.NotNull(layout, "SDL.GPURenderStateCreateInfo must declare StructLayout.");
+        TestAssert.Equal(LayoutKind.Sequential, layout!.Value, "SDL.GPURenderStateCreateInfo must use sequential layout.");
+
+        FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
+        string[] expectedNames =
+        [
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.FragmentShader),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.NumSamplerBindings),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.SamplerBindings),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.NumStorageTextures),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.StorageTextures),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.NumStorageBuffers),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.StorageBuffers),
+            nameof(SDL3.SDL.GPURenderStateCreateInfo.Props)
+        ];
+        Type[] expectedTypes =
+        [
+            typeof(IntPtr),
+            typeof(int),
+            typeof(IntPtr),
+            typeof(int),
+            typeof(IntPtr),
+            typeof(int),
+            typeof(IntPtr),
+            typeof(uint)
+        ];
+        int pointerSize = IntPtr.Size;
+        int[] expectedOffsets =
+        [
+            0,
+            pointerSize,
+            2 * pointerSize,
+            3 * pointerSize,
+            4 * pointerSize,
+            5 * pointerSize,
+            6 * pointerSize,
+            7 * pointerSize
+        ];
+
+        TestAssert.Equal(expectedNames.Length, fields.Length, "SDL.GPURenderStateCreateInfo must expose exactly the native fields.");
+
+        for (int index = 0; index < fields.Length; index++)
+        {
+            FieldInfo field = fields[index];
+            TestAssert.Equal(expectedNames[index], field.Name, $"SDL.GPURenderStateCreateInfo field {index} must keep native order.");
+            TestAssert.Equal(expectedTypes[index], field.FieldType, $"SDL.GPURenderStateCreateInfo.{field.Name} must use the native field type.");
+            TestAssert.Equal(expectedOffsets[index], Marshal.OffsetOf(type, field.Name).ToInt32(), $"SDL.GPURenderStateCreateInfo.{field.Name} must keep the native offset.");
+        }
+
+        int expectedSize = 8 * pointerSize;
+        TestAssert.Equal(expectedSize, Marshal.SizeOf<SDL3.SDL.GPURenderStateCreateInfo>(), "SDL.GPURenderStateCreateInfo must keep the native size.");
+    }
+}

--- a/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
@@ -29,6 +29,7 @@ internal static class PInvokeTests
     private static IntPtr capturedPixels;
     private static IntPtr capturedState;
     private static IntPtr capturedCreateInfo;
+    private static SDL3.SDL.GPURenderStateCreateInfo capturedGPURenderStateCreateInfo;
     private static IntPtr capturedData;
     private static IntPtr capturedYPlane;
     private static IntPtr capturedUPlane;
@@ -175,6 +176,8 @@ internal static class PInvokeTests
         GeometryRenderingFunctions_ForwardVerticesRawArraysAndGenericSpans();
         RenderTextureAddressReadPresentDestroyFlushAndMetalFunctions_ForwardInputsOutputsAndReturnNativeValues();
         VulkanVSyncDebugTextAndDefaultTextureScaleFunctions_ForwardInputsOutputsAndReturnNativeValues();
+        GPURenderStateCreateInfoTests.Layout_MatchesSdl3412Abi();
+        CreateGPURenderStateTypedOverload_UsesInParameterAndForwardsAllFields();
         GpuRenderStateFunctions_ForwardPointersArraysAndReturnNativeValues();
     }
 
@@ -2414,6 +2417,52 @@ internal static class PInvokeTests
         TestAssert.Equal(SDL3.SDL.ScaleMode.Nearest, scaleMode, "SDL.GetDefaultTextureScaleMode must write scale mode.");
     }
 
+    public static void CreateGPURenderStateTypedOverload_UsesInParameterAndForwardsAllFields()
+    {
+        MethodInfo? typedMethod = typeof(SDL3.SDL).GetMethod(
+            nameof(SDL3.SDL.CreateGPURenderState),
+            BindingFlags.Public | BindingFlags.Static,
+            binder: null,
+            types: [typeof(IntPtr), typeof(SDL3.SDL.GPURenderStateCreateInfo).MakeByRefType()],
+            modifiers: null);
+        TestAssert.NotNull(typedMethod, "SDL.CreateGPURenderState(IntPtr, in GPURenderStateCreateInfo) must exist.");
+
+        ParameterInfo createInfoParameter = typedMethod!.GetParameters()[1];
+        TestAssert.Equal(typeof(SDL3.SDL.GPURenderStateCreateInfo).MakeByRefType(), createInfoParameter.ParameterType, "SDL.CreateGPURenderState typed createinfo must be by-ref.");
+        TestAssert.True(createInfoParameter.IsIn, "SDL.CreateGPURenderState typed createinfo must keep in metadata.");
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0xA101;
+        SDL3.SDL.GPURenderStateCreateInfo createInfo = new()
+        {
+            FragmentShader = (IntPtr)0xA111,
+            NumSamplerBindings = 2,
+            SamplerBindings = (IntPtr)0xA112,
+            NumStorageTextures = 3,
+            StorageTextures = (IntPtr)0xA113,
+            NumStorageBuffers = 4,
+            StorageBuffers = (IntPtr)0xA114,
+            Props = 0xA115u
+        };
+
+        using (NativeHookScope _ = NativeHookScope.Install("CreateGPURenderStateNativeFunction", nameof(CaptureCreateGPURenderStateCreateInfo)))
+        {
+            IntPtr result = SDL3.SDL.CreateGPURenderState((IntPtr)0xA110, in createInfo);
+
+            TestAssert.Equal((IntPtr)0xA101, result, "SDL.CreateGPURenderState typed overload must return the native hook value.");
+            TestAssert.Equal((IntPtr)0xA110, capturedRenderer, "SDL.CreateGPURenderState typed overload must forward renderer.");
+            TestAssert.True(capturedCreateInfo != IntPtr.Zero, "SDL.CreateGPURenderState typed overload must pass a create-info pointer.");
+            TestAssert.Equal(createInfo.FragmentShader, capturedGPURenderStateCreateInfo.FragmentShader, "SDL.CreateGPURenderState must forward FragmentShader.");
+            TestAssert.Equal(createInfo.NumSamplerBindings, capturedGPURenderStateCreateInfo.NumSamplerBindings, "SDL.CreateGPURenderState must forward NumSamplerBindings.");
+            TestAssert.Equal(createInfo.SamplerBindings, capturedGPURenderStateCreateInfo.SamplerBindings, "SDL.CreateGPURenderState must forward SamplerBindings.");
+            TestAssert.Equal(createInfo.NumStorageTextures, capturedGPURenderStateCreateInfo.NumStorageTextures, "SDL.CreateGPURenderState must forward NumStorageTextures.");
+            TestAssert.Equal(createInfo.StorageTextures, capturedGPURenderStateCreateInfo.StorageTextures, "SDL.CreateGPURenderState must forward StorageTextures.");
+            TestAssert.Equal(createInfo.NumStorageBuffers, capturedGPURenderStateCreateInfo.NumStorageBuffers, "SDL.CreateGPURenderState must forward NumStorageBuffers.");
+            TestAssert.Equal(createInfo.StorageBuffers, capturedGPURenderStateCreateInfo.StorageBuffers, "SDL.CreateGPURenderState must forward StorageBuffers.");
+            TestAssert.Equal(createInfo.Props, capturedGPURenderStateCreateInfo.Props, "SDL.CreateGPURenderState must forward Props.");
+        }
+    }
+
     public static void GpuRenderStateFunctions_ForwardPointersArraysAndReturnNativeValues()
     {
         ResetCaptureState();
@@ -3660,6 +3709,14 @@ internal static class PInvokeTests
         return nextPointer;
     }
 
+    private static IntPtr CaptureCreateGPURenderStateCreateInfo(IntPtr renderer, IntPtr createinfo)
+    {
+        capturedRenderer = renderer;
+        capturedCreateInfo = createinfo;
+        capturedGPURenderStateCreateInfo = Marshal.PtrToStructure<SDL3.SDL.GPURenderStateCreateInfo>(createinfo);
+        return nextPointer;
+    }
+
     private static bool CaptureSetGPURenderStateFragmentUniforms(IntPtr state, uint slotIndex, IntPtr data, uint length)
     {
         capturedState = state;
@@ -4096,6 +4153,7 @@ internal static class PInvokeTests
         capturedPixels = IntPtr.Zero;
         capturedState = IntPtr.Zero;
         capturedCreateInfo = IntPtr.Zero;
+        capturedGPURenderStateCreateInfo = default;
         capturedData = IntPtr.Zero;
         capturedYPlane = IntPtr.Zero;
         capturedUPlane = IntPtr.Zero;

--- a/SDL3-CS/SDL/Video/render/GPURenderStateCreateInfo.cs
+++ b/SDL3-CS/SDL/Video/render/GPURenderStateCreateInfo.cs
@@ -1,0 +1,78 @@
+#region License
+/* Copyright (c) 2024-2026 Eduard Gushchin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+#endregion
+
+using System.Runtime.InteropServices;
+
+namespace SDL3;
+
+public static partial class SDL
+{
+    /// <summary>
+    /// A structure specifying the parameters of a GPU render state.
+    /// </summary>
+    /// <since>This struct is available since SDL 3.4.0.</since>
+    /// <seealso cref="CreateGPURenderState(nint, in GPURenderStateCreateInfo)"/>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct GPURenderStateCreateInfo
+    {
+        /// <summary>
+        /// The fragment shader to use when this render state is active.
+        /// </summary>
+        public IntPtr FragmentShader;
+
+        /// <summary>
+        /// The number of additional fragment samplers to bind when this render state is active.
+        /// </summary>
+        public int NumSamplerBindings;
+
+        /// <summary>
+        /// Additional fragment samplers to bind when this render state is active.
+        /// </summary>
+        public IntPtr SamplerBindings;
+
+        /// <summary>
+        /// The number of storage textures to bind when this render state is active.
+        /// </summary>
+        public int NumStorageTextures;
+
+        /// <summary>
+        /// Storage textures to bind when this render state is active.
+        /// </summary>
+        public IntPtr StorageTextures;
+
+        /// <summary>
+        /// The number of storage buffers to bind when this render state is active.
+        /// </summary>
+        public int NumStorageBuffers;
+
+        /// <summary>
+        /// Storage buffers to bind when this render state is active.
+        /// </summary>
+        public IntPtr StorageBuffers;
+
+        /// <summary>
+        /// A properties ID for extensions. Should be <c>0</c> if no extensions are needed.
+        /// </summary>
+        public uint Props;
+    }
+}

--- a/SDL3-CS/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/render/PInvoke.cs
@@ -253,7 +253,7 @@ public static partial class SDL
     /// <seealso cref="CreateRendererWithProperties"/>
     /// <seealso cref="GetGPURendererDevice"/>
     /// <seealso cref="CreateGPUShader"/>
-    /// <seealso cref="CreateGPURenderState"/>
+    /// <seealso cref="CreateGPURenderState(nint, in GPURenderStateCreateInfo)"/>
     /// <seealso cref="SetGPURenderState"/>
     public static IntPtr CreateGPURenderer(IntPtr device, IntPtr window)
     {
@@ -5468,7 +5468,7 @@ public static partial class SDL
     /// <para>Create custom GPU render state.</para>
     /// </summary>
     /// <param name="renderer">the renderer to use.</param>
-    /// <param name="createinfo">a struct describing the GPU render state to create.</param>
+    /// <param name="createinfo">a pointer to a <see cref="GPURenderStateCreateInfo"/> describing the GPU render state to create.</param>
     /// <returns>a custom GPU render state or <c>null</c> on failure; call <see cref="GetError"/>
     /// for more information.</returns>
     /// <threadsafety>This function should be called on the thread that created the
@@ -5480,6 +5480,17 @@ public static partial class SDL
     public static IntPtr CreateGPURenderState(IntPtr renderer, IntPtr createinfo)
     {
         return CreateGPURenderStateNativeFunction(renderer, createinfo);
+    }
+
+    /// <inheritdoc cref="CreateGPURenderState(nint, nint)"/>
+    /// <param name="renderer">the renderer to use.</param>
+    /// <param name="createinfo">a <see cref="GPURenderStateCreateInfo"/> describing the GPU render state to create.</param>
+    public static unsafe IntPtr CreateGPURenderState(IntPtr renderer, in GPURenderStateCreateInfo createinfo)
+    {
+        fixed (GPURenderStateCreateInfo* createInfoPointer = &createinfo)
+        {
+            return CreateGPURenderStateNativeFunction(renderer, (IntPtr)createInfoPointer);
+        }
     }
 
 


### PR DESCRIPTION
## Summary

- add the managed `SDL.GPURenderStateCreateInfo` binding with ABI-compatible sequential layout;
- add a typed `SDL.CreateGPURenderState(nint, in GPURenderStateCreateInfo)` overload;
- preserve the existing raw-pointer overload for source and binary compatibility;
- add mirrored layout, signature, forwarding, and compatibility tests.

## Validation

- tests-first compile-time reproduction;
- focused and full managed test runner;
- wrapper Release builds for net7.0, net8.0, net9.0, and net10.0;
- public XML documentation audit;
- native x64 ABI layout comparison;
- 100% line and branch coverage for the new managed path.

## Tracking

Related to issue 208.

This PR prepares the fix for the next eligible patch release. Issue 208 remains open until publication, and release timing remains governed by the repository release policy.