### PR TITLE
Add managed SDL main callbacks

### DIFF
--- a/.github/release-tools/Test-ManagedMainCallbacksPackage.ps1
+++ b/.github/release-tools/Test-ManagedMainCallbacksPackage.ps1
@@ -1,0 +1,132 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PackagePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PackageVersion
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedPackage = (Resolve-Path -LiteralPath $PackagePath).Path
+$packageDirectory = Split-Path -Parent $resolvedPackage
+$temporaryBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$temporaryRoot = [System.IO.Path]::GetFullPath((Join-Path $temporaryBase ("sdl3-cs-main-callbacks-" + [Guid]::NewGuid().ToString('N'))))
+
+if (-not $temporaryRoot.StartsWith($temporaryBase, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Temporary consumer path escaped the system temporary directory: $temporaryRoot"
+}
+
+New-Item -ItemType Directory -Path $temporaryRoot | Out-Null
+
+try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($resolvedPackage)
+    try {
+        $entryNames = @($archive.Entries | ForEach-Object FullName)
+        if ($entryNames -notcontains 'analyzers/dotnet/cs/SDL3-CS.Generators.dll') {
+            throw 'SDL3-CS package does not contain the managed main callback generator under analyzers/dotnet/cs.'
+        }
+
+        $nuspecEntry = $archive.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+        if ($null -eq $nuspecEntry) {
+            throw 'SDL3-CS package does not contain a nuspec.'
+        }
+
+        $reader = [System.IO.StreamReader]::new($nuspecEntry.Open())
+        try {
+            $nuspec = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        if ($nuspec -match 'Microsoft\.CodeAnalysis') {
+            throw 'SDL3-CS runtime package must not expose a Microsoft.CodeAnalysis dependency.'
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $projectPath = Join-Path $temporaryRoot 'Consumer.csproj'
+    $sourcePath = Join-Path $temporaryRoot 'Game.cs'
+    $nugetConfigPath = Join-Path $temporaryRoot 'NuGet.Config'
+
+    @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SDL3-CS" Version="$PackageVersion" />
+  </ItemGroup>
+</Project>
+"@ | Set-Content -LiteralPath $projectPath -Encoding utf8NoBOM
+
+    @'
+using SDL3;
+
+[SDL.GenerateMain]
+internal sealed partial class Game : SDL.IMainCallbacks<Game>
+{
+    public static SDL.AppResult AppInit(out Game? appState, string[] args)
+    {
+        appState = new Game();
+        return SDL.AppResult.Continue;
+    }
+
+    public SDL.AppResult AppIterate() => SDL.AppResult.Success;
+
+    public SDL.AppResult AppEvent(ref SDL.Event @event) => SDL.AppResult.Continue;
+
+    public void AppQuit(SDL.AppResult result)
+    {
+    }
+}
+'@ | Set-Content -LiteralPath $sourcePath -Encoding utf8NoBOM
+
+    @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$([System.Security.SecurityElement]::Escape($packageDirectory))" />
+  </packageSources>
+</configuration>
+"@ | Set-Content -LiteralPath $nugetConfigPath -Encoding utf8NoBOM
+
+    dotnet restore $projectPath --configfile $nugetConfigPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "Managed main callback consumer restore failed with exit code $LASTEXITCODE."
+    }
+
+    dotnet build $projectPath -c Release --no-restore
+    if ($LASTEXITCODE -ne 0) {
+        throw "Managed main callback consumer build failed with exit code $LASTEXITCODE."
+    }
+
+    $generatedSource = Get-ChildItem -LiteralPath (Join-Path $temporaryRoot 'Generated') -Recurse -Filter '*.g.cs' |
+        Where-Object { (Get-Content -LiteralPath $_.FullName -Raw) -match 'RunMainCallbacks<global::Game>' } |
+        Select-Object -First 1
+    if ($null -eq $generatedSource) {
+        throw 'The package consumer build did not emit the expected SDL managed Main source.'
+    }
+
+    Write-Output 'Managed main callback package consumer validation passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $temporaryRoot) {
+        $resolvedCleanupTarget = [System.IO.Path]::GetFullPath($temporaryRoot)
+        if (-not $resolvedCleanupTarget.StartsWith($temporaryBase, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to clean an unexpected path: $resolvedCleanupTarget"
+        }
+
+        Remove-Item -LiteralPath $resolvedCleanupTarget -Recurse -Force
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,29 @@ jobs:
         run: |
           dotnet restore .\SDL3-CS\SDL3-CS.csproj --force --no-cache
           dotnet restore .\SDL3-CS.Tests\SDL3-CS.Tests.csproj --force --no-cache
+          dotnet restore .\SDL3-CS.Generators.Tests\SDL3-CS.Generators.Tests.csproj --force --no-cache
 
       - name: Build managed wrapper and tests
         shell: pwsh
         run: |
           dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore /p:GeneratePackageOnBuild=false
           dotnet build .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-restore
+          dotnet build .\SDL3-CS.Generators.Tests\SDL3-CS.Generators.Tests.csproj -c Release --no-restore /p:GeneratePackageOnBuild=false
+
+      - name: Run managed main callback generator tests
+        shell: pwsh
+        run: dotnet run --project .\SDL3-CS.Generators.Tests\SDL3-CS.Generators.Tests.csproj -c Release --no-build --no-restore
+
+      - name: Validate managed main callback package consumer
+        shell: pwsh
+        run: |
+          dotnet pack .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore `
+            /p:PackageVersion=0.0.0-ci `
+            /p:GeneratePackageOnBuild=false `
+            --output .\artifacts\managed-main-callbacks
+          .\.github\release-tools\Test-ManagedMainCallbacksPackage.ps1 `
+            -PackagePath .\artifacts\managed-main-callbacks\SDL3-CS.0.0.0-ci.nupkg `
+            -PackageVersion 0.0.0-ci
 
       - name: Restore published native runtime for managed tests
         shell: pwsh

--- a/README-nuget.md
+++ b/README-nuget.md
@@ -67,6 +67,37 @@ Replace `Windows` with `Linux`, `MacOS`, `Android`, `iOS`, or `tvOS`.
 
 Android applications use `MainActivity : Org.Libsdl.App.SDLActivity`, override `GetLibraries()`, and run SDL from the managed `Main()` override.
 
+## Managed Main Callbacks
+
+For SDL's callback-based application lifecycle, implement `SDL.IMainCallbacks<TSelf>` and apply `[SDL.GenerateMain]` to the partial application class:
+
+```csharp
+using SDL3;
+
+[SDL.GenerateMain]
+internal sealed partial class Game : SDL.IMainCallbacks<Game>
+{
+    public static SDL.AppResult AppInit(out Game? appState, string[] args)
+    {
+        appState = new Game();
+        return SDL.AppResult.Continue;
+    }
+
+    public SDL.AppResult AppIterate() => SDL.AppResult.Continue;
+
+    public SDL.AppResult AppEvent(ref SDL.Event @event) =>
+        (SDL.EventType)@event.Type == SDL.EventType.Quit
+            ? SDL.AppResult.Success
+            : SDL.AppResult.Continue;
+
+    public void AppQuit(SDL.AppResult result)
+    {
+    }
+}
+```
+
+`SDL3-CS` supplies the source generator through the package's analyzer assets. It creates the entry point and delegates to `SDL.RunMainCallbacks<TApp>`, which owns the managed/native state lifetime and contains managed exceptions until SDL returns control to the caller.
+
 ## Example
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -156,6 +156,37 @@ cd SDL3-CS
 dotnet build SDL3-CS.sln -c Release
 ```
 
+### Managed Main Callbacks
+
+SDL3-CS can generate the application entry point for SDL's main-callback lifecycle. Implement `SDL.IMainCallbacks<TSelf>` on a partial class and opt in with `[SDL.GenerateMain]`:
+
+```csharp
+using SDL3;
+
+[SDL.GenerateMain]
+internal sealed partial class Game : SDL.IMainCallbacks<Game>
+{
+    public static SDL.AppResult AppInit(out Game? appState, string[] args)
+    {
+        appState = new Game();
+        return SDL.AppResult.Continue;
+    }
+
+    public SDL.AppResult AppIterate() => SDL.AppResult.Continue;
+
+    public SDL.AppResult AppEvent(ref SDL.Event @event) =>
+        (SDL.EventType)@event.Type == SDL.EventType.Quit
+            ? SDL.AppResult.Success
+            : SDL.AppResult.Continue;
+
+    public void AppQuit(SDL.AppResult result)
+    {
+    }
+}
+```
+
+The package generator creates `Main(string[] args)` and calls `SDL.RunMainCallbacks<Game>`. The runner manages the native app-state handle, callback lifetime, argument conversion, cleanup, and managed exception boundary. The existing low-level callback APIs remain available for applications that need direct control.
+
 ## 🎓 Examples
 
 ```csharp

--- a/SDL3-CS.Generators.Tests/Program.cs
+++ b/SDL3-CS.Generators.Tests/Program.cs
@@ -1,0 +1,186 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using SDL3.Generators;
+
+MainCallbacksGeneratorTests.GeneratesEntryPointForOptedInCallbackType();
+Console.WriteLine("Managed main callback generator positive test passed.");
+MainCallbacksGeneratorTests.DoesNotGenerateWithoutOptIn();
+Console.WriteLine("Managed main callback generator opt-in test passed.");
+MainCallbacksGeneratorTests.ReportsMissingPartial();
+Console.WriteLine("Managed main callback generator partial diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsMultipleCallbackTypes();
+Console.WriteLine("Managed main callback generator uniqueness diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsIncompatibleContract();
+Console.WriteLine("Managed main callback generator contract diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsExistingEntryPoint();
+Console.WriteLine("Managed main callback generator entry-point diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsTopLevelStatements();
+Console.WriteLine("Managed main callback generator top-level statements diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsUnsupportedTypeShape();
+Console.WriteLine("Managed main callback generator type-shape diagnostic test passed.");
+MainCallbacksGeneratorTests.ReportsNonExecutableProject();
+Console.WriteLine("Managed main callback generator output-kind diagnostic test passed.");
+
+internal static class MainCallbacksGeneratorTests
+{
+    private const string ValidCallbackType = """
+        #nullable enable
+        using SDL3;
+
+        namespace Demo;
+
+        [SDL.GenerateMain]
+        internal sealed partial class Game : SDL.IMainCallbacks<Game>
+        {
+            public static SDL.AppResult AppInit(out Game? appState, string[] args)
+            {
+                appState = new Game();
+                return SDL.AppResult.Continue;
+            }
+
+            public SDL.AppResult AppIterate() => SDL.AppResult.Continue;
+            public SDL.AppResult AppEvent(ref SDL.Event @event) => SDL.AppResult.Continue;
+            public void AppQuit(SDL.AppResult result) { }
+        }
+        """;
+
+    public static void GeneratesEntryPointForOptedInCallbackType()
+    {
+        GeneratorRun run = Run(ValidCallbackType);
+
+        AssertEqual(0, run.GeneratorDiagnostics.Count(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error), "Valid opt-in must not produce generator errors.");
+        AssertEqual(1, run.GeneratedSources.Length, "Valid opt-in must generate exactly one source file.");
+        string generated = run.GeneratedSources[0];
+        AssertContains("public static int Main(string[] args)", generated, "Generated source must contain a conventional entry point.");
+        AssertContains("global::SDL3.SDL.RunMainCallbacks<global::Demo.Game>(args)", generated, "Generated entry point must delegate to the managed runner.");
+        Diagnostic[] compilationErrors = run.OutputCompilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error).ToArray();
+        AssertEqual(0, compilationErrors.Length, $"Generated compilation must succeed: {string.Join(Environment.NewLine, compilationErrors.Select(diagnostic => diagnostic.ToString()))}");
+    }
+
+    public static void DoesNotGenerateWithoutOptIn()
+    {
+        string source = ValidCallbackType.Replace("[SDL.GenerateMain]", string.Empty, StringComparison.Ordinal);
+        GeneratorRun run = Run(source, OutputKind.DynamicallyLinkedLibrary);
+
+        AssertEqual(0, run.GeneratedSources.Length, "A project without opt-in must not receive generated sources.");
+        AssertEqual(0, run.GeneratorDiagnostics.Length, "A project without opt-in must not receive generator diagnostics.");
+    }
+
+    public static void ReportsMissingPartial()
+    {
+        string source = ValidCallbackType.Replace("partial class Game", "class Game", StringComparison.Ordinal);
+        AssertDiagnostic(source, "SDLGEN001");
+    }
+
+    public static void ReportsMultipleCallbackTypes()
+    {
+        string secondType = """
+
+            [SDL.GenerateMain]
+            internal sealed partial class SecondGame : SDL.IMainCallbacks<SecondGame>
+            {
+                public static SDL.AppResult AppInit(out SecondGame? appState, string[] args)
+                {
+                    appState = new SecondGame();
+                    return SDL.AppResult.Continue;
+                }
+
+                public SDL.AppResult AppIterate() => SDL.AppResult.Continue;
+                public SDL.AppResult AppEvent(ref SDL.Event @event) => SDL.AppResult.Continue;
+                public void AppQuit(SDL.AppResult result) { }
+            }
+            """;
+        AssertDiagnostic(ValidCallbackType + secondType, "SDLGEN002");
+    }
+
+    public static void ReportsIncompatibleContract()
+    {
+        string source = """
+            using SDL3;
+            [SDL.GenerateMain]
+            internal sealed partial class Game
+            {
+            }
+            """;
+        AssertDiagnostic(source, "SDLGEN003");
+    }
+
+    public static void ReportsExistingEntryPoint()
+    {
+        string source = ValidCallbackType + """
+
+            internal static class Program
+            {
+                public static void Main(string[] args) { }
+            }
+            """;
+        AssertDiagnostic(source, "SDLGEN004");
+    }
+
+    public static void ReportsTopLevelStatements()
+    {
+        string source = ValidCallbackType.Replace("namespace Demo;", "System.Console.WriteLine(\"existing\");", StringComparison.Ordinal);
+        AssertDiagnostic(source, "SDLGEN004");
+    }
+
+    public static void ReportsUnsupportedTypeShape()
+    {
+        string source = ValidCallbackType.Replace("sealed partial class Game", "abstract partial class Game", StringComparison.Ordinal);
+        AssertDiagnostic(source, "SDLGEN005");
+    }
+
+    public static void ReportsNonExecutableProject()
+    {
+        AssertDiagnostic(ValidCallbackType, "SDLGEN006", OutputKind.DynamicallyLinkedLibrary);
+    }
+
+    private static void AssertDiagnostic(string source, string expectedId, OutputKind outputKind = OutputKind.ConsoleApplication)
+    {
+        GeneratorRun run = Run(source, outputKind);
+        Diagnostic[] matches = run.GeneratorDiagnostics.Where(diagnostic => diagnostic.Id == expectedId).ToArray();
+        int expectedCount = expectedId == "SDLGEN002" ? 2 : 1;
+        AssertEqual(expectedCount, matches.Length, $"Generator must report {expectedId}. Actual: {string.Join(", ", run.GeneratorDiagnostics.Select(diagnostic => diagnostic.Id))}");
+        AssertEqual(0, run.GeneratedSources.Length, $"Generator must not emit source when reporting {expectedId}.");
+    }
+
+    private static GeneratorRun Run(string source, OutputKind outputKind = OutputKind.ConsoleApplication)
+    {
+        CSharpParseOptions parseOptions = new(LanguageVersion.Preview);
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        IEnumerable<MetadataReference> references = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path))
+            .Append(MetadataReference.CreateFromFile(typeof(SDL3.SDL).Assembly.Location));
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "GeneratorConsumer",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));
+
+        ISourceGenerator generator = new MainCallbacksGenerator().AsSourceGenerator();
+        GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], parseOptions: parseOptions);
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation outputCompilation, out _);
+        GeneratorDriverRunResult result = driver.GetRunResult();
+        string[] generatedSources = result.Results.SelectMany(generatorResult => generatorResult.GeneratedSources).Select(generated => generated.SourceText.ToString()).ToArray();
+        Diagnostic[] diagnostics = result.Results.SelectMany(generatorResult => generatorResult.Diagnostics).ToArray();
+        return new GeneratorRun(outputCompilation, generatedSources, diagnostics);
+    }
+
+    private static void AssertContains(string expected, string actual, string message)
+    {
+        if (!actual.Contains(expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"{message} Expected fragment: {expected}{Environment.NewLine}Generated:{Environment.NewLine}{actual}");
+        }
+    }
+
+    private static void AssertEqual<T>(T expected, T actual, string message)
+    {
+        if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        {
+            throw new InvalidOperationException($"{message} Expected: {expected}; actual: {actual}.");
+        }
+    }
+
+    private sealed record GeneratorRun(Compilation OutputCompilation, string[] GeneratedSources, Diagnostic[] GeneratorDiagnostics);
+}

--- a/SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj
+++ b/SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>14</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SDL3-CS\SDL3-CS.csproj" />
+    <ProjectReference Include="..\SDL3-CS.Generators\SDL3-CS.Generators.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/SDL3-CS.Generators/AnalyzerReleases.Shipped.md
+++ b/SDL3-CS.Generators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,1 @@
+; Shipped analyzer releases

--- a/SDL3-CS.Generators/AnalyzerReleases.Unshipped.md
+++ b/SDL3-CS.Generators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,12 @@
+; Unshipped analyzer release
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+SDLGEN001 | SDL3-CS.MainCallbacks | Error | Main callback type must be partial
+SDLGEN002 | SDL3-CS.MainCallbacks | Error | Only one generated SDL entry point is allowed
+SDLGEN003 | SDL3-CS.MainCallbacks | Error | Main callback type must implement its self contract
+SDLGEN004 | SDL3-CS.MainCallbacks | Error | Existing entry points and top-level statements are incompatible
+SDLGEN005 | SDL3-CS.MainCallbacks | Error | Main callback type shape is unsupported
+SDLGEN006 | SDL3-CS.MainCallbacks | Error | Generated entry points require executable output

--- a/SDL3-CS.Generators/MainCallbacksGenerator.cs
+++ b/SDL3-CS.Generators/MainCallbacksGenerator.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace SDL3.Generators;
+
+[Generator(LanguageNames.CSharp)]
+public sealed class MainCallbacksGenerator : IIncrementalGenerator
+{
+    private const string AttributeMetadataName = "SDL3.SDL+GenerateMainAttribute";
+    private const string ContractMetadataName = "SDL3.SDL+IMainCallbacks`1";
+
+    private static readonly DiagnosticDescriptor MissingPartial = new(
+        "SDLGEN001",
+        "Main callback type must be partial",
+        "Type '{0}' must be declared partial so SDL3-CS can generate its Main entry point",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor MultipleCallbackTypes = new(
+        "SDLGEN002",
+        "Only one generated SDL entry point is allowed",
+        "Project contains multiple types marked with SDL.GenerateMain; keep the attribute only on one callback type",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor IncompatibleContract = new(
+        "SDLGEN003",
+        "Main callback type does not implement its SDL contract",
+        "Type '{0}' must implement SDL.IMainCallbacks<{0}>",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ExistingEntryPoint = new(
+        "SDLGEN004",
+        "Project already has an entry point",
+        "SDL3-CS cannot generate Main for '{0}' because the project already contains an entry point or top-level statements",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor UnsupportedTypeShape = new(
+        "SDLGEN005",
+        "Unsupported main callback type",
+        "Type '{0}' must be a top-level, non-abstract, non-generic class",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor UnsupportedOutputKind = new(
+        "SDLGEN006",
+        "Generated SDL entry point requires an executable project",
+        "SDL.GenerateMain on '{0}' requires OutputType Exe or WinExe",
+        "SDL3-CS.MainCallbacks",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        IncrementalValuesProvider<INamedTypeSymbol> candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
+            AttributeMetadataName,
+            static (node, _) => node is ClassDeclarationSyntax,
+            static (attributeContext, _) => (INamedTypeSymbol)attributeContext.TargetSymbol);
+
+        IncrementalValueProvider<(Compilation Compilation, ImmutableArray<INamedTypeSymbol> Candidates)> input =
+            context.CompilationProvider.Combine(candidates.Collect());
+
+        context.RegisterSourceOutput(input, static (sourceContext, value) =>
+            Generate(sourceContext, value.Compilation, value.Candidates));
+    }
+
+    private static void Generate(
+        SourceProductionContext context,
+        Compilation compilation,
+        ImmutableArray<INamedTypeSymbol> candidates)
+    {
+        if (candidates.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        List<INamedTypeSymbol> uniqueCandidates = [];
+        foreach (INamedTypeSymbol candidate in candidates)
+        {
+            if (!uniqueCandidates.Any(existing => SymbolEqualityComparer.Default.Equals(existing, candidate)))
+            {
+                uniqueCandidates.Add(candidate);
+            }
+        }
+
+        if (uniqueCandidates.Count != 1)
+        {
+            foreach (INamedTypeSymbol candidate in uniqueCandidates)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MultipleCallbackTypes, GetLocation(candidate)));
+            }
+
+            return;
+        }
+
+        INamedTypeSymbol callbackType = uniqueCandidates[0];
+        if (!IsPartial(callbackType, context.CancellationToken))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MissingPartial, GetLocation(callbackType), callbackType.Name));
+            return;
+        }
+
+        if (callbackType.TypeKind != TypeKind.Class ||
+            callbackType.IsAbstract ||
+            callbackType.IsStatic ||
+            callbackType.Arity != 0 ||
+            callbackType.ContainingType is not null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(UnsupportedTypeShape, GetLocation(callbackType), callbackType.Name));
+            return;
+        }
+
+        INamedTypeSymbol? contract = compilation.GetTypeByMetadataName(ContractMetadataName);
+        bool implementsSelfContract = contract is not null && callbackType.AllInterfaces.Any(candidateContract =>
+            SymbolEqualityComparer.Default.Equals(candidateContract.OriginalDefinition, contract) &&
+            candidateContract.TypeArguments.Length == 1 &&
+            SymbolEqualityComparer.Default.Equals(candidateContract.TypeArguments[0], callbackType));
+        if (!implementsSelfContract)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(IncompatibleContract, GetLocation(callbackType), callbackType.Name));
+            return;
+        }
+
+        if (compilation.Options.OutputKind is not OutputKind.ConsoleApplication and not OutputKind.WindowsApplication)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(UnsupportedOutputKind, GetLocation(callbackType), callbackType.Name));
+            return;
+        }
+
+        if (compilation.GetEntryPoint(context.CancellationToken) is not null)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(ExistingEntryPoint, GetLocation(callbackType), callbackType.Name));
+            return;
+        }
+
+        string typeName = EscapeIdentifier(callbackType.Name);
+        string fullyQualifiedTypeName = callbackType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        string? namespaceName = callbackType.ContainingNamespace is { IsGlobalNamespace: false } containingNamespace
+            ? containingNamespace.ToDisplayString()
+            : null;
+        StringBuilder source = new();
+        source.AppendLine("// <auto-generated/>");
+        source.AppendLine("#nullable enable");
+        if (namespaceName is not null)
+        {
+            source.Append("namespace ").Append(namespaceName).AppendLine();
+            source.AppendLine("{");
+        }
+
+        string indent = namespaceName is null ? string.Empty : "    ";
+        source.Append(indent).Append("partial class ").Append(typeName).AppendLine();
+        source.Append(indent).AppendLine("{");
+        source.Append(indent).AppendLine("    /// <summary>Runs the SDL managed main-callback application.</summary>");
+        source.Append(indent).AppendLine("    /// <param name=\"args\">Application arguments, excluding the executable path.</param>");
+        source.Append(indent).AppendLine("    /// <returns>The platform main return code.</returns>");
+        source.Append(indent).AppendLine("    public static int Main(string[] args)");
+        source.Append(indent).Append("        => global::SDL3.SDL.RunMainCallbacks<")
+            .Append(fullyQualifiedTypeName)
+            .AppendLine(">(args);");
+        source.Append(indent).AppendLine("}");
+        if (namespaceName is not null)
+        {
+            source.AppendLine("}");
+        }
+
+        string hintName = $"SDL3.MainCallbacks.{SanitizeHintName(callbackType)}.g.cs";
+        context.AddSource(hintName, SourceText.From(source.ToString(), Encoding.UTF8));
+    }
+
+    private static bool IsPartial(INamedTypeSymbol type, CancellationToken cancellationToken)
+    {
+        ImmutableArray<SyntaxReference> declarations = type.DeclaringSyntaxReferences;
+        return declarations.Length != 0 && declarations.All(reference =>
+            reference.GetSyntax(cancellationToken) is TypeDeclarationSyntax declaration &&
+            declaration.Modifiers.Any(SyntaxKind.PartialKeyword));
+    }
+
+    private static Location GetLocation(INamedTypeSymbol type)
+    {
+        return type.Locations.FirstOrDefault(location => location.IsInSource) ?? Location.None;
+    }
+
+    private static string EscapeIdentifier(string identifier)
+    {
+        return SyntaxFacts.GetKeywordKind(identifier) == SyntaxKind.None ? identifier : $"@{identifier}";
+    }
+
+    private static string SanitizeHintName(INamedTypeSymbol type)
+    {
+        string name = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        foreach (char invalidCharacter in new[] { '<', '>', ':', '"', '/', '\\', '|', '?', '*', '.', '+' })
+        {
+            name = name.Replace(invalidCharacter, '_');
+        }
+
+        return name;
+    }
+}

