### PR TITLE
fix: include libwebp license in image packages

### DIFF
--- a/.github/release-tools/Test-ImageLibwebpLicenses.ps1
+++ b/.github/release-tools/Test-ImageLibwebpLicenses.ps1
@@ -1,0 +1,102 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $RepositoryRoot = (Join-Path $PSScriptRoot '../..'),
+    [string[]] $PackagePaths
+)
+
+$repoRoot = [System.IO.Path]::GetFullPath($RepositoryRoot)
+$licenseRelativePath = 'SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING'
+$licensePath = Join-Path $repoRoot $licenseRelativePath
+$projectRelativePaths = @(
+    'SDL3-CS.NativePackages/SDL3-CS.Android.Image/SDL3-CS.Android.Image.csproj',
+    'SDL3-CS.NativePackages/SDL3-CS.Linux.Image/SDL3-CS.Linux.Image.csproj',
+    'SDL3-CS.NativePackages/SDL3-CS.Windows.Image/SDL3-CS.Windows.Image.csproj'
+)
+$excludedProjectRelativePaths = @(
+    'SDL3-CS.NativePackages/SDL3-CS.iOS.Image/SDL3-CS.iOS.Image.csproj',
+    'SDL3-CS.NativePackages/SDL3-CS.MacOS.Image/SDL3-CS.MacOS.Image.csproj',
+    'SDL3-CS.NativePackages/SDL3-CS.tvOS.Image/SDL3-CS.tvOS.Image.csproj'
+)
+$expectedInclude = '../ThirdPartyLicenses/libwebp/COPYING'
+$expectedPackagePath = 'licenses/libwebp'
+$expectedPackageEntry = 'licenses/libwebp/COPYING'
+$errors = New-Object System.Collections.Generic.List[string]
+
+if (-not (Test-Path -LiteralPath $licensePath -PathType Leaf)) {
+    $errors.Add("Missing libwebp license source: $licenseRelativePath")
+}
+
+foreach ($relativeProjectPath in $projectRelativePaths) {
+    $projectPath = Join-Path $repoRoot $relativeProjectPath
+    if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+        $errors.Add("Missing Image package project: $relativeProjectPath")
+        continue
+    }
+
+    $projectText = Get-Content -LiteralPath $projectPath -Raw -Encoding UTF8
+    $expectedItem = '<None Include="{0}" Pack="true" PackagePath="{1}" />' -f $expectedInclude, $expectedPackagePath
+    if (-not $projectText.Contains($expectedItem, [System.StringComparison]::Ordinal)) {
+        $errors.Add("$relativeProjectPath must pack libwebp license as $expectedPackageEntry")
+    }
+}
+
+foreach ($relativeProjectPath in $excludedProjectRelativePaths) {
+    $projectPath = Join-Path $repoRoot $relativeProjectPath
+    if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+        $errors.Add("Missing excluded Image package project: $relativeProjectPath")
+        continue
+    }
+
+    $projectText = Get-Content -LiteralPath $projectPath -Raw -Encoding UTF8
+    if ($projectText.Contains($expectedInclude, [System.StringComparison]::Ordinal)) {
+        $errors.Add("$relativeProjectPath must not pack libwebp license while WebP is disabled")
+    }
+}
+
+if ($PackagePaths) {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $expectedLicenseText = Get-Content -LiteralPath $licensePath -Raw -Encoding UTF8
+    foreach ($packagePath in $PackagePaths) {
+        $resolvedPackagePath = [System.IO.Path]::GetFullPath($packagePath)
+        if (-not (Test-Path -LiteralPath $resolvedPackagePath -PathType Leaf)) {
+            $errors.Add("Package does not exist: $resolvedPackagePath")
+            continue
+        }
+
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($resolvedPackagePath)
+        try {
+            $licenseEntry = $zip.GetEntry($expectedPackageEntry)
+            if (-not $licenseEntry) {
+                $errors.Add("Package is missing libwebp license entry: $resolvedPackagePath -> $expectedPackageEntry")
+            }
+            else {
+                $stream = $licenseEntry.Open()
+                try {
+                    $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true)
+                    try {
+                        if ($reader.ReadToEnd() -ne $expectedLicenseText) {
+                            $errors.Add("Package libwebp license entry does not match source: $resolvedPackagePath -> $expectedPackageEntry")
+                        }
+                    }
+                    finally {
+                        $reader.Dispose()
+                    }
+                }
+                finally {
+                    $stream.Dispose()
+                }
+            }
+        }
+        finally {
+            $zip.Dispose()
+        }
+    }
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "libwebp license package validation failed with $($errors.Count) error(s)."
+}
+
+Write-Host 'libwebp license package validation passed.'

