### PR TITLE
fix: align PointInRectFloat boundaries

### DIFF
--- a/SDL3-CS.Tests/SDL/Video/rect/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/rect/PInvoke.cs
@@ -53,6 +53,7 @@ internal static class PInvokeTests
         GetRectEnclosingPoints_WithRectClipForwardsArrayClipAndResult();
         GetRectAndLineIntersection_ForwardsLineMutatesCoordinatesAndReturnsNativeValue();
         PointInRectFloat_ReturnsExpectedValuesForNullsAndEdges();
+        PointInRectFloat_NonNullableOverloadReturnsExpectedValuesForEdges();
         RectEmptyFloat_ReturnsExpectedValuesForNullAndNonPositiveSize();
         RectsEqualEpsilon_ReturnsExpectedValuesForNullsAndFieldDifferences();
         RectsEqualFloat_UsesDefaultEpsilon();
@@ -307,17 +308,47 @@ internal static class PInvokeTests
         SDL3.SDL.FPoint? topLeft = CreateFPoint(10.0f, 20.0f);
         SDL3.SDL.FPoint? beforeLeft = CreateFPoint(9.99f, 23.5f);
         SDL3.SDL.FPoint? rightEdge = CreateFPoint(15.0f, 23.5f);
+        SDL3.SDL.FPoint? afterRight = CreateFPoint(15.01f, 23.5f);
         SDL3.SDL.FPoint? aboveTop = CreateFPoint(12.5f, 19.99f);
         SDL3.SDL.FPoint? bottomEdge = CreateFPoint(12.5f, 26.0f);
+        SDL3.SDL.FPoint? belowBottom = CreateFPoint(12.5f, 26.01f);
+        SDL3.SDL.FPoint? bottomRight = CreateFPoint(15.0f, 26.0f);
 
         TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in noPoint, in rect), "SDL.PointInRectFloat must reject a null point.");
         TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in inside, in noRect), "SDL.PointInRectFloat must reject a null rect.");
         TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in inside, in rect), "SDL.PointInRectFloat must accept an interior point.");
         TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in topLeft, in rect), "SDL.PointInRectFloat must include the top-left edge.");
         TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in beforeLeft, in rect), "SDL.PointInRectFloat must reject points before the left edge.");
-        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in rightEdge, in rect), "SDL.PointInRectFloat must reject the right edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in rightEdge, in rect), "SDL.PointInRectFloat must include the right edge.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in afterRight, in rect), "SDL.PointInRectFloat must reject points after the right edge.");
         TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in aboveTop, in rect), "SDL.PointInRectFloat must reject points above the top edge.");
-        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in bottomEdge, in rect), "SDL.PointInRectFloat must reject the bottom edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in bottomEdge, in rect), "SDL.PointInRectFloat must include the bottom edge.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in belowBottom, in rect), "SDL.PointInRectFloat must reject points below the bottom edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in bottomRight, in rect), "SDL.PointInRectFloat must include the bottom-right corner.");
+    }
+
+    public static void PointInRectFloat_NonNullableOverloadReturnsExpectedValuesForEdges()
+    {
+        SDL3.SDL.FRect rect = CreateFRect(10.0f, 20.0f, 5.0f, 6.0f);
+        SDL3.SDL.FPoint inside = CreateFPoint(12.5f, 23.5f);
+        SDL3.SDL.FPoint topLeft = CreateFPoint(10.0f, 20.0f);
+        SDL3.SDL.FPoint rightEdge = CreateFPoint(15.0f, 23.5f);
+        SDL3.SDL.FPoint bottomEdge = CreateFPoint(12.5f, 26.0f);
+        SDL3.SDL.FPoint bottomRight = CreateFPoint(15.0f, 26.0f);
+        SDL3.SDL.FPoint beforeLeft = CreateFPoint(9.99f, 23.5f);
+        SDL3.SDL.FPoint afterRight = CreateFPoint(15.01f, 23.5f);
+        SDL3.SDL.FPoint aboveTop = CreateFPoint(12.5f, 19.99f);
+        SDL3.SDL.FPoint belowBottom = CreateFPoint(12.5f, 26.01f);
+
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in inside, in rect), "SDL.PointInRectFloat non-nullable overload must accept an interior point.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in topLeft, in rect), "SDL.PointInRectFloat non-nullable overload must include the top-left edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in rightEdge, in rect), "SDL.PointInRectFloat non-nullable overload must include the right edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in bottomEdge, in rect), "SDL.PointInRectFloat non-nullable overload must include the bottom edge.");
+        TestAssert.Equal(true, SDL3.SDL.PointInRectFloat(in bottomRight, in rect), "SDL.PointInRectFloat non-nullable overload must include the bottom-right corner.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in beforeLeft, in rect), "SDL.PointInRectFloat non-nullable overload must reject points before the left edge.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in afterRight, in rect), "SDL.PointInRectFloat non-nullable overload must reject points after the right edge.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in aboveTop, in rect), "SDL.PointInRectFloat non-nullable overload must reject points above the top edge.");
+        TestAssert.Equal(false, SDL3.SDL.PointInRectFloat(in belowBottom, in rect), "SDL.PointInRectFloat non-nullable overload must reject points below the bottom edge.");
     }
 
     public static void RectEmptyFloat_ReturnsExpectedValuesForNullAndNonPositiveSize()