--- a/SDL3-CS.Generators/SDL3-CS.Generators.csproj
+++ b/SDL3-CS.Generators/SDL3-CS.Generators.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <RootNamespace>SDL3.Generators</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -1,5 +1,12 @@
 using SDL3;
 
+if (args.SequenceEqual(["--main-callbacks-only"]))
+{
+    SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunManagedMainCallbackFocusedTests();
+    Console.WriteLine("SDL managed main callback focused tests passed.");
+    return;
+}
+
 SDL3.Tests.Repository.FileNameTests.TrackedFilePaths_DoNotContainCyrillicCharacters();
 Console.WriteLine("Repository tracked file path Cyrillic guard test passed.");
 SDL3.Tests.Repository.FileNameTests.TrackedCSharpIdentifiers_DoNotContainCyrillicCharacters();
@@ -136,6 +143,24 @@ SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_ForwardsArgumentsA
 Console.WriteLine("SDL.EnterAppMainCallbacks binding test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_NullAndEmptyArgumentsForwardNull();
 Console.WriteLine("SDL.EnterAppMainCallbacks null and empty argv normalization test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_UsesManagedArgumentsAndForwardsLifecycle();
+Console.WriteLine("SDL.RunMainCallbacks managed lifecycle test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_NormalizesNullArgumentsAndSupportsEarlySuccess();
+Console.WriteLine("SDL.RunMainCallbacks null arguments and early success test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_RejectsContinueWithoutState();
+Console.WriteLine("SDL.RunMainCallbacks null-state contract test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_AllowsEarlyTerminationWithoutState();
+Console.WriteLine("SDL.RunMainCallbacks stateless early termination test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_ContainsAndRethrowsManagedCallbackExceptions();
+Console.WriteLine("SDL.RunMainCallbacks exception boundary test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_PerformsFallbackCleanupAndIgnoresDuplicateQuit();
+Console.WriteLine("SDL.RunMainCallbacks cleanup idempotency test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_CleansUpBeforeRethrowingNativeFailure();
+Console.WriteLine("SDL.RunMainCallbacks native failure cleanup test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunMainCallbacks_WaitsForActiveEventBeforeQuit();
+Console.WriteLine("SDL.RunMainCallbacks concurrent quit test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.ManagedMainCallbacks_PublicContractHasExpectedShape();
+Console.WriteLine("SDL managed main callbacks public contract test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.RegisterApp_ForwardsNameStyleHInstAndReturnsNativeValue();
 Console.WriteLine("SDL.RegisterApp binding test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.UnregisterApp_CallsNativeHook();

--- a/SDL3-CS.Tests/SDL/Basics/main/ManagedCallbacks.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/ManagedCallbacks.cs
@@ -1,0 +1,380 @@
+namespace SDL3.Tests.SDL.Basics.Main;
+
+internal static partial class PInvokeTests
+{
+    private static IntPtr managedAppstate;
+
+    public static void RunManagedMainCallbackFocusedTests()
+    {
+        RunMainCallbacks_UsesManagedArgumentsAndForwardsLifecycle();
+        RunMainCallbacks_NormalizesNullArgumentsAndSupportsEarlySuccess();
+        RunMainCallbacks_RejectsContinueWithoutState();
+        RunMainCallbacks_AllowsEarlyTerminationWithoutState();
+        RunMainCallbacks_ContainsAndRethrowsManagedCallbackExceptions();
+        RunMainCallbacks_PerformsFallbackCleanupAndIgnoresDuplicateQuit();
+        RunMainCallbacks_CleansUpBeforeRethrowingNativeFailure();
+        RunMainCallbacks_WaitsForActiveEventBeforeQuit();
+        ManagedMainCallbacks_PublicContractHasExpectedShape();
+    }
+
+    public static void RunMainCallbacks_UsesManagedArgumentsAndForwardsLifecycle()
+    {
+        RecordingApp.Reset();
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedLifecycle));
+
+        int result = SDL3.SDL.RunMainCallbacks<RecordingApp>(["--renderer", "software"]);
+
+        TestAssert.Equal(73, result, "SDL.RunMainCallbacks must return the native main result.");
+        TestAssert.Equal(2, RecordingApp.Arguments.Length, "Managed AppInit must receive only C# Main arguments.");
+        TestAssert.Equal("--renderer", RecordingApp.Arguments[0], "Managed AppInit must preserve the first argument.");
+        TestAssert.Equal("software", RecordingApp.Arguments[1], "Managed AppInit must preserve the second argument.");
+        TestAssert.Equal(1, RecordingApp.IterateCount, "Managed AppIterate must run once.");
+        TestAssert.Equal(1, RecordingApp.EventCount, "Managed AppEvent must run once.");
+        TestAssert.Equal((uint)SDL3.SDL.EventType.Quit, RecordingApp.EventType, "Managed AppEvent must receive the native event by reference.");
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Managed AppQuit must run once.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, RecordingApp.QuitResult, "Managed AppQuit must receive the native termination result.");
+    }
+
+    public static void RunMainCallbacks_NormalizesNullArgumentsAndSupportsEarlySuccess()
+    {
+        RecordingApp.Reset();
+        RecordingApp.InitResult = SDL3.SDL.AppResult.Success;
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedEarlyExit));
+
+        int result = SDL3.SDL.RunMainCallbacks<RecordingApp>(null);
+
+        TestAssert.Equal(17, result, "SDL.RunMainCallbacks must preserve an early native result.");
+        TestAssert.Equal(0, RecordingApp.Arguments.Length, "Managed AppInit must normalize null arguments to an empty array.");
+        TestAssert.Equal(0, RecordingApp.IterateCount, "Early success must not invoke AppIterate.");
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Early success must still invoke AppQuit once.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, RecordingApp.QuitResult, "Early success must reach AppQuit.");
+    }
+
+    public static void RunMainCallbacks_RejectsContinueWithoutState()
+    {
+        RecordingApp.Reset();
+        RecordingApp.ReturnNullState = true;
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedInitFailure));
+
+        InvalidOperationException exception = CaptureException<InvalidOperationException>(
+            () => SDL3.SDL.RunMainCallbacks<RecordingApp>([]),
+            "Continue without managed state must fail after returning from the native boundary.");
+
+        TestAssert.True(exception.Message.Contains("state", StringComparison.OrdinalIgnoreCase), "The null-state error must explain the invalid state contract.");
+        TestAssert.Equal(0, RecordingApp.QuitCount, "AppQuit cannot run when AppInit did not create state.");
+    }
+
+    public static void RunMainCallbacks_AllowsEarlyTerminationWithoutState()
+    {
+        RecordingApp.Reset();
+        RecordingApp.ReturnNullState = true;
+        RecordingApp.InitResult = SDL3.SDL.AppResult.Success;
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedEarlyExit));
+
+        int result = SDL3.SDL.RunMainCallbacks<RecordingApp>([]);
+
+        TestAssert.Equal(17, result, "Early termination without state must preserve the native result.");
+        TestAssert.Equal(0, RecordingApp.QuitCount, "AppQuit cannot run when early termination did not create state.");
+    }
+
+    public static void RunMainCallbacks_ContainsAndRethrowsManagedCallbackExceptions()
+    {
+        foreach (CallbackStage stage in Enum.GetValues<CallbackStage>())
+        {
+            RecordingApp.Reset();
+            RecordingApp.ThrowAt = stage;
+            using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedFailure));
+
+            ApplicationException exception = CaptureException<ApplicationException>(
+                () => SDL3.SDL.RunMainCallbacks<RecordingApp>([stage.ToString()]),
+                $"An exception from {stage} must be rethrown after the native boundary.");
+
+            TestAssert.Equal(stage.ToString(), exception.Message, $"The original {stage} exception must be preserved.");
+            TestAssert.True(RecordingApp.NativeBoundaryReturned, $"The {stage} exception must not escape through the native callback boundary.");
+        }
+    }
+
+    public static void RunMainCallbacks_PerformsFallbackCleanupAndIgnoresDuplicateQuit()
+    {
+        RecordingApp.Reset();
+        using (NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedWithoutQuit)))
+        {
+            SDL3.SDL.RunMainCallbacks<RecordingApp>([]);
+        }
+
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Runner fallback must invoke AppQuit when the native path omits it.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Failure, RecordingApp.QuitResult, "Fallback cleanup must report an incomplete native lifecycle as failure.");
+
+        RecordingApp.Reset();
+        using (NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedDuplicateQuit)))
+        {
+            SDL3.SDL.RunMainCallbacks<RecordingApp>([]);
+        }
+
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Duplicate native AppQuit calls must reach managed state only once.");
+    }
+
+    public static void RunMainCallbacks_CleansUpBeforeRethrowingNativeFailure()
+    {
+        RecordingApp.Reset();
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedNativeFailure));
+
+        NotSupportedException exception = CaptureException<NotSupportedException>(
+            () => SDL3.SDL.RunMainCallbacks<RecordingApp>([]),
+            "A native bridge failure must be rethrown after managed cleanup.");
+
+        TestAssert.Equal("native bridge", exception.Message, "Runner must preserve the native bridge exception.");
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Native bridge failure must trigger fallback AppQuit.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Failure, RecordingApp.QuitResult, "Native bridge failure cleanup must use AppResult.Failure.");
+    }
+
+    public static void RunMainCallbacks_WaitsForActiveEventBeforeQuit()
+    {
+        RecordingApp.Reset();
+        RecordingApp.BlockEvent = true;
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(RunManagedConcurrentQuit));
+
+        SDL3.SDL.RunMainCallbacks<RecordingApp>([]);
+
+        TestAssert.Equal(1, RecordingApp.EventCount, "Concurrent event must complete.");
+        TestAssert.Equal(1, RecordingApp.QuitCount, "Quit must run after the active event.");
+        TestAssert.True(RecordingApp.EventCompletedBeforeQuit, "AppQuit must wait for an active AppEvent before releasing state.");
+    }
+
+    public static void ManagedMainCallbacks_PublicContractHasExpectedShape()
+    {
+        Type contract = typeof(SDL3.SDL.IMainCallbacks<RecordingApp>);
+        TestAssert.True(contract.IsInterface, "SDL.IMainCallbacks<TSelf> must be an interface.");
+        TestAssert.NotNull(contract.GetMethod("AppInit"), "Managed callback contract must expose AppInit.");
+        TestAssert.NotNull(contract.GetMethod("AppIterate"), "Managed callback contract must expose AppIterate.");
+        TestAssert.NotNull(contract.GetMethod("AppEvent"), "Managed callback contract must expose AppEvent.");
+        TestAssert.NotNull(contract.GetMethod("AppQuit"), "Managed callback contract must expose AppQuit.");
+
+        AttributeUsageAttribute? usage = typeof(SDL3.SDL.GenerateMainAttribute).GetCustomAttributes(typeof(AttributeUsageAttribute), false).Cast<AttributeUsageAttribute>().SingleOrDefault();
+        TestAssert.NotNull(usage, "SDL.GenerateMainAttribute must declare AttributeUsage.");
+        TestAssert.Equal(AttributeTargets.Class, usage!.ValidOn, "SDL.GenerateMainAttribute must target classes.");
+        TestAssert.Equal(false, usage.AllowMultiple, "SDL.GenerateMainAttribute must not allow duplicates.");
+        TestAssert.Equal(false, usage.Inherited, "SDL.GenerateMainAttribute must not be inherited.");
+    }
+
+    private static int RunManagedLifecycle(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        AssertNativeArguments(argc, argv, "--renderer", "software");
+        managedAppstate = IntPtr.Zero;
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appinit(ref managedAppstate, argc, argv), "Managed AppInit must continue.");
+        TestAssert.True(managedAppstate != IntPtr.Zero, "Managed AppInit must provide an opaque native state handle.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appiter(managedAppstate), "Managed AppIterate must continue.");
+        SDL3.SDL.Event @event = new() { Type = (uint)SDL3.SDL.EventType.Quit };
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appevent(managedAppstate, ref @event), "Managed AppEvent must continue.");
+        TestAssert.Equal((uint)SDL3.SDL.EventType.Terminating, @event.Type, "Managed AppEvent must preserve ref mutations.");
+        appquit(managedAppstate, SDL3.SDL.AppResult.Success);
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, appiter(managedAppstate), "Callbacks after quit begins must not access released state.");
+        SDL3.SDL.Event eventAfterQuit = new() { Type = (uint)SDL3.SDL.EventType.Quit };
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, appevent(managedAppstate, ref eventAfterQuit), "Events after quit begins must not access released state.");
+        TestAssert.Equal((uint)SDL3.SDL.EventType.Quit, eventAfterQuit.Type, "Events after quit must remain untouched.");
+        return 73;
+    }
+
+    private static int RunManagedEarlyExit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        AssertNativeArguments(argc, argv);
+        managedAppstate = IntPtr.Zero;
+        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, result, "Managed AppInit must return configured early success.");
+        appquit(managedAppstate, result);
+        return 17;
+    }
+
+    private static int RunManagedInitFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        TestAssert.Equal(SDL3.SDL.AppResult.Failure, result, "Invalid managed state must become native failure.");
+        appquit(managedAppstate, result);
+        return -1;
+    }
+
+    private static int RunManagedFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        if (result == SDL3.SDL.AppResult.Continue)
+        {
+            result = appiter(managedAppstate);
+        }
+
+        if (result == SDL3.SDL.AppResult.Continue)
+        {
+            SDL3.SDL.Event @event = new() { Type = (uint)SDL3.SDL.EventType.Quit };
+            result = appevent(managedAppstate, ref @event);
+        }
+
+        appquit(managedAppstate, result);
+        RecordingApp.NativeBoundaryReturned = true;
+        return -1;
+    }
+
+    private static int RunManagedWithoutQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appinit(ref managedAppstate, argc, argv), "Managed AppInit must continue before fallback cleanup.");
+        return 0;
+    }
+
+    private static int RunManagedDuplicateQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        appinit(ref managedAppstate, argc, argv);
+        appquit(managedAppstate, SDL3.SDL.AppResult.Success);
+        appquit(managedAppstate, SDL3.SDL.AppResult.Failure);
+        return 0;
+    }
+
+    private static int RunManagedNativeFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        appinit(ref managedAppstate, argc, argv);
+        throw new NotSupportedException("native bridge");
+    }
+
+    private static int RunManagedConcurrentQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    {
+        managedAppstate = IntPtr.Zero;
+        appinit(ref managedAppstate, argc, argv);
+        SDL3.SDL.Event @event = new() { Type = (uint)SDL3.SDL.EventType.Quit };
+        Task<SDL3.SDL.AppResult> eventTask = Task.Run(() => appevent(managedAppstate, ref @event));
+        TestAssert.True(RecordingApp.EventEntered.Wait(TimeSpan.FromSeconds(5)), "Managed AppEvent did not start in time.");
+        Task quitTask = Task.Run(() => appquit(managedAppstate, SDL3.SDL.AppResult.Success));
+        TestAssert.Equal(false, RecordingApp.QuitEntered.Wait(TimeSpan.FromMilliseconds(100)), "AppQuit must not enter user code while AppEvent is active.");
+        RecordingApp.ReleaseEvent.Set();
+        TestAssert.True(Task.WaitAll([eventTask, quitTask], TimeSpan.FromSeconds(5)), "Concurrent event and quit did not complete in time.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, appiter(managedAppstate), "The quit result must remain terminal when an active event returns later.");
+        return 0;
+    }
+
+    private static void AssertNativeArguments(int argc, string[]? argv, params string[] expectedArgs)
+    {
+        TestAssert.NotNull(argv, "Native argv must contain the executable path.");
+        TestAssert.Equal(expectedArgs.Length + 1, argc, "Native argc must include the executable path.");
+        TestAssert.Equal(argc, argv!.Length, "Native argc must match argv length.");
+        TestAssert.True(!string.IsNullOrWhiteSpace(argv[0]), "Native argv[0] must identify the executable.");
+        for (int index = 0; index < expectedArgs.Length; index++)
+        {
+            TestAssert.Equal(expectedArgs[index], argv[index + 1], $"Native argv must preserve managed argument {index}.");
+        }
+    }
+
+    private static TException CaptureException<TException>(Action action, string message)
+        where TException : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (TException exception)
+        {
+            return exception;
+        }
+
+        throw new InvalidOperationException(message);
+    }
+
+    private enum CallbackStage
+    {
+        Init,
+        Iterate,
+        Event,
+        Quit
+    }
+
+    private sealed class RecordingApp : SDL3.SDL.IMainCallbacks<RecordingApp>
+    {
+        public static string[] Arguments { get; private set; } = [];
+        public static SDL3.SDL.AppResult InitResult { get; set; } = SDL3.SDL.AppResult.Continue;
+        public static bool ReturnNullState { get; set; }
+        public static CallbackStage? ThrowAt { get; set; }
+        public static bool NativeBoundaryReturned { get; set; }
+        public static int IterateCount { get; private set; }
+        public static int EventCount { get; private set; }
+        public static uint EventType { get; private set; }
+        public static int QuitCount { get; private set; }
+        public static SDL3.SDL.AppResult QuitResult { get; private set; }
+        public static bool BlockEvent { get; set; }
+        public static bool EventCompletedBeforeQuit { get; private set; }
+        public static ManualResetEventSlim EventEntered { get; } = new(false);
+        public static ManualResetEventSlim ReleaseEvent { get; } = new(false);
+        public static ManualResetEventSlim QuitEntered { get; } = new(false);
+
+        public static SDL3.SDL.AppResult AppInit(out RecordingApp? appState, string[] args)
+        {
+            appState = null;
+            Arguments = args;
+            ThrowIfConfigured(CallbackStage.Init);
+            if (!ReturnNullState)
+            {
+                appState = new RecordingApp();
+            }
+
+            return InitResult;
+        }
+
+        public SDL3.SDL.AppResult AppIterate()
+        {
+            IterateCount++;
+            ThrowIfConfigured(CallbackStage.Iterate);
+            return SDL3.SDL.AppResult.Continue;
+        }
+
+        public SDL3.SDL.AppResult AppEvent(ref SDL3.SDL.Event @event)
+        {
+            EventCount++;
+            EventType = @event.Type;
+            ThrowIfConfigured(CallbackStage.Event);
+            if (BlockEvent)
+            {
+                EventEntered.Set();
+                TestAssert.True(ReleaseEvent.Wait(TimeSpan.FromSeconds(5)), "Managed AppEvent was not released in time.");
+            }
+
+            @event.Type = (uint)SDL3.SDL.EventType.Terminating;
+            EventCompletedBeforeQuit = true;
+            return SDL3.SDL.AppResult.Continue;
+        }
+
+        public void AppQuit(SDL3.SDL.AppResult result)
+        {
+            QuitEntered.Set();
+            QuitCount++;
+            QuitResult = result;
+            TestAssert.True(!BlockEvent || EventCompletedBeforeQuit, "AppQuit entered before AppEvent completed.");
+            ThrowIfConfigured(CallbackStage.Quit);
+        }
+
+        public static void Reset()
+        {
+            Arguments = [];
+            InitResult = SDL3.SDL.AppResult.Continue;
+            ReturnNullState = false;
+            ThrowAt = null;
+            NativeBoundaryReturned = false;
+            IterateCount = 0;
+            EventCount = 0;
+            EventType = 0;
+            QuitCount = 0;
+            QuitResult = default;
+            BlockEvent = false;
+            EventCompletedBeforeQuit = false;
+            EventEntered.Reset();
+            ReleaseEvent.Reset();
+            QuitEntered.Reset();
+        }
+
+        private static void ThrowIfConfigured(CallbackStage stage)
+        {
+            if (ThrowAt == stage)
+            {
+                throw new ApplicationException(stage.ToString());
+            }
+        }
+    }
+}

