### PR TITLE
fix: correct DownloadFromGPUBuffer source region

### DIFF
--- a/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
@@ -1742,17 +1742,22 @@ internal static class PInvokeTests
         AssertSdlLibraryImport(nativeMethod, "SDL_DownloadFromGPUBuffer");
         AssertByRefParameter(nativeMethod, "source");
         AssertByRefParameter(nativeMethod, "destination");
+        ParameterInfo sourceParameter = nativeMethod.GetParameters().Single(parameter => parameter.Name == "source");
+        TestAssert.Equal(typeof(SDL3.SDL.GPUBufferRegion).MakeByRefType(), sourceParameter.ParameterType, "SDL_DownloadFromGPUBuffer source must be a by-ref GPUBufferRegion.");
 
         ResetCaptureState();
         using NativeHookScope _ = NativeHookScope.Install("DownloadFromGPUBufferNativeFunction", nameof(CaptureDownloadFromGPUBuffer));
-        SDL3.SDL.GPUTextureRegion source = CreateTextureRegion((IntPtr)5801);
+        SDL3.SDL.GPUBufferRegion source = CreateBufferRegion((IntPtr)5801);
         SDL3.SDL.GPUTransferBufferLocation destination = CreateTransferBufferLocation((IntPtr)5802);
 
         SDL3.SDL.DownloadFromGPUBuffer((IntPtr)5803, in source, in destination);
 
         TestAssert.Equal((IntPtr)5803, capturedCopyPass, "SDL.DownloadFromGPUBuffer must forward copyPass.");
-        TestAssert.Equal(source.Texture, capturedTextureRegion.Texture, "SDL.DownloadFromGPUBuffer must forward source region.");
+        TestAssert.Equal(source.Buffer, capturedBufferRegion.Buffer, "SDL.DownloadFromGPUBuffer must forward source buffer.");
+        TestAssert.Equal(source.Offset, capturedBufferRegion.Offset, "SDL.DownloadFromGPUBuffer must forward source offset.");
+        TestAssert.Equal(source.Size, capturedBufferRegion.Size, "SDL.DownloadFromGPUBuffer must forward source size.");
         TestAssert.Equal(destination.TransferBuffer, capturedTransferBufferLocation.TransferBuffer, "SDL.DownloadFromGPUBuffer must forward destination transfer buffer.");
+        TestAssert.Equal(destination.Offset, capturedTransferBufferLocation.Offset, "SDL.DownloadFromGPUBuffer must forward destination offset.");
         TestAssert.Equal(1, capturedCallCount, "SDL.DownloadFromGPUBuffer must call native hook once.");
     }
 
@@ -2835,10 +2840,10 @@ internal static class PInvokeTests
         capturedCallCount++;
     }
 
-    private static void CaptureDownloadFromGPUBuffer(IntPtr copyPass, in SDL3.SDL.GPUTextureRegion source, in SDL3.SDL.GPUTransferBufferLocation destination)
+    private static void CaptureDownloadFromGPUBuffer(IntPtr copyPass, in SDL3.SDL.GPUBufferRegion source, in SDL3.SDL.GPUTransferBufferLocation destination)
     {
         capturedCopyPass = copyPass;
-        capturedTextureRegion = source;
+        capturedBufferRegion = source;
         capturedTransferBufferLocation = destination;
         capturedCallCount++;
     }

--- a/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
@@ -2627,8 +2627,8 @@ public partial class SDL
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_DownloadFromGPUBuffer"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial void SDL_DownloadFromGPUBuffer(IntPtr copyPass, in GPUTextureRegion source, in GPUTransferBufferLocation destination);
-    private delegate void DownloadFromGPUBufferNativeDelegate(IntPtr copyPass, in GPUTextureRegion source, in GPUTransferBufferLocation destination);
+    private static partial void SDL_DownloadFromGPUBuffer(IntPtr copyPass, in GPUBufferRegion source, in GPUTransferBufferLocation destination);
+    private delegate void DownloadFromGPUBufferNativeDelegate(IntPtr copyPass, in GPUBufferRegion source, in GPUTransferBufferLocation destination);
     private static DownloadFromGPUBufferNativeDelegate DownloadFromGPUBufferNativeFunction = SDL_DownloadFromGPUBuffer;
 
     /// <code>extern SDL_DECLSPEC void SDLCALL SDL_DownloadFromGPUBuffer(SDL_GPUCopyPass *copy_pass, const SDL_GPUBufferRegion *source, const SDL_GPUTransferBufferLocation *destination);</code>
@@ -2641,7 +2641,7 @@ public partial class SDL
     /// <param name="source">the source buffer with offset and size.</param>
     /// <param name="destination">the destination transfer buffer with offset.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    public static void DownloadFromGPUBuffer(IntPtr copyPass, in GPUTextureRegion source, in GPUTransferBufferLocation destination)
+    public static void DownloadFromGPUBuffer(IntPtr copyPass, in GPUBufferRegion source, in GPUTransferBufferLocation destination)
     {
         DownloadFromGPUBufferNativeFunction(copyPass, in source, in destination);
     }


### PR DESCRIPTION
## Summary

- correct `SDL.DownloadFromGPUBuffer` so `source` uses `GPUBufferRegion` in the import, hook delegate, and public API;
- add mirrored ABI metadata and forwarding regression coverage.

## Verification

- `dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore`
- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- coverage report: `DownloadFromGPUBuffer` has 100% block and line coverage.

Relates to #221.