--- a/SDL3-CS/SDL/Video/rect/FPoint.cs
+++ b/SDL3-CS/SDL/Video/rect/FPoint.cs
@@ -32,7 +32,7 @@ public static partial class SDL
     /// </summary>
     /// <since>This struct is available since SDL 3.2.0</since>
     /// <seealso cref="GetRectEnclosingPointsFloat(FPoint[], int, IntPtr, out FRect)"/>
-    /// <seealso cref="PointInRectFloat"/>
+    /// <seealso cref="PointInRectFloat(in FPoint, in FRect)"/>
     [StructLayout(LayoutKind.Sequential)]
     public struct FPoint
     {

--- a/SDL3-CS/SDL/Video/rect/FRect.cs
+++ b/SDL3-CS/SDL/Video/rect/FRect.cs
@@ -42,7 +42,7 @@ public static partial class SDL
     /// <seealso cref="GetRectAndLineIntersectionFloat"/>
     /// <seealso cref="GetRectUnionFloat"/>
     /// <seealso cref="GetRectEnclosingPointsFloat(FPoint[], int, IntPtr, out FRect)"/>
-    /// <seealso cref="PointInRectFloat"/>
+    /// <seealso cref="PointInRectFloat(in FPoint, in FRect)"/>
     [StructLayout(LayoutKind.Sequential)]
     public struct FRect
     {

--- a/SDL3-CS/SDL/Video/rect/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/rect/PInvoke.cs
@@ -335,8 +335,22 @@ public static partial class SDL
     public static bool PointInRectFloat(in FPoint? p, in FRect? r)
     {
         return (p.HasValue && r.HasValue &&
-                p.Value.X >= r.Value.X && p.Value.X < (r.Value.X + r.Value.W) &&
-                p.Value.Y >= r.Value.Y && p.Value.Y < (r.Value.Y + r.Value.H));
+                p.Value.X >= r.Value.X && p.Value.X <= (r.Value.X + r.Value.W) &&
+                p.Value.Y >= r.Value.Y && p.Value.Y <= (r.Value.Y + r.Value.H));
+    }
+
+    /// <summary>
+    /// Determines whether a non-nullable point resides inside a floating point rectangle.
+    /// </summary>
+    /// <param name="p">the point to test.</param>
+    /// <param name="r">the rectangle to test.</param>
+    /// <returns><c>true</c> if <c>p</c> is contained by <c>r</c>, <c>false</c> otherwise.</returns>
+    /// <threadsafety>It is safe to call this function from any thread.</threadsafety>
+    /// <since>This overload is available since SDL3-CS 3.4.12.4.</since>
+    public static bool PointInRectFloat(in FPoint p, in FRect r)
+    {
+        return (p.X >= r.X && p.X <= (r.X + r.W) &&
+                p.Y >= r.Y && p.Y <= (r.Y + r.H));
     }
 
 


### PR DESCRIPTION
## Что изменено

- `PointInRectFloat(in FPoint?, in FRect?)` теперь включает правую и нижнюю границы, как `SDL_PointInRectFloat`.
- Добавлен совместимый non-nullable overload для `FPoint`/`FRect` без `Nullable<T>` overhead.
- Mirrored tests покрывают null, внутреннюю область, все границы и значения за прямоугольником.
- Уточнены XML `cref` для нового overload.

## Проверки

- `dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build`
- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- coverage: оба overload и mirrored tests имеют line-rate/branch-rate `1/1`

Refs #225. Публикация package остаётся отдельным решением maintainer.