### PR TITLE
Release: prepare SDL3-CS 3.4.12.4

### DIFF
--- a/.github/release-tools/New-NativePackageRepack.ps1
+++ b/.github/release-tools/New-NativePackageRepack.ps1
@@ -1,0 +1,294 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int] $PackageRevision,
+    [Parameter(Mandatory)][int] $PreviousPackageRevision,
+    [Parameter(Mandatory)][string[]] $PackageIds,
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $OutputDir,
+    [string] $PreviousPackageDir,
+    [string] $AdditionalFilePath = 'SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING',
+    [string] $AdditionalPackagePath = 'licenses/libwebp/COPYING',
+    [string] $RepositoryCommit,
+    [switch] $SkipSourceSignatureValidation
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+function Get-PackageUri {
+    param([Parameter(Mandatory)][object] $Package)
+
+    $id = $Package.Id.ToLowerInvariant()
+    $version = (Get-ReleaseNormalizedNuGetVersion -PackageVersion $Package.PackageVersion).ToLowerInvariant()
+    return "https://api.nuget.org/v3-flatcontainer/$id/$version/$id.$version.nupkg"
+}
+
+function Get-EntryBytes {
+    param([Parameter(Mandatory)][System.IO.Compression.ZipArchiveEntry] $Entry)
+
+    $stream = $Entry.Open()
+    try {
+        $memory = [System.IO.MemoryStream]::new()
+        try {
+            $stream.CopyTo($memory)
+            return $memory.ToArray()
+        }
+        finally {
+            $memory.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Set-XmlElementValue {
+    param(
+        [Parameter(Mandatory)][xml] $Xml,
+        [Parameter(Mandatory)][string] $LocalName,
+        [Parameter(Mandatory)][string] $Value
+    )
+
+    $nodes = @($Xml.SelectNodes("//*[local-name()='$LocalName']"))
+    if ($nodes.Count -ne 1) {
+        throw "Expected exactly one XML element '$LocalName', got $($nodes.Count)."
+    }
+    $nodes[0].InnerText = $Value
+}
+
+function Convert-XmlToBytes {
+    param([Parameter(Mandatory)][xml] $Xml)
+
+    $settings = [System.Xml.XmlWriterSettings]::new()
+    $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+    $settings.Indent = $true
+    $settings.NewLineChars = "`r`n"
+    $settings.NewLineHandling = [System.Xml.NewLineHandling]::Replace
+    $memory = [System.IO.MemoryStream]::new()
+    try {
+        $writer = [System.Xml.XmlWriter]::Create($memory, $settings)
+        try {
+            $Xml.Save($writer)
+        }
+        finally {
+            $writer.Dispose()
+        }
+        return $memory.ToArray()
+    }
+    finally {
+        $memory.Dispose()
+    }
+}
+
+function Convert-BytesToXml {
+    param([Parameter(Mandatory)][byte[]] $Bytes)
+
+    $memory = [System.IO.MemoryStream]::new($Bytes, $false)
+    try {
+        $document = [System.Xml.XmlDocument]::new()
+        $document.PreserveWhitespace = $false
+        $document.Load($memory)
+        return $document
+    }
+    finally {
+        $memory.Dispose()
+    }
+}
+
+if ($PackageRevision -lt 0 -or $PreviousPackageRevision -lt 0) {
+    throw 'Package revisions must be zero or greater.'
+}
+if (-not $PackageIds -or $PackageIds.Count -eq 0) {
+    throw 'PackageIds must select at least one native package.'
+}
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+if (-not $OutputDir) {
+    $OutputDir = Join-Path (Resolve-ReleasePath $manifest.artifactsRoot) 'nuget'
+}
+$OutputDir = Resolve-ReleasePath $OutputDir
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+if ($PreviousPackageDir) {
+    $PreviousPackageDir = Resolve-ReleasePath $PreviousPackageDir
+}
+$additionalFile = Resolve-ReleasePath $AdditionalFilePath
+if (-not (Test-Path -LiteralPath $additionalFile -PathType Leaf)) {
+    throw "Additional repack file was not found: $additionalFile"
+}
+$additionalPackageSegments = @($AdditionalPackagePath.Replace('\', '/').Split('/'))
+if ([string]::IsNullOrWhiteSpace($AdditionalPackagePath) -or
+    $AdditionalPackagePath.StartsWith('/', [System.StringComparison]::Ordinal) -or
+    $additionalPackageSegments -contains '' -or
+    $additionalPackageSegments -contains '.' -or
+    $additionalPackageSegments -contains '..') {
+    throw "AdditionalPackagePath must be a safe relative package path: $AdditionalPackagePath"
+}
+if (-not $RepositoryCommit) {
+    $RepositoryCommit = (& git -C (Get-ReleaseRepoRoot) rev-parse HEAD 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or $RepositoryCommit -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not determine release repository commit: $RepositoryCommit"
+    }
+}
+elseif ($RepositoryCommit -notmatch '^[0-9a-f]{40}$') {
+    throw "RepositoryCommit must be a full 40-character hexadecimal commit: $RepositoryCommit"
+}
+
+$targetRows = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision)
+$previousRows = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PreviousPackageRevision)
+$selectedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$selections = @()
+foreach ($packageId in $PackageIds) {
+    if ([string]::IsNullOrWhiteSpace($packageId)) {
+        throw 'PackageIds must not contain empty values.'
+    }
+    if (-not $selectedIds.Add($packageId)) {
+        throw "PackageIds contains duplicate package id: $packageId"
+    }
+    $target = @($targetRows | Where-Object { $_.Id -eq $packageId })
+    $previous = @($previousRows | Where-Object { $_.Id -eq $packageId })
+    if ($target.Count -ne 1 -or $previous.Count -ne 1) {
+        throw "PackageIds contains unknown package id: $packageId"
+    }
+    if ($target[0].Kind -ne 'native' -or $previous[0].Kind -ne 'native') {
+        throw "PackageIds can select only native packages: $packageId"
+    }
+    if ([version]$target[0].PackageVersion -le [version]$previous[0].PackageVersion) {
+        throw "Target package version must be newer than previous package version for $packageId."
+    }
+    $selections += [pscustomobject]@{ Target = $target[0]; Previous = $previous[0] }
+}
+
+$tempRoot = $null
+$rows = @()
+try {
+    if (-not $PreviousPackageDir) {
+        $tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        $tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-native-repack-input-$([guid]::NewGuid().ToString('N'))"))
+        if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Unsafe temporary repack input path: $tempRoot"
+        }
+        New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+        $PreviousPackageDir = $tempRoot
+    }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    foreach ($selection in $selections) {
+        $target = $selection.Target
+        $previous = $selection.Previous
+        $previousPath = Get-ReleaseNuGetPackagePath -PackageDir $PreviousPackageDir -Package $previous
+        if (-not (Test-Path -LiteralPath $previousPath -PathType Leaf)) {
+            Invoke-WebRequest -Uri (Get-PackageUri -Package $previous) -OutFile $previousPath -TimeoutSec 120
+        }
+        if (-not $SkipSourceSignatureValidation) {
+            & dotnet nuget verify $previousPath --all
+            if ($LASTEXITCODE -ne 0) {
+                throw "Published source package signature validation failed for $($previous.Id) $($previous.PackageVersion)."
+            }
+        }
+        $targetPath = Get-ReleaseNuGetPackagePath -PackageDir $OutputDir -Package $target
+        if (Test-Path -LiteralPath $targetPath) {
+            Remove-Item -LiteralPath $targetPath -Force
+        }
+
+        $sourceZip = [System.IO.Compression.ZipFile]::OpenRead($previousPath)
+        try {
+            if ($sourceZip.GetEntry($AdditionalPackagePath)) {
+                throw "Previous package already contains target additional entry: $($previous.Id) -> $AdditionalPackagePath"
+            }
+            $targetStream = [System.IO.File]::Open($targetPath, [System.IO.FileMode]::CreateNew)
+            try {
+                $targetZip = [System.IO.Compression.ZipArchive]::new($targetStream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
+                try {
+                    foreach ($sourceEntry in $sourceZip.Entries) {
+                        $entryName = $sourceEntry.FullName.Replace('\', '/')
+                        if (-not $entryName -or $entryName.EndsWith('/', [System.StringComparison]::Ordinal) -or
+                            $entryName -eq '.signature.p7s') {
+                            continue
+                        }
+
+                        $bytes = Get-EntryBytes -Entry $sourceEntry
+                        if ($entryName.EndsWith('.nuspec', [System.StringComparison]::OrdinalIgnoreCase)) {
+                            [xml] $nuspec = Convert-BytesToXml -Bytes $bytes
+                            Set-XmlElementValue -Xml $nuspec -LocalName 'version' -Value $target.PackageVersion
+                            $repositoryNodes = @($nuspec.SelectNodes("//*[local-name()='repository']"))
+                            if ($repositoryNodes.Count -eq 1) {
+                                $repositoryNodes[0].SetAttribute('commit', $RepositoryCommit)
+                            }
+                            $bytes = Convert-XmlToBytes -Xml $nuspec
+                        }
+                        elseif ($entryName.EndsWith('.psmdcp', [System.StringComparison]::OrdinalIgnoreCase)) {
+                            [xml] $coreProperties = Convert-BytesToXml -Bytes $bytes
+                            Set-XmlElementValue -Xml $coreProperties -LocalName 'version' -Value $target.PackageVersion
+                            $bytes = Convert-XmlToBytes -Xml $coreProperties
+                        }
+                        elseif ($entryName -eq '[Content_Types].xml') {
+                            [xml] $contentTypes = Convert-BytesToXml -Bytes $bytes
+                            $namespace = $contentTypes.DocumentElement.NamespaceURI
+                            $override = $contentTypes.CreateElement('Override', $namespace)
+                            [void] $override.SetAttribute('PartName', "/$AdditionalPackagePath")
+                            [void] $override.SetAttribute('ContentType', 'application/octet')
+                            [void] $contentTypes.DocumentElement.AppendChild($override)
+                            $bytes = Convert-XmlToBytes -Xml $contentTypes
+                        }
+
+                        $targetEntry = $targetZip.CreateEntry($entryName, [System.IO.Compression.CompressionLevel]::Optimal)
+                        $targetEntry.LastWriteTime = $sourceEntry.LastWriteTime
+                        $entryStream = $targetEntry.Open()
+                        try {
+                            $entryStream.Write($bytes, 0, $bytes.Length)
+                        }
+                        finally {
+                            $entryStream.Dispose()
+                        }
+                    }
+
+                    $additionalBytes = [System.IO.File]::ReadAllBytes($additionalFile)
+                    $additionalEntry = $targetZip.CreateEntry($AdditionalPackagePath, [System.IO.Compression.CompressionLevel]::Optimal)
+                    $additionalStream = $additionalEntry.Open()
+                    try {
+                        $additionalStream.Write($additionalBytes, 0, $additionalBytes.Length)
+                    }
+                    finally {
+                        $additionalStream.Dispose()
+                    }
+                }
+                finally {
+                    $targetZip.Dispose()
+                }
+            }
+            finally {
+                $targetStream.Dispose()
+            }
+        }
+        catch {
+            if (Test-Path -LiteralPath $targetPath) {
+                Remove-Item -LiteralPath $targetPath -Force
+            }
+            throw
+        }
+        finally {
+            $sourceZip.Dispose()
+        }
+
+        $rows += [pscustomobject]@{
+            Package = $target.Id
+            SourceVersion = $previous.PackageVersion
+            TargetVersion = $target.PackageVersion
+            Output = $targetPath
+        }
+    }
+}
+finally {
+    if ($tempRoot -and (Test-Path -LiteralPath $tempRoot)) {
+        $tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-native-repack-input-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary repack input path: $resolvedTempRoot"
+        }
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+$rows | Format-Table -AutoSize
+Write-Host "Created $($rows.Count) selective native package repack(s)."

--- a/.github/release-tools/Publish-NativePackageRepack.ps1
+++ b/.github/release-tools/Publish-NativePackageRepack.ps1
@@ -1,0 +1,70 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int] $PackageRevision,
+    [Parameter(Mandatory)][int] $PreviousPackageRevision,
+    [Parameter(Mandatory)][string[]] $PackageIds,
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $PackageDir,
+    [switch] $NuGetPush,
+    [switch] $DryRun
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+if (-not $PackageDir) {
+    $PackageDir = Join-Path (Resolve-ReleasePath $manifest.artifactsRoot) 'nuget'
+}
+$PackageDir = Resolve-ReleasePath $PackageDir
+
+& (Join-Path $PSScriptRoot 'Test-PackageVersioning.ps1') `
+    -PackageRevision $PackageRevision `
+    -ManifestPath $ManifestPath
+& (Join-Path $PSScriptRoot 'Test-NuGetPackageContents.ps1') `
+    -PackageRevision $PackageRevision `
+    -ManifestPath $ManifestPath `
+    -PackageDir $PackageDir `
+    -PackageIds $PackageIds
+& (Join-Path $PSScriptRoot 'Test-NativePackageRepack.ps1') `
+    -PackageRevision $PackageRevision `
+    -PreviousPackageRevision $PreviousPackageRevision `
+    -PackageIds $PackageIds `
+    -ManifestPath $ManifestPath `
+    -PackageDir $PackageDir
+
+$allPackages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision)
+$packages = @()
+foreach ($packageId in $PackageIds) {
+    $matches = @($allPackages | Where-Object { $_.Id -eq $packageId -and $_.Kind -eq 'native' })
+    if ($matches.Count -ne 1) {
+        throw "Cannot publish unknown or non-native package id: $packageId"
+    }
+    $packages += $matches[0]
+}
+
+if (-not $NuGetPush) {
+    Write-Host 'Selective native packages are validated. Pass -NuGetPush to publish them.'
+    return
+}
+if (-not $DryRun -and [string]::IsNullOrWhiteSpace($env:NUGET_API_KEY)) {
+    throw 'NUGET_API_KEY is required for -NuGetPush. In GitHub Actions it is provided by NuGet/login trusted publishing.'
+}
+
+foreach ($package in $packages) {
+    $packagePath = Get-ReleaseNuGetPackagePath -PackageDir $PackageDir -Package $package
+    if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+        throw "Expected selective repack package is missing: $packagePath"
+    }
+
+    $args = @(
+        'nuget', 'push', $packagePath,
+        '--api-key', $env:NUGET_API_KEY,
+        '--source', 'https://api.nuget.org/v3/index.json',
+        '--timeout', '600'
+    )
+    Write-Host "Publishing $($package.Id) $($package.PackageVersion)"
+    Invoke-ReleaseCommand -FilePath 'dotnet' -Arguments $args -DryRun:$DryRun
+}
+
+Write-Host "Selective native package publication completed for $($packages.Count) package(s)."

--- a/.github/release-tools/Test-ManagedReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ManagedReleaseWorkflow.ps1
@@ -35,6 +35,18 @@ function Assert-TextExcludes {
     }
 }
 
+function Assert-TextMatches {
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string] $Text,
+        [Parameter(Mandatory)][string] $Pattern,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if ($Text -notmatch $Pattern) {
+        Add-ManagedWorkflowError "$Description is missing expected pattern: $Pattern"
+    }
+}
+
 $errors = New-Object System.Collections.Generic.List[string]
 $workflowFile = Resolve-ReleasePath $WorkflowPath
 $workflowText = ''
@@ -72,11 +84,10 @@ foreach ($expected in @(
     '-ManagedOnly',
     'name: managed-nuget-package',
     'path: artifacts/release/nuget/SDL3-CS.*.nupkg',
-    'uses: NuGet/login@v1',
     'environment: production',
     "NATIVE_PACKAGE_REVISION: `${{ inputs.native_package_revision }}",
     "BASE_RELEASE_REF: `${{ inputs.base_release_ref }}",
-    "if: `${{ inputs.managed_only }}",
+    "if: `${{ inputs.managed_only && !inputs.selective_native_repack }}",
     "if: `${{ inputs.managed_only && (inputs.publish_github || inputs.publish_nuget) }}",
     "if: `${{ !inputs.managed_only && (inputs.publish_github || inputs.publish_nuget) }}",
     'NativePackageRevision = [int]$env:NATIVE_PACKAGE_REVISION',
@@ -86,6 +97,10 @@ foreach ($expected in @(
 )) {
     Assert-TextContains -Text $workflowText -Expected $expected -Description 'managed release workflow'
 }
+Assert-TextMatches `
+    -Text $workflowText `
+    -Pattern '(?m)^\s+uses:\s+NuGet/login@[0-9a-f]{40}\s+#\s+v1\s*$' `
+    -Description 'managed release workflow SHA-pinned NuGet Trusted Publishing login action'
 
 foreach ($publishInput in @('publish_github', 'publish_nuget')) {
     if ($workflowText -notmatch "(?ms)^\s{6}$publishInput\s*:\s*\r?\n.*?^\s{8}default:\s+false\s*$") {

--- a/.github/release-tools/Test-NativePackageRepack.Tests.ps1
+++ b/.github/release-tools/Test-NativePackageRepack.Tests.ps1
@@ -1,0 +1,247 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param()
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$builder = Join-Path $PSScriptRoot 'New-NativePackageRepack.ps1'
+$validator = Join-Path $PSScriptRoot 'Test-NativePackageRepack.ps1'
+$publisher = Join-Path $PSScriptRoot 'Publish-NativePackageRepack.ps1'
+$workflow = Join-Path $repoRoot '.github/workflows/release-native-packages.yml'
+$manifest = Join-Path $PSScriptRoot 'release-manifest.json'
+
+foreach ($requiredPath in @($builder, $validator, $publisher, $workflow, $manifest)) {
+    if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+        throw "Selective native repack dependency was not found: $requiredPath"
+    }
+}
+
+function Assert-TextContains {
+    param(
+        [Parameter(Mandatory)][string] $Text,
+        [Parameter(Mandatory)][string] $Expected,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if (-not $Text.Contains($Expected, [System.StringComparison]::Ordinal)) {
+        throw "$Description is missing expected text: $Expected"
+    }
+}
+
+function Assert-ActionFails {
+    param(
+        [Parameter(Mandatory)][string] $Description,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $failed = $false
+    try {
+        & $Action
+    }
+    catch {
+        $failed = $true
+    }
+
+    if (-not $failed) {
+        throw "Expected selective native repack validation to fail: $Description"
+    }
+}
+
+function New-PackageFixture {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $Version,
+        [Parameter(Mandatory)][byte[]] $NativeBytes,
+        [switch] $IncludeLibwebpLicense
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path -Force
+    }
+
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::CreateNew)
+    try {
+        $archive = [System.IO.Compression.ZipArchive]::new($stream, [System.IO.Compression.ZipArchiveMode]::Create, $false)
+        try {
+            $entries = [ordered]@{
+                '[Content_Types].xml' = [System.Text.Encoding]::UTF8.GetBytes('<?xml version="1.0" encoding="utf-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="psmdcp" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/><Default Extension="nuspec" ContentType="application/octet"/><Default Extension="dll" ContentType="application/octet"/><Default Extension="targets" ContentType="application/octet"/><Default Extension="p7s" ContentType="application/octet"/></Types>')
+                'SDL3-CS.Windows.Image.nuspec' = [System.Text.Encoding]::UTF8.GetBytes(('<?xml version="1.0"?><package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"><metadata><id>SDL3-CS.Windows.Image</id><version>{0}</version><repository type="git" url="https://github.com/edwardgushchin/SDL3-CS" commit="0000000000000000000000000000000000000000" /></metadata></package>' -f $Version))
+                'package/services/metadata/core-properties/test.psmdcp' = [System.Text.Encoding]::UTF8.GetBytes(('<?xml version="1.0"?><coreProperties xmlns="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"><version>{0}</version></coreProperties>' -f $Version))
+                'runtimes/win-x64/native/SDL3_image.dll' = $NativeBytes
+                'buildTransitive/SDL3-CS.Windows.Image.targets' = [System.Text.Encoding]::UTF8.GetBytes('<Project />')
+                'LICENSE' = [System.Text.Encoding]::UTF8.GetBytes('SDL license')
+                '.signature.p7s' = [System.Text.Encoding]::UTF8.GetBytes('old signature')
+            }
+            if ($IncludeLibwebpLicense) {
+                $entries['licenses/libwebp/COPYING'] = [System.Text.Encoding]::UTF8.GetBytes('libwebp license')
+            }
+
+            foreach ($item in $entries.GetEnumerator()) {
+                $entry = $archive.CreateEntry($item.Key)
+                $entryStream = $entry.Open()
+                try {
+                    $entryStream.Write($item.Value, 0, $item.Value.Length)
+                }
+                finally {
+                    $entryStream.Dispose()
+                }
+            }
+        }
+        finally {
+            $archive.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-ZipEntryText {
+    param(
+        [Parameter(Mandatory)][string] $PackagePath,
+        [Parameter(Mandatory)][string] $EntryName
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+    try {
+        $entry = $archive.GetEntry($EntryName)
+        if (-not $entry) {
+            throw "Package entry was not found: $EntryName"
+        }
+        $reader = [System.IO.StreamReader]::new($entry.Open(), [System.Text.Encoding]::UTF8)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+$workflowText = Get-Content -LiteralPath $workflow -Raw -Encoding UTF8
+$selectiveStart = $workflowText.IndexOf('  selective-repack:', [System.StringComparison]::Ordinal)
+if ($selectiveStart -lt 0) {
+    throw 'Trusted release workflow is missing the selective-repack job.'
+}
+$selectiveText = $workflowText.Substring($selectiveStart)
+foreach ($expectation in @(
+    @{ Text = 'uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1'; Description = 'SHA-pinned trusted publishing login' },
+    @{ Text = './.github/release-tools/New-NativePackageRepack.ps1'; Description = 'package clone command' },
+    @{ Text = './.github/release-tools/Publish-NativePackageRepack.ps1'; Description = 'selective publish command' },
+    @{ Text = 'environment: production'; Description = 'protected publication environment' }
+)) {
+    Assert-TextContains -Text $selectiveText -Expected $expectation.Text -Description $expectation.Description
+}
+foreach ($forbidden in @('Build-Native.ps1', 'Invoke-NativeHostBuild.ps1', 'Invoke-ReleasePipeline.ps1', 'Pack-NuGet.ps1', '-SkipSourceSignatureValidation')) {
+    if ($selectiveText.Contains($forbidden, [System.StringComparison]::Ordinal)) {
+        throw "Package-only workflow must not invoke build/pack tooling: $forbidden"
+    }
+}
+foreach ($modeExpectation in @(
+    'selective_native_repack:',
+    'publish_selective_nuget:',
+    "throw 'Selective native repack requires managed_only=true",
+    'if: ${{ inputs.managed_only && !inputs.selective_native_repack }}'
+)) {
+    Assert-TextContains -Text $workflowText -Expected $modeExpectation -Description 'fail-closed selective release mode'
+}
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-native-repack-$([guid]::NewGuid().ToString('N'))"))
+if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe temporary repack test path: $tempRoot"
+}
+
+$previousDir = Join-Path $tempRoot 'previous'
+$targetDir = Join-Path $tempRoot 'target'
+New-Item -ItemType Directory -Force -Path $previousDir, $targetDir | Out-Null
+$previousPackage = Join-Path $previousDir 'SDL3-CS.Windows.Image.3.4.4.7.nupkg'
+$targetPackage = Join-Path $targetDir 'SDL3-CS.Windows.Image.3.4.4.8.nupkg'
+
+try {
+    $unchangedBytes = [byte[]](1, 2, 3, 4, 5)
+    New-PackageFixture -Path $previousPackage -Version '3.4.4.7' -NativeBytes $unchangedBytes
+
+    & $builder `
+        -PackageRevision 8 `
+        -PreviousPackageRevision 7 `
+        -PackageIds 'SDL3-CS.Windows.Image' `
+        -OutputDir $targetDir `
+        -PreviousPackageDir $previousDir `
+        -RepositoryCommit ('a' * 40) `
+        -SkipSourceSignatureValidation
+
+    & $validator `
+        -PackageRevision 8 `
+        -PreviousPackageRevision 7 `
+        -PackageIds 'SDL3-CS.Windows.Image' `
+        -PackageDir $targetDir `
+        -PreviousPackageDir $previousDir `
+        -SkipTargetAvailabilityCheck
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($targetPackage)
+    try {
+        if ($archive.GetEntry('.signature.p7s')) {
+            throw 'Repacked package must not preserve the source package signature.'
+        }
+        if (-not $archive.GetEntry('licenses/libwebp/COPYING')) {
+            throw 'Repacked package must contain the libwebp license.'
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+    Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'SDL3-CS.Windows.Image.nuspec') -Expected '<version>3.4.4.8</version>' -Description 'nuspec target version'
+    Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'package/services/metadata/core-properties/test.psmdcp') -Expected '<version>3.4.4.8</version>' -Description 'core properties target version'
+
+    Assert-ActionFails -Description 'unsafe additional package path' -Action {
+        & $builder `
+            -PackageRevision 8 `
+            -PreviousPackageRevision 7 `
+            -PackageIds 'SDL3-CS.Windows.Image' `
+            -OutputDir $targetDir `
+            -PreviousPackageDir $previousDir `
+            -AdditionalPackagePath '../COPYING' `
+            -RepositoryCommit ('a' * 40) `
+            -SkipSourceSignatureValidation *> $null
+    }
+
+    New-PackageFixture -Path $targetPackage -Version '3.4.4.8' -NativeBytes ([byte[]](9, 2, 3, 4, 5)) -IncludeLibwebpLicense
+    Assert-ActionFails -Description 'changed native binary' -Action {
+        & $validator `
+            -PackageRevision 8 `
+            -PreviousPackageRevision 7 `
+            -PackageIds 'SDL3-CS.Windows.Image' `
+            -PackageDir $targetDir `
+            -PreviousPackageDir $previousDir `
+            -SkipTargetAvailabilityCheck *> $null
+    }
+
+    foreach ($invalidId in @('SDL3-CS', 'SDL3-CS.Does.Not.Exist')) {
+        Assert-ActionFails -Description "invalid package id $invalidId" -Action {
+            & $validator `
+                -PackageRevision 8 `
+                -PreviousPackageRevision 7 `
+                -PackageIds $invalidId `
+                -PackageDir $targetDir `
+                -PreviousPackageDir $previousDir `
+                -SkipTargetAvailabilityCheck *> $null
+        }
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-native-repack-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary repack test path: $resolvedTempRoot"
+        }
+
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Selective native package repack tests passed.'

--- a/.github/release-tools/Test-NativePackageRepack.ps1
+++ b/.github/release-tools/Test-NativePackageRepack.ps1
@@ -1,0 +1,219 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][int] $PackageRevision,
+    [Parameter(Mandatory)][int] $PreviousPackageRevision,
+    [Parameter(Mandatory)][string[]] $PackageIds,
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
+    [string] $PackageDir,
+    [string] $PreviousPackageDir,
+    [string[]] $RequiredEntries = @('licenses/libwebp/COPYING'),
+    [switch] $SkipTargetAvailabilityCheck
+)
+
+. (Join-Path $PSScriptRoot 'Release.Common.ps1')
+
+function Get-PackageUri {
+    param([Parameter(Mandatory)][object] $Package)
+
+    $id = $Package.Id.ToLowerInvariant()
+    $version = (Get-ReleaseNormalizedNuGetVersion -PackageVersion $Package.PackageVersion).ToLowerInvariant()
+    return "https://api.nuget.org/v3-flatcontainer/$id/$version/$id.$version.nupkg"
+}
+
+function Get-ZipPayloadMap {
+    param([Parameter(Mandatory)][string] $Path)
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $map = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::Ordinal)
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        foreach ($entry in $zip.Entries) {
+            $name = $entry.FullName.Replace('\', '/')
+            if (-not $name -or $name.EndsWith('/', [System.StringComparison]::Ordinal)) {
+                continue
+            }
+            if (-not ($name.StartsWith('runtimes/', [System.StringComparison]::Ordinal) -or
+                $name.StartsWith('buildTransitive/', [System.StringComparison]::Ordinal))) {
+                continue
+            }
+
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $stream = $entry.Open()
+                try {
+                    $hash = $sha256.ComputeHash($stream)
+                    $map[$name] = ([System.BitConverter]::ToString($hash) -replace '-', '').ToLowerInvariant()
+                }
+                finally {
+                    $stream.Dispose()
+                }
+            }
+            finally {
+                $sha256.Dispose()
+            }
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+
+    return $map
+}
+
+function Test-ZipEntryExists {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $EntryName
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        return $null -ne $zip.GetEntry($EntryName)
+    }
+    finally {
+        $zip.Dispose()
+    }
+}
+
+if ($PackageRevision -lt 0 -or $PreviousPackageRevision -lt 0) {
+    throw 'Package revisions must be zero or greater.'
+}
+if (-not $PackageIds -or $PackageIds.Count -eq 0) {
+    throw 'PackageIds must select at least one native package.'
+}
+
+$manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
+if (-not $PackageDir) {
+    $PackageDir = Join-Path (Resolve-ReleasePath $manifest.artifactsRoot) 'nuget'
+}
+$PackageDir = Resolve-ReleasePath $PackageDir
+if ($PreviousPackageDir) {
+    $PreviousPackageDir = Resolve-ReleasePath $PreviousPackageDir
+}
+
+$targetRows = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision)
+$previousRows = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PreviousPackageRevision)
+$selectedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$selected = @()
+foreach ($packageId in $PackageIds) {
+    if ([string]::IsNullOrWhiteSpace($packageId)) {
+        throw 'PackageIds must not contain empty values.'
+    }
+    if (-not $selectedIds.Add($packageId)) {
+        throw "PackageIds contains duplicate package id: $packageId"
+    }
+
+    $target = @($targetRows | Where-Object { $_.Id -eq $packageId })
+    $previous = @($previousRows | Where-Object { $_.Id -eq $packageId })
+    if ($target.Count -ne 1 -or $previous.Count -ne 1) {
+        throw "PackageIds contains unknown package id: $packageId"
+    }
+    if ($target[0].Kind -ne 'native' -or $previous[0].Kind -ne 'native') {
+        throw "PackageIds can select only native packages: $packageId"
+    }
+    if ([version]$target[0].PackageVersion -le [version]$previous[0].PackageVersion) {
+        throw "Target package version must be newer than previous package version for $packageId`: $($target[0].PackageVersion) <= $($previous[0].PackageVersion)"
+    }
+
+    $selected += [pscustomobject]@{ Target = $target[0]; Previous = $previous[0] }
+}
+
+$tempRoot = $null
+$errors = New-Object System.Collections.Generic.List[string]
+$rows = New-Object System.Collections.Generic.List[object]
+try {
+    if (-not $PreviousPackageDir) {
+        $tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        $tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-native-repack-source-$([guid]::NewGuid().ToString('N'))"))
+        if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Unsafe temporary source package path: $tempRoot"
+        }
+        New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+        $PreviousPackageDir = $tempRoot
+    }
+
+    foreach ($selection in $selected) {
+        $target = $selection.Target
+        $previous = $selection.Previous
+        $targetPath = Get-ReleaseNuGetPackagePath -PackageDir $PackageDir -Package $target
+        $previousPath = Get-ReleaseNuGetPackagePath -PackageDir $PreviousPackageDir -Package $previous
+
+        if (-not (Test-Path -LiteralPath $targetPath -PathType Leaf)) {
+            $errors.Add("Target repack package is missing: $targetPath")
+            continue
+        }
+
+        if (-not $SkipTargetAvailabilityCheck) {
+            $response = Invoke-WebRequest -Uri (Get-PackageUri -Package $target) -Method Head -TimeoutSec 30 -SkipHttpErrorCheck
+            if ([int]$response.StatusCode -ne 404) {
+                $errors.Add("Target NuGet package version is not available: $($target.Id) $($target.PackageVersion) (HTTP $([int]$response.StatusCode))")
+            }
+        }
+
+        if (-not (Test-Path -LiteralPath $previousPath -PathType Leaf)) {
+            $uri = Get-PackageUri -Package $previous
+            try {
+                Invoke-WebRequest -Uri $uri -OutFile $previousPath -TimeoutSec 120
+            }
+            catch {
+                $errors.Add("Could not download previous NuGet package $($previous.Id) $($previous.PackageVersion): $($_.Exception.Message)")
+                continue
+            }
+        }
+
+        foreach ($requiredEntry in $RequiredEntries) {
+            if (-not (Test-ZipEntryExists -Path $targetPath -EntryName $requiredEntry)) {
+                $errors.Add("Target repack package $($target.Id) is missing required entry: $requiredEntry")
+            }
+        }
+
+        $previousPayload = Get-ZipPayloadMap -Path $previousPath
+        $targetPayload = Get-ZipPayloadMap -Path $targetPath
+        if ($previousPayload.Count -eq 0) {
+            $errors.Add("Previous package has no runtimes/buildTransitive payload: $($previous.Id) $($previous.PackageVersion)")
+        }
+        foreach ($entryName in $previousPayload.Keys) {
+            if (-not $targetPayload.ContainsKey($entryName)) {
+                $errors.Add("Target package $($target.Id) is missing unchanged payload entry: $entryName")
+            }
+            elseif ($targetPayload[$entryName] -ne $previousPayload[$entryName]) {
+                $errors.Add("Target package $($target.Id) changed payload entry: $entryName")
+            }
+        }
+        foreach ($entryName in $targetPayload.Keys) {
+            if (-not $previousPayload.ContainsKey($entryName)) {
+                $errors.Add("Target package $($target.Id) added unexpected payload entry: $entryName")
+            }
+        }
+
+        $status = if (@($errors | Where-Object { $_ -like "*$($target.Id)*" }).Count -eq 0) { 'valid' } else { 'failed' }
+        $rows.Add([pscustomobject]@{
+            Package = $target.Id
+            PreviousVersion = $previous.PackageVersion
+            TargetVersion = $target.PackageVersion
+            PayloadEntries = $targetPayload.Count
+            Status = $status
+        })
+    }
+}
+finally {
+    if ($tempRoot -and (Test-Path -LiteralPath $tempRoot)) {
+        $tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-native-repack-source-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary source package path: $resolvedTempRoot"
+        }
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+$rows | Format-Table -AutoSize
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "Native package repack validation failed with $($errors.Count) error(s)."
+}
+
+Write-Host "Native package repack is valid for $($selected.Count) package(s)."