--- a/.github/release-tools/Test-NuGetPackageContents.ps1
+++ b/.github/release-tools/Test-NuGetPackageContents.ps1
@@ -265,6 +265,29 @@ foreach ($package in $packages) {
         }
     }
 
+    if ($package.VersionComponent -eq 'SDL_image' -and $package.NativePackagePlatform -in @('Android', 'Linux', 'Windows')) {
+        $licenseEntry = 'licenses/libwebp/COPYING'
+        if (-not $entrySet.Contains($licenseEntry)) {
+            Add-ContentError "$($package.Id) package is missing $licenseEntry."
+            $rows.Add([pscustomobject]@{
+                PackageId = $package.Id
+                Scope = 'license'
+                Expected = $licenseEntry
+                Count = 0
+                Status = 'missing'
+            })
+        }
+        else {
+            $rows.Add([pscustomobject]@{
+                PackageId = $package.Id
+                Scope = 'license'
+                Expected = $licenseEntry
+                Count = 1
+                Status = 'present'
+            })
+        }
+    }
+
     $nativeArtifactProject = if ($package.PSObject.Properties.Name.Contains('NativeArtifactProject') -and $package.NativeArtifactProject) {
         $package.NativeArtifactProject
     }

--- a/SDL3-CS.NativePackages/SDL3-CS.Android.Image/SDL3-CS.Android.Image.csproj
+++ b/SDL3-CS.NativePackages/SDL3-CS.Android.Image/SDL3-CS.Android.Image.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <None Include="../../LICENSE" Pack="true" PackagePath="\" />
+    <None Include="../ThirdPartyLicenses/libwebp/COPYING" Pack="true" PackagePath="licenses/libwebp" />
     <None Include="../../logo.png" Pack="true" Visible="false" PackagePath="\" />
     <None Include="README.md" Pack="true" Visible="true" PackagePath="\" />
     <None Include="buildTransitive\SDL3-CS.Android.Image.targets" Pack="true" PackagePath="buildTransitive\$(PackageId).targets" />

--- a/SDL3-CS.NativePackages/SDL3-CS.Linux.Image/SDL3-CS.Linux.Image.csproj
+++ b/SDL3-CS.NativePackages/SDL3-CS.Linux.Image/SDL3-CS.Linux.Image.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <None Include="../../LICENSE" Pack="true" PackagePath="\" />
+    <None Include="../ThirdPartyLicenses/libwebp/COPYING" Pack="true" PackagePath="licenses/libwebp" />
     <None Include="../../logo.png" Pack="true" Visible="false" PackagePath="\" />
     <None Include="README.md" Pack="true" Visible="true" PackagePath="\" />
     <None Include="buildTransitive\SDL3-CS.Linux.Image.targets" Pack="true" PackagePath="buildTransitive\$(PackageId).targets" />

--- a/SDL3-CS.NativePackages/SDL3-CS.Windows.Image/SDL3-CS.Windows.Image.csproj
+++ b/SDL3-CS.NativePackages/SDL3-CS.Windows.Image/SDL3-CS.Windows.Image.csproj
@@ -44,6 +44,7 @@
 
   <ItemGroup>
     <None Include="../../LICENSE" Pack="true" PackagePath="\" />
+    <None Include="../ThirdPartyLicenses/libwebp/COPYING" Pack="true" PackagePath="licenses/libwebp" />
     <None Include="../../logo.png" Pack="true" Visible="false" PackagePath="\" />
     <None Include="README.md" Pack="true" Visible="true" PackagePath="\" />
     <None Include="buildTransitive\SDL3-CS.Windows.Image.targets" Pack="true" PackagePath="buildTransitive\$(PackageId).targets" />

--- a/SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING
+++ b/SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING
@@ -1,0 +1,29 @@
+Copyright (c) 2010, Google Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+  * Neither the name of Google nor the names of its contributors may
+    be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary`n- add the libwebp license to Android, Linux, and Windows SDL_image native packages`n- validate the license entry in release package-content checks`n- add a focused source/package regression validator`n`n## Validation`n- `pwsh ./.github/release-tools/Test-ImageLibwebpLicenses.ps1 -PackagePaths ./.agents/issue-226/nuget/SDL3-CS.Windows.Image.3.4.4.nupkg``n- `dotnet pack ./SDL3-CS.NativePackages/SDL3-CS.Windows.Image/SDL3-CS.Windows.Image.csproj -c Release --no-restore -o ./.agents/issue-226/nuget`