### PR TITLE
feat: add mixed CreateAudioStream overloads

### DIFF
--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -640,6 +640,10 @@ SDL3.Tests.SDL.Audio.Audio.PInvokeTests.CreateAudioStream_WithPointers_ForwardsS
 Console.WriteLine("SDL.CreateAudioStream(IntPtr, IntPtr) binding test passed.");
 SDL3.Tests.SDL.Audio.Audio.PInvokeTests.CreateAudioStream_WithSpecs_ForwardsSpecs();
 Console.WriteLine("SDL.CreateAudioStream(in AudioSpec, in AudioSpec) binding test passed.");
+SDL3.Tests.SDL.Audio.Audio.PInvokeTests.CreateAudioStream_WithSourceSpecAndDestinationPointer_ForwardsSpecs();
+Console.WriteLine("SDL.CreateAudioStream(in AudioSpec, IntPtr) binding test passed.");
+SDL3.Tests.SDL.Audio.Audio.PInvokeTests.CreateAudioStream_WithSourcePointerAndDestinationSpec_ForwardsSpecs();
+Console.WriteLine("SDL.CreateAudioStream(IntPtr, in AudioSpec) binding test passed.");
 SDL3.Tests.SDL.Audio.Audio.PInvokeTests.GetAudioStreamProperties_ReturnsNativeValue();
 Console.WriteLine("SDL.GetAudioStreamProperties binding test passed.");
 SDL3.Tests.SDL.Audio.Audio.PInvokeTests.GetAudioStreamFormat_ForwardsStreamAndOutputs();

--- a/SDL3-CS.Tests/SDL/Audio/audio/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Audio/audio/PInvoke.cs
@@ -466,6 +466,38 @@ internal static class PInvokeTests
         AssertAudioSpec(dstSpec, capturedDstSpec, "SDL.CreateAudioStream(in AudioSpec, in AudioSpec) must forward dst spec.");
     }
 