--- a/.github/release-tools/Test-NuGetPackageContents.ps1
+++ b/.github/release-tools/Test-NuGetPackageContents.ps1
@@ -4,6 +4,7 @@ param(
     [int] $PackageRevision = -1,
     [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
     [string] $PackageDir,
+    [string[]] $PackageIds,
     [string[]] $Components,
     [string[]] $Rids,
     [switch] $ManagedOnly
@@ -76,9 +77,32 @@ foreach ($rid in $Rids) {
 
 $errors = New-Object System.Collections.Generic.List[string]
 $rows = New-Object System.Collections.Generic.List[object]
-$packages = Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision
+$packages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision)
 if ($ManagedOnly) {
     $packages = @($packages | Where-Object { $_.Kind -eq 'managed' })
+}
+elseif ($PackageIds) {
+    $selectedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    $selectedPackages = @()
+    foreach ($packageId in $PackageIds) {
+        if ([string]::IsNullOrWhiteSpace($packageId)) {
+            throw 'PackageIds must not contain empty values.'
+        }
+        if (-not $selectedIds.Add($packageId)) {
+            throw "PackageIds contains duplicate package id: $packageId"
+        }
+
+        $matches = @($packages | Where-Object { $_.Id -eq $packageId })
+        if ($matches.Count -ne 1) {
+            throw "PackageIds contains unknown package id: $packageId"
+        }
+        if ($matches[0].Kind -ne 'native') {
+            throw "PackageIds can select only native packages: $packageId"
+        }
+
+        $selectedPackages += $matches[0]
+    }
+    $packages = $selectedPackages
 }
 
 function Get-ZipEntryText {
@@ -143,7 +167,7 @@ foreach ($package in $packages) {
         continue
     }
 
-    $entryNames = Get-ZipEntryNames -Path $packagePath
+    $entryNames = @(Get-ZipEntryNames -Path $packagePath)
     $entrySet = New-EntrySet -EntryNames $entryNames
     $rows.Add([pscustomobject]@{
         PackageId = $package.Id

--- a/.github/release-tools/release-notes/v3.4.12.4.md
+++ b/.github/release-tools/release-notes/v3.4.12.4.md
@@ -1,0 +1,25 @@
+Stable SDL3-CS patch release for SDL 3.4.12.
+
+This release publishes the managed `SDL3-CS` wrapper and selectively repacks only the Android, Linux, and Windows SDL_image native packages to include the required libwebp license. Native binaries and source revisions are unchanged.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.12.4` |
+| `SDL3-CS.<Platform>` | `3.4.12.1` |
+| `SDL3-CS.{Android,Linux,Windows}.Image` | `3.4.4.8` |
+| `SDL3-CS.{iOS,MacOS,tvOS}.Image` | `3.4.4.7` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.7` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.7` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.7` |
+
+## Changes
+
+- Added the missing `GPURenderStateCreateInfo` managed binding and typed GPU render-state creation API ([#208](https://github.com/edwardgushchin/SDL3-CS/issues/208)).
+- Corrected the source-region type used by `DownloadFromGPUBuffer` ([#221](https://github.com/edwardgushchin/SDL3-CS/issues/221)).
+- Added mixed nullable/pointer `CreateAudioStream` overloads for practical source and destination specification combinations ([#223](https://github.com/edwardgushchin/SDL3-CS/issues/223)).
+- Aligned `PointInRectFloat` edge handling with SDL and added a non-nullable overload ([#225](https://github.com/edwardgushchin/SDL3-CS/issues/225)).
+- Added the libwebp license to Android, Linux, and Windows Image runtime packages without rebuilding or changing their native payloads ([#226](https://github.com/edwardgushchin/SDL3-CS/issues/226)).
+
+Applications should update `SDL3-CS` to `3.4.12.4`. Consumers of Android, Linux, or Windows Image packages should also update those packages to `3.4.4.8`; other native package versions remain unchanged.

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -39,6 +39,24 @@ on:
         required: true
         type: boolean
         default: false
+      selective_native_repack:
+        description: Repack exact published native packages without running the native matrix.
+        required: true
+        type: boolean
+        default: false
+      previous_native_package_revision:
+        description: Published source revision for selective native package repack.
+        required: true
+        default: "7"
+      selective_package_ids:
+        description: Comma-separated exact native package IDs for selective repack.
+        required: true
+        default: SDL3-CS.Android.Image,SDL3-CS.Linux.Image,SDL3-CS.Windows.Image
+      publish_selective_nuget:
+        description: Publish validated selective native repacks through trusted publishing.
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -49,9 +67,32 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
 
 jobs:
+  validate-mode:
+    name: Validate release mode
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce exclusive release mode
+        shell: pwsh
+        run: |
+          $selective = '${{ inputs.selective_native_repack }}' -eq 'true'
+          $managed = '${{ inputs.managed_only }}' -eq 'true'
+          $normalPublish = '${{ inputs.publish_github }}' -eq 'true' -or '${{ inputs.publish_nuget }}' -eq 'true'
+          $selectivePublish = '${{ inputs.publish_selective_nuget }}' -eq 'true'
+          if ($selective -and -not $managed) {
+            throw 'Selective native repack requires managed_only=true so the full native matrix stays disabled.'
+          }
+          if ($selective -and $normalPublish) {
+            throw 'Selective native repack requires publish_github=false and publish_nuget=false.'
+          }
+          if (-not $selective -and $selectivePublish) {
+            throw 'publish_selective_nuget requires selective_native_repack=true.'
+          }
+
   plan:
     name: Plan native matrix
     if: ${{ !inputs.managed_only }}
+    needs: validate-mode
     runs-on: ubuntu-latest
     outputs:
       native_matrix: ${{ steps.native-matrix.outputs.native_matrix }}
@@ -526,7 +567,8 @@ jobs:
 
   managed-build:
     name: Build and validate managed package
-    if: ${{ inputs.managed_only }}
+    if: ${{ inputs.managed_only && !inputs.selective_native_repack }}
+    needs: validate-mode
     runs-on: windows-2025
 
     steps:
@@ -673,3 +715,105 @@ jobs:
           }
 
           ./.github/release-tools/Publish-Release.ps1 @params
+
+  selective-repack:
+    name: Repack selected published native packages
+    if: ${{ inputs.selective_native_repack }}
+    needs: validate-mode
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout SDL3-CS
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Clone only selected published packages
+        shell: pwsh
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+          PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
+          PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+        run: |
+          $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          ./.github/release-tools/New-NativePackageRepack.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
+            -PackageIds $ids `
+            -OutputDir 'artifacts/release/nuget'
+
+      - name: Prove package-only payload equivalence
+        shell: pwsh
+        env:
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+          PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
+          PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+        run: |
+          $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          $rids = @('android-arm', 'android-arm64', 'android-x86', 'android-x64', 'linux-x64', 'linux-arm64', 'win-x86', 'win-x64', 'win-arm64')
+          ./.github/release-tools/Test-NuGetPackageContents.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -PackageIds $ids `
+            -Rids $rids `
+            -PackageDir 'artifacts/release/nuget'
+          ./.github/release-tools/Test-NativePackageRepack.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
+            -PackageIds $ids `
+            -PackageDir 'artifacts/release/nuget'
+          $packagePaths = @(Get-ChildItem -LiteralPath 'artifacts/release/nuget' -Filter '*.nupkg' -File | ForEach-Object FullName)
+          ./.github/release-tools/Test-ImageLibwebpLicenses.ps1 -PackagePaths $packagePaths
+
+      - name: Upload selected NuGet packages
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: selective-native-repack-packages
+          path: artifacts/release/nuget/*.nupkg
+          if-no-files-found: error
+
+  selective-publish:
+    name: Publish selected native packages
+    if: ${{ inputs.selective_native_repack && inputs.publish_selective_nuget }}
+    needs: selective-repack
+    runs-on: windows-2025
+    environment: production
+
+    steps:
+      - name: Checkout SDL3-CS
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download selected NuGet packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: selective-native-repack-packages
+          path: artifacts/release/nuget
+
+      - name: NuGet trusted publishing login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
+        id: selective_nuget_login
+        with:
+          user: edwardgushchin
+
+      - name: Publish only selected packages
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.selective_nuget_login.outputs.NUGET_API_KEY }}
+          PACKAGE_REVISION: ${{ inputs.package_revision }}
+          PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
+          PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+        run: |
+          $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+          ./.github/release-tools/Publish-NativePackageRepack.ps1 `
+            -PackageRevision ([int]$env:PACKAGE_REVISION) `
+            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
+            -PackageIds $ids `
+            -PackageDir 'artifacts/release/nuget' `
+            -NuGetPush

--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,13 +4,14 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Latest Release
 
-Current stable release: [`SDL3-CS 3.4.12.3`](https://www.nuget.org/packages/SDL3-CS/3.4.12.3).
+Current stable release: [`SDL3-CS 3.4.12.4`](https://www.nuget.org/packages/SDL3-CS/3.4.12.4).
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.12.3` |
+| `SDL3-CS` | `3.4.12.4` |
 | `SDL3-CS.<Platform>` | `3.4.12.1` |
-| `SDL3-CS.<Platform>.Image` | `3.4.4.7` |
+| `SDL3-CS.{Android,Linux,Windows}.Image` | `3.4.4.8` |
+| `SDL3-CS.{iOS,MacOS,tvOS}.Image` | `3.4.4.7` |
 | `SDL3-CS.<Platform>.Mixer` | `3.2.4.7` |
 | `SDL3-CS.<Platform>.TTF` | `3.2.2.7` |
 | `SDL3-CS.<Platform>.Shadercross` | `3.0.0.7` |

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <a href="https://github.com/edwardgushchin/SDL3-CS/actions/workflows/ci.yml">
     <img alt="CI" src="https://github.com/edwardgushchin/SDL3-CS/actions/workflows/ci.yml/badge.svg?branch=main">
   </a>
-  <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.3">
-    <img alt="NuGet SDL3-CS 3.4.12.3" src="https://img.shields.io/badge/nuget-v3.4.12.3-004880?style=flat-square">
+  <a href="https://www.nuget.org/packages/SDL3-CS/3.4.12.4">
+    <img alt="NuGet SDL3-CS 3.4.12.4" src="https://img.shields.io/badge/nuget-v3.4.12.4-004880?style=flat-square">
   </a>
   <a href="https://www.nuget.org/packages/SDL3-CS">
     <img alt="NuGet SDL3-CS downloads" src="https://img.shields.io/nuget/dt/SDL3-CS?style=flat-square">


### PR DESCRIPTION
## Summary

- add a fail-closed selective native repack mode to the existing trusted release workflow
- clone and verify only the published Android/Linux/Windows Image 3.4.4.7 packages, preserving native payloads byte-for-byte while adding the libwebp license
- prepare managed SDL3-CS 3.4.12.4 metadata and release notes

## Verification

- selective fixture tests and real package SHA-256 equivalence: Android 5, Linux 55, Windows 28 payload entries
- NuGet repository signatures verified for all three source packages
- managed Release build/tests, full binding runner, public XML audit and managed package validation passed
- `Test-ReleaseReadiness.ps1 -PackageRevision 4 -SkipToolchainValidation -SkipNativeArtifactValidation -SkipNativeBuildReceiptValidation -FailOnError` passed; skips are limited to the no-native-rebuild scope
- YAML parse, release workflow validator and managed workflow validator passed

Related issues: #208, #221, #223, #225, #226. These issues remain open until the release is published and verified.