### PR TITLE
Fix cross-platform package license validation

### DIFF
--- a/.github/release-tools/Test-ImageLibwebpLicenses.ps1
+++ b/.github/release-tools/Test-ImageLibwebpLicenses.ps1
@@ -23,6 +23,12 @@ $expectedPackagePath = 'licenses/libwebp'
 $expectedPackageEntry = 'licenses/libwebp/COPYING'
 $errors = New-Object System.Collections.Generic.List[string]
 
+function ConvertTo-NormalizedLicenseText {
+    param([Parameter(Mandatory)][AllowEmptyString()][string] $Text)
+
+    return $Text.Replace("`r`n", "`n").Replace("`r", "`n")
+}
+
 if (-not (Test-Path -LiteralPath $licensePath -PathType Leaf)) {
     $errors.Add("Missing libwebp license source: $licenseRelativePath")
 }
@@ -75,7 +81,9 @@ if ($PackagePaths) {
                 try {
                     $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8, $true)
                     try {
-                        if ($reader.ReadToEnd() -ne $expectedLicenseText) {
+                        $actualLicenseText = $reader.ReadToEnd()
+                        if ((ConvertTo-NormalizedLicenseText -Text $actualLicenseText) -ne
+                            (ConvertTo-NormalizedLicenseText -Text $expectedLicenseText)) {
                             $errors.Add("Package libwebp license entry does not match source: $resolvedPackagePath -> $expectedPackageEntry")
                         }
                     }

--- a/.github/release-tools/Test-NativePackageRepack.Tests.ps1
+++ b/.github/release-tools/Test-NativePackageRepack.Tests.ps1
@@ -6,10 +6,11 @@ $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
 $builder = Join-Path $PSScriptRoot 'New-NativePackageRepack.ps1'
 $validator = Join-Path $PSScriptRoot 'Test-NativePackageRepack.ps1'
 $publisher = Join-Path $PSScriptRoot 'Publish-NativePackageRepack.ps1'
+$imageLicenseValidator = Join-Path $PSScriptRoot 'Test-ImageLibwebpLicenses.ps1'
 $workflow = Join-Path $repoRoot '.github/workflows/release-native-packages.yml'
 $manifest = Join-Path $PSScriptRoot 'release-manifest.json'
 
-foreach ($requiredPath in @($builder, $validator, $publisher, $workflow, $manifest)) {
+foreach ($requiredPath in @($builder, $validator, $publisher, $imageLicenseValidator, $workflow, $manifest)) {
     if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
         throw "Selective native repack dependency was not found: $requiredPath"
     }
@@ -51,7 +52,8 @@ function New-PackageFixture {
         [Parameter(Mandatory)][string] $Path,
         [Parameter(Mandatory)][string] $Version,
         [Parameter(Mandatory)][byte[]] $NativeBytes,
-        [switch] $IncludeLibwebpLicense
+        [switch] $IncludeLibwebpLicense,
+        [byte[]] $LicenseBytes = [System.Text.Encoding]::UTF8.GetBytes('libwebp license')
     )
 
     Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -73,7 +75,7 @@ function New-PackageFixture {
                 '.signature.p7s' = [System.Text.Encoding]::UTF8.GetBytes('old signature')
             }
             if ($IncludeLibwebpLicense) {
-                $entries['licenses/libwebp/COPYING'] = [System.Text.Encoding]::UTF8.GetBytes('libwebp license')
+                $entries['licenses/libwebp/COPYING'] = $LicenseBytes
             }
 
             foreach ($item in $entries.GetEnumerator()) {
@@ -160,6 +162,7 @@ $targetDir = Join-Path $tempRoot 'target'
 New-Item -ItemType Directory -Force -Path $previousDir, $targetDir | Out-Null
 $previousPackage = Join-Path $previousDir 'SDL3-CS.Windows.Image.3.4.4.7.nupkg'
 $targetPackage = Join-Path $targetDir 'SDL3-CS.Windows.Image.3.4.4.8.nupkg'
+$crlfLicensePackage = Join-Path $targetDir 'crlf-license-fixture.nupkg'
 
 try {
     $unchangedBytes = [byte[]](1, 2, 3, 4, 5)
@@ -196,6 +199,16 @@ try {
     }
     Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'SDL3-CS.Windows.Image.nuspec') -Expected '<version>3.4.4.8</version>' -Description 'nuspec target version'
     Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'package/services/metadata/core-properties/test.psmdcp') -Expected '<version>3.4.4.8</version>' -Description 'core properties target version'
+
+    $sourceLicenseText = Get-Content -LiteralPath (Join-Path $repoRoot 'SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING') -Raw -Encoding UTF8
+    $crlfLicenseBytes = [System.Text.Encoding]::UTF8.GetBytes(($sourceLicenseText -replace "`r?`n", "`r`n"))
+    New-PackageFixture `
+        -Path $crlfLicensePackage `
+        -Version '3.4.4.8' `
+        -NativeBytes $unchangedBytes `
+        -IncludeLibwebpLicense `
+        -LicenseBytes $crlfLicenseBytes
+    & $imageLicenseValidator -PackagePaths $crlfLicensePackage
 
     Assert-ActionFails -Description 'unsafe additional package path' -Action {
         & $builder `


### PR DESCRIPTION
## Summary

- normalize only LF/CRLF when comparing the complete libwebp license text
- add a Windows-style CRLF package regression fixture

## Evidence

Published Image 3.4.4.8 packages contain the same full license text as the pinned source; the only byte difference is Git line-ending conversion on the Windows runner. Native payload equivalence and NuGet repository signatures remain valid.