--- a/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
@@ -5,7 +5,7 @@ using SDL3.Tests;
 
 namespace SDL3.Tests.SDL.Basics.Main;
 
-internal static class PInvokeTests
+internal static partial class PInvokeTests
 {
     private static IntPtr capturedAppstate;
     private static IntPtr nextAppstate;

--- a/SDL3-CS/README.md
+++ b/SDL3-CS/README.md
@@ -15,6 +15,7 @@
 - Add-on bindings for Image, TTF, Mixer, and ShaderCross namespaces.
 - C# representations of SDL enums, flags, structs, callbacks, opaque handles, and constants.
 - XML documentation generated from upstream SDL documentation and kept warning-clean by repository checks.
+- A managed SDL main-callback contract, runtime runner, and opt-in `Main` source generator.
 - NuGet package metadata for the managed `SDL3-CS` package.
 
 ## What This Project Does Not Ship
@@ -53,9 +54,12 @@ dotnet add package SDL3-CS.Windows
 
 Replace `Windows` with the native package family for the platform that will run the application. Add companion native packages such as `SDL3-CS.Windows.Image` only when the application uses those companion bindings.
 
+For a callback-based application, implement `SDL.IMainCallbacks<TSelf>` on a partial class and apply `[SDL.GenerateMain]`. The analyzer included in `SDL3-CS` generates `Main(string[] args)` and calls `SDL.RunMainCallbacks<TApp>`; direct calls to the runner are also supported.
+
 ## Source Layout
 
 - `SDL/` contains core SDL3 namespaces grouped by upstream SDL header categories.
+- `../SDL3-CS.Generators/` contains the opt-in managed main-callback entry-point generator shipped as an analyzer asset.
 - `Image/`, `TTF/`, `Mixer/`, and `ShaderCross/` contain companion library bindings.
 - Public wrapper methods carry XML documentation; private native entry points stay implementation-focused.
 - Unsafe and fixed-buffer shapes are used where SDL ABI compatibility requires them.

--- a/SDL3-CS/SDL/Basics/main/ManagedCallbacks.cs
+++ b/SDL3-CS/SDL/Basics/main/ManagedCallbacks.cs
@@ -1,0 +1,393 @@
+#region License
+/* Copyright (c) 2024-2026 Eduard Gushchin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+#endregion
+
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
+
+namespace SDL3;
+
+public partial class SDL
+{
+    /// <summary>
+    /// Defines a managed SDL application that uses the main-callback lifecycle.
+    /// </summary>
+    /// <typeparam name="TSelf">The managed application state type.</typeparam>
+    /// <remarks>
+    /// Use <see cref="RunMainCallbacks{TApp}"/> to run an implementation directly,
+    /// or apply <see cref="GenerateMainAttribute"/> to let SDL3-CS generate the entry point.
+    /// </remarks>
+    public interface IMainCallbacks<TSelf>
+        where TSelf : class, IMainCallbacks<TSelf>
+    {
+        /// <summary>
+        /// Creates and initializes the managed application state.
+        /// </summary>
+        /// <param name="appState">The managed application state, or <c>null</c> when initialization terminates before state is needed.</param>
+        /// <param name="args">The application arguments, excluding the executable path.</param>
+        /// <returns><see cref="AppResult.Continue"/> to start the callback loop, <see cref="AppResult.Success"/> to finish successfully, or <see cref="AppResult.Failure"/> to finish with an error.</returns>
+        static abstract AppResult AppInit(out TSelf? appState, string[] args);
+
+        /// <summary>
+        /// Runs one managed application iteration.
+        /// </summary>
+        /// <returns><see cref="AppResult.Continue"/> to keep running, <see cref="AppResult.Success"/> to finish successfully, or <see cref="AppResult.Failure"/> to finish with an error.</returns>
+        AppResult AppIterate();
+
+        /// <summary>
+        /// Handles an SDL event for the managed application.
+        /// </summary>
+        /// <param name="event">The event to examine or update.</param>
+        /// <returns><see cref="AppResult.Continue"/> to keep running, <see cref="AppResult.Success"/> to finish successfully, or <see cref="AppResult.Failure"/> to finish with an error.</returns>
+        AppResult AppEvent(ref Event @event);
+
+        /// <summary>
+        /// Releases resources owned by the managed application.
+        /// </summary>
+        /// <param name="result">The result that terminated the application.</param>
+        void AppQuit(AppResult result);
+    }
+
+    /// <summary>
+    /// Requests generation of a managed <c>Main(string[])</c> entry point for an
+    /// <see cref="IMainCallbacks{TSelf}"/> implementation.
+    /// </summary>
+    /// <remarks>
+    /// Apply this attribute to exactly one top-level, non-abstract, non-generic partial class
+    /// in an executable project. The source generator calls <see cref="RunMainCallbacks{TApp}"/>.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class GenerateMainAttribute : Attribute
+    {
+    }
+
+    /// <summary>
+    /// Runs a managed SDL application through the SDL main-callback lifecycle.
+    /// </summary>
+    /// <typeparam name="TApp">The managed application state type.</typeparam>
+    /// <param name="args">The application arguments from a C# <c>Main(string[])</c>, excluding the executable path, or <c>null</c> for no arguments.</param>
+    /// <returns>The platform main return code from <see cref="EnterAppMainCallbacks"/>.</returns>
+    /// <exception cref="InvalidOperationException"><typeparamref name="TApp"/> returns <see cref="AppResult.Continue"/> without creating managed state.</exception>
+    /// <remarks>
+    /// Managed callback exceptions are contained before crossing the native boundary. The first
+    /// exception is rethrown on the calling thread after SDL finishes the callback lifecycle and
+    /// managed state has been released.
+    /// </remarks>
+    public static int RunMainCallbacks<TApp>(string[]? args)
+        where TApp : class, IMainCallbacks<TApp>
+    {
+        string[] managedArgs = args is null ? [] : (string[])args.Clone();
+        string[] nativeArgv = CreateNativeMainArguments(managedArgs);
+        MainCallbacksContext<TApp> context = new(managedArgs);
+        ExceptionDispatchInfo? nativeFailure = null;
+        int result = 0;
+
+        try
+        {
+            result = EnterAppMainCallbacks(
+                nativeArgv.Length,
+                nativeArgv,
+                context.AppInit,
+                context.AppIterate,
+                context.AppEvent,
+                context.AppQuit);
+        }
+        catch (Exception exception)
+        {
+            nativeFailure = ExceptionDispatchInfo.Capture(exception);
+        }
+        finally
+        {
+            context.EnsureQuit();
+        }
+
+        nativeFailure?.Throw();
+        context.ThrowIfFaulted();
+        GC.KeepAlive(context);
+        return result;
+    }
+
+    private static string[] CreateNativeMainArguments(string[] args)
+    {
+        string? executablePath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            executablePath = AppDomain.CurrentDomain.FriendlyName;
+        }
+
+        if (string.IsNullOrWhiteSpace(executablePath))
+        {
+            executablePath = "SDL3-CS";
+        }
+
+        string[] nativeArguments = new string[args.Length + 1];
+        nativeArguments[0] = executablePath;
+        Array.Copy(args, 0, nativeArguments, 1, args.Length);
+        return nativeArguments;
+    }
+
+    private sealed class MainCallbacksContext<TApp>
+        where TApp : class, IMainCallbacks<TApp>
+    {
+        private readonly object sync = new();
+        private readonly string[] arguments;
+        private readonly AppInitFunc appInitCallback;
+        private readonly AppIterateFunc appIterateCallback;
+        private readonly AppEventFunc appEventCallback;
+        private readonly AppQuitFunc appQuitCallback;
+        private TApp? application;
+        private GCHandle stateHandle;
+        private ExceptionDispatchInfo? callbackFailure;
+        private AppResult terminalResult = AppResult.Failure;
+        private int activeCallbacks;
+        private bool stateHandleAllocated;
+        private bool quitStarted;
+        private bool quitCompleted;
+
+        internal MainCallbacksContext(string[] arguments)
+        {
+            this.arguments = arguments;
+            appInitCallback = AppInitCore;
+            appIterateCallback = AppIterateCore;
+            appEventCallback = AppEventCore;
+            appQuitCallback = AppQuitCore;
+        }
+
+        internal AppInitFunc AppInit => appInitCallback;
+        internal AppIterateFunc AppIterate => appIterateCallback;
+        internal AppEventFunc AppEvent => appEventCallback;
+        internal AppQuitFunc AppQuit => appQuitCallback;
+
+        internal void EnsureQuit()
+        {
+            Complete(AppResult.Failure);
+        }
+
+        internal void ThrowIfFaulted()
+        {
+            callbackFailure?.Throw();
+        }
+
+        private AppResult AppInitCore(ref IntPtr appstate, int argc, string[]? argv)
+        {
+            try
+            {
+                AppResult result = TApp.AppInit(out TApp? createdApplication, arguments);
+                if (createdApplication is null)
+                {
+                    if (result == AppResult.Continue)
+                    {
+                        throw new InvalidOperationException($"{typeof(TApp).FullName}.AppInit returned Continue without creating managed state.");
+                    }
+
+                    SetTerminalResultIfRunning(result);
+                    return result;
+                }
+
+                lock (sync)
+                {
+                    application = createdApplication;
+                    stateHandle = GCHandle.Alloc(this, GCHandleType.Normal);
+                    stateHandleAllocated = true;
+                    appstate = GCHandle.ToIntPtr(stateHandle);
+                    terminalResult = result;
+                }
+
+                return result;
+            }
+            catch (Exception exception)
+            {
+                CaptureFailure(exception);
+                SetTerminalResultIfRunning(AppResult.Failure);
+                return AppResult.Failure;
+            }
+        }
+
+        private AppResult AppIterateCore(IntPtr appstate)
+        {
+            if (!TryEnterCallback(out TApp? currentApplication))
+            {
+                return GetTerminalResult();
+            }
+
+            try
+            {
+                AppResult result = currentApplication!.AppIterate();
+                SetTerminalResultIfRunning(result);
+                return result;
+            }
+            catch (Exception exception)
+            {
+                CaptureFailure(exception);
+                SetTerminalResultIfRunning(AppResult.Failure);
+                return AppResult.Failure;
+            }
+            finally
+            {
+                ExitCallback();
+            }
+        }
+
+        private AppResult AppEventCore(IntPtr appstate, ref Event @event)
+        {
+            if (!TryEnterCallback(out TApp? currentApplication))
+            {
+                return GetTerminalResult();
+            }
+
+            try
+            {
+                AppResult result = currentApplication!.AppEvent(ref @event);
+                SetTerminalResultIfRunning(result);
+                return result;
+            }
+            catch (Exception exception)
+            {
+                CaptureFailure(exception);
+                SetTerminalResultIfRunning(AppResult.Failure);
+                return AppResult.Failure;
+            }
+            finally
+            {
+                ExitCallback();
+            }
+        }
+
+        private void AppQuitCore(IntPtr appstate, AppResult result)
+        {
+            Complete(result);
+        }
+
+        private bool TryEnterCallback(out TApp? currentApplication)
+        {
+            lock (sync)
+            {
+                if (quitStarted || application is null)
+                {
+                    currentApplication = null;
+                    return false;
+                }
+
+                activeCallbacks++;
+                currentApplication = application;
+                return true;
+            }
+        }
+
+        private void ExitCallback()
+        {
+            lock (sync)
+            {
+                activeCallbacks--;
+                if (activeCallbacks == 0)
+                {
+                    Monitor.PulseAll(sync);
+                }
+            }
+        }
+
+        private AppResult GetTerminalResult()
+        {
+            lock (sync)
+            {
+                return terminalResult;
+            }
+        }
+
+        private void SetTerminalResultIfRunning(AppResult result)
+        {
+            lock (sync)
+            {
+                if (!quitStarted)
+                {
+                    terminalResult = result;
+                }
+            }
+        }
+
+        private void Complete(AppResult result)
+        {
+            TApp? applicationToQuit;
+            GCHandle handleToFree = default;
+            bool freeHandle;
+
+            lock (sync)
+            {
+                if (quitStarted)
+                {
+                    while (!quitCompleted)
+                    {
+                        Monitor.Wait(sync);
+                    }
+
+                    return;
+                }
+
+                quitStarted = true;
+                terminalResult = result;
+                while (activeCallbacks != 0)
+                {
+                    Monitor.Wait(sync);
+                }
+
+                applicationToQuit = application;
+                application = null;
+                freeHandle = stateHandleAllocated;
+                if (freeHandle)
+                {
+                    handleToFree = stateHandle;
+                    stateHandleAllocated = false;
+                }
+            }
+
+            try
+            {
+                applicationToQuit?.AppQuit(result);
+            }
+            catch (Exception exception)
+            {
+                CaptureFailure(exception);
+            }
+            finally
+            {
+                if (freeHandle)
+                {
+                    handleToFree.Free();
+                }
+
+                lock (sync)
+                {
+                    quitCompleted = true;
+                    Monitor.PulseAll(sync);
+                }
+            }
+        }
+
+        private void CaptureFailure(Exception exception)
+        {
+            lock (sync)
+            {
+                callbackFailure ??= ExceptionDispatchInfo.Capture(exception);
+            }
+        }
+    }
+}

--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -50,6 +50,14 @@
     </PropertyGroup>
     
     <ItemGroup>
+        <ProjectReference Include="..\SDL3-CS.Generators\SDL3-CS.Generators.csproj"
+                          OutputItemType="Analyzer"
+                          ReferenceOutputAssembly="false"
+                          PrivateAssets="all" />
+        <None Include="..\SDL3-CS.Generators\bin\$(Configuration)\netstandard2.0\SDL3-CS.Generators.dll"
+              Pack="true"
+              PackagePath="analyzers/dotnet/cs"
+              Visible="false" />
         <None Include="../README.md" Pack="true" PackagePath="\"/>
         <None Include="../README-nuget.md" Pack="true" PackagePath="\"/>
         <None Include="../LICENSE" Pack="true" PackagePath="\"/>


### PR DESCRIPTION
## Summary

- add `SDL.IMainCallbacks<TSelf>` and `SDL.RunMainCallbacks<TApp>` with managed state, delegate lifetime, exception containment, and concurrent cleanup;
- ship an opt-in `[SDL.GenerateMain]` incremental source generator in the main NuGet package;
- add runtime, generator, package-consumer, XML documentation, coverage, README, and CI validation.

Tracks #232 and implements the design from Discussion #133.

## Release scope

Managed-only change for milestone `SDL3-CS 3.4.12.5`; native packages are unchanged.

## Verification

- managed wrapper and tests build with zero warnings;
- full managed binding runner passes with the published `win-x64` runtime;
- generator diagnostic suite passes;
- local NuGet consumer receives and compiles the generated entry point;
- public XML documentation audit passes;
- focused wrapper coverage reports 19/19 functions covered.