+    public static void CreateAudioStream_WithSourceSpecAndDestinationPointer_ForwardsSpecs()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_CreateAudioStream", [typeof(SDL3.SDL.AudioSpec).MakeByRefType(), typeof(IntPtr)]);
+        AssertSdlLibraryImport(nativeMethod, "SDL_CreateAudioStream");
+
+        nextPointer = (IntPtr)304;
+        SDL3.SDL.AudioSpec srcSpec = CreateAudioSpec(SDL3.SDL.AudioFormat.AudioS16LE, 1, 22050);
+
+        using NativeHookScope _ = NativeHookScope.Install("CreateAudioStreamWithSourceSpecAndDestinationPointerNativeFunction", nameof(CaptureCreateAudioStreamWithSourceSpecAndDestinationPointer));
+        IntPtr result = SDL3.SDL.CreateAudioStream(in srcSpec, IntPtr.Zero);
+
+        TestAssert.Equal((IntPtr)304, result, "SDL.CreateAudioStream(in AudioSpec, IntPtr) must return the native hook stream.");
+        AssertAudioSpec(srcSpec, capturedSrcSpec, "SDL.CreateAudioStream(in AudioSpec, IntPtr) must forward src spec.");
+        TestAssert.Equal(IntPtr.Zero, capturedDstSpecPointer, "SDL.CreateAudioStream(in AudioSpec, IntPtr) must forward dst spec pointer.");
+    }
+
+    public static void CreateAudioStream_WithSourcePointerAndDestinationSpec_ForwardsSpecs()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_CreateAudioStream", [typeof(IntPtr), typeof(SDL3.SDL.AudioSpec).MakeByRefType()]);
+        AssertSdlLibraryImport(nativeMethod, "SDL_CreateAudioStream");
+
+        nextPointer = (IntPtr)305;
+        SDL3.SDL.AudioSpec dstSpec = CreateAudioSpec(SDL3.SDL.AudioFormat.AudioF32LE, 2, 48000);
+
+        using NativeHookScope _ = NativeHookScope.Install("CreateAudioStreamWithSourcePointerAndDestinationSpecNativeFunction", nameof(CaptureCreateAudioStreamWithSourcePointerAndDestinationSpec));
+        IntPtr result = SDL3.SDL.CreateAudioStream(IntPtr.Zero, in dstSpec);
+
+        TestAssert.Equal((IntPtr)305, result, "SDL.CreateAudioStream(IntPtr, in AudioSpec) must return the native hook stream.");
+        TestAssert.Equal(IntPtr.Zero, capturedSrcSpecPointer, "SDL.CreateAudioStream(IntPtr, in AudioSpec) must forward src spec pointer.");
+        AssertAudioSpec(dstSpec, capturedDstSpec, "SDL.CreateAudioStream(IntPtr, in AudioSpec) must forward dst spec.");
+    }
+
     public static void GetAudioStreamProperties_ReturnsNativeValue()
     {
         MethodInfo nativeMethod = GetNativeMethod("SDL_GetAudioStreamProperties");
@@ -1292,6 +1324,20 @@ internal static class PInvokeTests
     private static IntPtr CaptureCreateAudioStreamWithSpecs(in SDL3.SDL.AudioSpec srcSpec, in SDL3.SDL.AudioSpec dstSpec)
     {
         capturedSrcSpec = srcSpec;
+        capturedDstSpec = dstSpec;
+        return nextPointer;
+    }
+
+    private static IntPtr CaptureCreateAudioStreamWithSourceSpecAndDestinationPointer(in SDL3.SDL.AudioSpec srcSpec, IntPtr dstSpec)
+    {
+        capturedSrcSpec = srcSpec;
+        capturedDstSpecPointer = dstSpec;
+        return nextPointer;
+    }
+
+    private static IntPtr CaptureCreateAudioStreamWithSourcePointerAndDestinationSpec(IntPtr srcSpec, in SDL3.SDL.AudioSpec dstSpec)
+    {
+        capturedSrcSpecPointer = srcSpec;
         capturedDstSpec = dstSpec;
         return nextPointer;
     }

--- a/SDL3-CS/SDL/Audio/audio/PInvoke.cs
+++ b/SDL3-CS/SDL/Audio/audio/PInvoke.cs
@@ -946,6 +946,72 @@ public static partial class SDL
 
 
     [ExcludeFromCodeCoverage]
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_CreateAudioStream"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr SDL_CreateAudioStream(in AudioSpec srcSpec, IntPtr dstSpec);
+    private delegate IntPtr CreateAudioStreamWithSourceSpecAndDestinationPointerNative(in AudioSpec srcSpec, IntPtr dstSpec);
+    private static CreateAudioStreamWithSourceSpecAndDestinationPointerNative CreateAudioStreamWithSourceSpecAndDestinationPointerNativeFunction = SDL_CreateAudioStream;
+
+    /// <code>extern SDL_DECLSPEC SDL_AudioStream * SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);</code>
+    /// <summary>
+    /// <para>Create a new audio stream.</para>
+    /// <para>SDL_AudioStream is an audio conversion interface. You push data as you have
+    /// it, and pull it when you need it; the stream will buffer data as needed.</para>
+    /// <para>Pass <c>IntPtr.Zero</c> for <c>dstSpec</c> to leave the output format unset.
+    /// Attempts to put or get data from the stream will fail until it has valid specs
+    /// assigned to both ends. Specs can be assigned later through
+    /// <see cref="SetAudioStreamFormat(nint, nint, nint)"/>, or binding the stream to an
+    /// audio device.</para>
+    /// </summary>
+    /// <param name="srcSpec">the format details of the input audio.</param>
+    /// <param name="dstSpec">the format details of the output audio, or <c>IntPtr.Zero</c>.</param>
+    /// <returns>a new audio stream on success or <c>null</c> on failure; call
+    /// <see cref="GetError"/> for more information.</returns>
+    /// <threadsafety>It is safe to call this function from any thread.</threadsafety>
+    /// <since>This function is available since SDL 3.2.0.</since>
+    /// <seealso cref="CreateAudioStream(nint, nint)"/>
+    /// <seealso cref="CreateAudioStream(nint, in AudioSpec)"/>
+    /// <seealso cref="CreateAudioStream(in AudioSpec, in AudioSpec)"/>
+    /// <seealso cref="SetAudioStreamFormat(nint, nint, nint)"/>
+    public static IntPtr CreateAudioStream(in AudioSpec srcSpec, IntPtr dstSpec)
+    {
+        return CreateAudioStreamWithSourceSpecAndDestinationPointerNativeFunction(in srcSpec, dstSpec);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    [LibraryImport(SDLLibrary, EntryPoint = "SDL_CreateAudioStream"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+    private static partial IntPtr SDL_CreateAudioStream(IntPtr srcSpec, in AudioSpec dstSpec);
+    private delegate IntPtr CreateAudioStreamWithSourcePointerAndDestinationSpecNative(IntPtr srcSpec, in AudioSpec dstSpec);
+    private static CreateAudioStreamWithSourcePointerAndDestinationSpecNative CreateAudioStreamWithSourcePointerAndDestinationSpecNativeFunction = SDL_CreateAudioStream;
+
+    /// <code>extern SDL_DECLSPEC SDL_AudioStream * SDLCALL SDL_CreateAudioStream(const SDL_AudioSpec *src_spec, const SDL_AudioSpec *dst_spec);</code>
+    /// <summary>
+    /// <para>Create a new audio stream.</para>
+    /// <para>SDL_AudioStream is an audio conversion interface. You push data as you have
+    /// it, and pull it when you need it; the stream will buffer data as needed.</para>
+    /// <para>Pass <c>IntPtr.Zero</c> for <c>srcSpec</c> to leave the input format unset.
+    /// Attempts to put or get data from the stream will fail until it has valid specs
+    /// assigned to both ends. Specs can be assigned later through
+    /// <see cref="SetAudioStreamFormat(nint, nint, nint)"/>, or binding the stream to an
+    /// audio device.</para>
+    /// </summary>
+    /// <param name="srcSpec">the format details of the input audio, or <c>IntPtr.Zero</c>.</param>
+    /// <param name="dstSpec">the format details of the output audio.</param>
+    /// <returns>a new audio stream on success or <c>null</c> on failure; call
+    /// <see cref="GetError"/> for more information.</returns>
+    /// <threadsafety>It is safe to call this function from any thread.</threadsafety>
+    /// <since>This function is available since SDL 3.2.0.</since>
+    /// <seealso cref="CreateAudioStream(nint, nint)"/>
+    /// <seealso cref="CreateAudioStream(in AudioSpec, nint)"/>
+    /// <seealso cref="CreateAudioStream(in AudioSpec, in AudioSpec)"/>
+    /// <seealso cref="SetAudioStreamFormat(nint, nint, nint)"/>
+    public static IntPtr CreateAudioStream(IntPtr srcSpec, in AudioSpec dstSpec)
+    {
+        return CreateAudioStreamWithSourcePointerAndDestinationSpecNativeFunction(srcSpec, in dstSpec);
+    }
+
+
+    [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_GetAudioStreamProperties"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     private static partial uint SDL_GetAudioStreamProperties(IntPtr stream);
     private delegate uint GetAudioStreamPropertiesNative(IntPtr stream);


### PR DESCRIPTION
## Summary
- add typed/pointer CreateAudioStream overloads for either nullable spec side
- preserve existing pointer and typed overloads
- add ABI metadata and forwarding regression coverage

## Verification
- dotnet build .\\SDL3-CS.Tests\\SDL3-CS.Tests.csproj -c Release --no-restore
- dotnet run --project .\\SDL3-CS.Tests\\SDL3-CS.Tests.csproj -c Release --no-build --no-restore
- dotnet build .\\SDL3-CS\\SDL3-CS.csproj -c Release --no-restore
- pwsh .\\.github\\release-tools\\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\\SDL3-CS
- dotnet-coverage collect (issue-223)