### PR TITLE
Integrate release governance and CI checks

### DIFF
--- a/.github/release-tools/Publish-Release.ps1
+++ b/.github/release-tools/Publish-Release.ps1
@@ -47,6 +47,7 @@ if ($ManagedOnly) {
 }
 $wrapper = @($packages | Where-Object { $_.Id -eq 'SDL3-CS' })[0]
 $tag = "v$($wrapper.PackageVersion)"
+$releaseTarget = Invoke-ReleaseGitValue -RepositoryPath (Get-ReleaseRepoRoot) -Arguments @('rev-parse', 'HEAD')
 $releaseNotesDirPath = Resolve-ReleasePath $ReleaseNotesDir
 $releaseNotesPath = Join-Path $releaseNotesDirPath "$tag.md"
 if (-not (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf)) {
@@ -82,6 +83,15 @@ $packagePaths = $expectedPackagePaths
 if (-not $GitHubRelease -and -not $NuGetPush) {
     Write-Host "No publish target selected. Pass -GitHubRelease and/or -NuGetPush. Use -DryRun to inspect commands."
     return
+}
+
+if (-not $DryRun -or $ValidateReadinessInDryRun) {
+    & (Join-Path (Join-Path $PSScriptRoot '..') 'wiki-tools\Test-PublishedApiWiki.ps1') `
+        -ExpectedManagedVersion $wrapper.PackageVersion `
+        -ExpectedSourceCommit $releaseTarget
+}
+else {
+    Write-Host '[dry-run] published Wiki freshness validation skipped. Pass -ValidateReadinessInDryRun to validate the live Wiki.'
 }
 
 if (-not $SkipPublishStateValidation -and $missingPackagePaths.Count -eq 0) {
@@ -134,7 +144,6 @@ if ($GitHubRelease) {
         throw "GitHub CLI 'gh' is required for -GitHubRelease."
     }
 
-    $releaseTarget = Invoke-ReleaseGitValue -RepositoryPath (Get-ReleaseRepoRoot) -Arguments @('rev-parse', 'HEAD')
     $args = @('release', 'create', $tag, '--repo', $Repository, '--target', $releaseTarget, '--title', "SDL3-CS $($wrapper.PackageVersion)")
     if (Test-Path -LiteralPath $releaseNotesPath -PathType Leaf) {
         & (Join-Path $PSScriptRoot 'Test-ReleaseNotes.ps1') -ReleaseNotesPath $releaseNotesPath

--- a/.github/release-tools/Test-ExampleProjects.Tests.ps1
+++ b/.github/release-tools/Test-ExampleProjects.Tests.ps1
@@ -1,0 +1,97 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param()
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot '../..'))
+$validator = Join-Path $PSScriptRoot 'Test-ExampleProjects.ps1'
+$ciPath = Join-Path $repoRoot '.github/workflows/ci.yml'
+
+if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+    throw "Example project validator was not found: $validator"
+}
+
+function Assert-TextContains {
+    param(
+        [Parameter(Mandatory)][string] $Text,
+        [Parameter(Mandatory)][string] $Expected,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if (-not $Text.Contains($Expected, [System.StringComparison]::Ordinal)) {
+        throw "$Description is missing expected text: $Expected"
+    }
+}
+
+function Assert-ValidationFails {
+    param(
+        [Parameter(Mandatory)][string] $Description,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $failed = $false
+    try {
+        & $Action
+    }
+    catch {
+        $failed = $true
+    }
+
+    if (-not $failed) {
+        throw "Expected example project validation to fail: $Description"
+    }
+}
+
+& $validator -ValidateOnly -Scope All
+
+$ciText = Get-Content -LiteralPath $ciPath -Raw -Encoding UTF8
+foreach ($expectation in @(
+    @{ Text = 'name: Build desktop examples'; Description = 'desktop examples CI job' },
+    @{ Text = 'name: Build Android example'; Description = 'Android example CI job' },
+    @{ Text = 'dotnet workload install android'; Description = 'Android workload installation' },
+    @{ Text = './.github/release-tools/Test-ExampleProjects.ps1 -Configuration Release -Scope Desktop'; Description = 'desktop examples validation command' },
+    @{ Text = './.github/release-tools/Test-ExampleProjects.ps1 -Configuration Release -Scope Android'; Description = 'Android example validation command' }
+)) {
+    Assert-TextContains -Text $ciText -Expected $expectation.Text -Description $expectation.Description
+}
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-example-projects-$([guid]::NewGuid().ToString('N'))"))
+if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe temporary example project path: $tempRoot"
+}
+
+$examplesRoot = Join-Path $tempRoot 'Examples'
+$includedRoot = Join-Path $examplesRoot 'Included'
+$missingRoot = Join-Path $examplesRoot 'Missing'
+New-Item -ItemType Directory -Force -Path $includedRoot, $missingRoot | Out-Null
+
+try {
+    Set-Content -LiteralPath (Join-Path $includedRoot 'Included.csproj') -Value '<Project Sdk="Microsoft.NET.Sdk" />' -Encoding UTF8
+    Set-Content -LiteralPath (Join-Path $missingRoot 'Missing.csproj') -Value '<Project Sdk="Microsoft.NET.Sdk" />' -Encoding UTF8
+
+    $solutionPath = Join-Path $tempRoot 'Examples.sln'
+    @'
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Included", "Examples\Included\Included.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+EndGlobal
+'@ | Set-Content -LiteralPath $solutionPath -Encoding UTF8
+
+    Assert-ValidationFails -Description 'project exists on disk but is absent from solution' -Action {
+        & $validator -ExamplesRoot $examplesRoot -SolutionPath $solutionPath -ValidateOnly -Scope All *> $null
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-example-projects-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary example project path: $resolvedTempRoot"
+        }
+
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Example project tests passed.'

--- a/.github/release-tools/Test-ExampleProjects.ps1
+++ b/.github/release-tools/Test-ExampleProjects.ps1
@@ -1,0 +1,154 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $ExamplesRoot = (Join-Path $PSScriptRoot '../../SDL3-CS.Examples'),
+    [string] $SolutionPath = (Join-Path $PSScriptRoot '../../SDL3-CS.sln'),
+    [ValidateSet('All', 'Desktop', 'Android')]
+    [string] $Scope = 'All',
+    [ValidateSet('Debug', 'Release', 'Prerelease')]
+    [string] $Configuration = 'Release',
+    [switch] $ValidateOnly
+)
+
+function Get-NormalizedFullPath {
+    param([Parameter(Mandatory)][string] $Path)
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd(
+        [System.IO.Path]::DirectorySeparatorChar,
+        [System.IO.Path]::AltDirectorySeparatorChar
+    )
+}
+
+function Test-PathInsideRoot {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $Root
+    )
+
+    $rootPrefix = $Root + [System.IO.Path]::DirectorySeparatorChar
+    return $Path.StartsWith($rootPrefix, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Convert-SolutionProjectPath {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string] $SolutionRoot
+    )
+
+    $directorySeparator = [System.IO.Path]::DirectorySeparatorChar
+    $platformPath = $Path.Replace([char]92, $directorySeparator).Replace([char]47, $directorySeparator)
+    return [System.IO.Path]::GetFullPath((Join-Path $SolutionRoot $platformPath))
+}
+
+function Test-AndroidProject {
+    param([Parameter(Mandatory)][string] $ProjectPath)
+
+    [xml] $projectXml = Get-Content -LiteralPath $ProjectPath -Raw -Encoding UTF8
+    $targetFrameworks = @($projectXml.SelectNodes('//TargetFramework | //TargetFrameworks') |
+        ForEach-Object { $_.InnerText -split ';' })
+    return @($targetFrameworks | Where-Object { $_ -like '*-android*' }).Count -gt 0
+}
+
+function Invoke-ExampleBuild {
+    param(
+        [Parameter(Mandatory)][string] $ProjectPath,
+        [Parameter(Mandatory)][string] $BuildConfiguration
+    )
+
+    & dotnet build $ProjectPath `
+        --configuration $BuildConfiguration `
+        --nologo `
+        /p:GeneratePackageOnBuild=false
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Example project build failed with exit code $LASTEXITCODE`: $ProjectPath"
+    }
+}
+
+$resolvedExamplesRoot = Get-NormalizedFullPath -Path $ExamplesRoot
+$resolvedSolutionPath = [System.IO.Path]::GetFullPath($SolutionPath)
+if (-not (Test-Path -LiteralPath $resolvedExamplesRoot -PathType Container)) {
+    throw "Examples root was not found: $resolvedExamplesRoot"
+}
+if (-not (Test-Path -LiteralPath $resolvedSolutionPath -PathType Leaf)) {
+    throw "Solution was not found: $resolvedSolutionPath"
+}
+
+$projectFiles = @(Get-ChildItem -LiteralPath $resolvedExamplesRoot -Recurse -File -Filter '*.csproj' |
+    Sort-Object FullName)
+if ($projectFiles.Count -eq 0) {
+    throw "No example projects were found under $resolvedExamplesRoot"
+}
+
+$projects = @($projectFiles | ForEach-Object {
+    $fullPath = [System.IO.Path]::GetFullPath($_.FullName)
+    [pscustomobject]@{
+        FullPath = $fullPath
+        RelativePath = [System.IO.Path]::GetRelativePath($resolvedExamplesRoot, $fullPath).Replace('\', '/')
+        IsAndroid = Test-AndroidProject -ProjectPath $fullPath
+    }
+})
+
+$solutionRoot = Split-Path -Parent $resolvedSolutionPath
+$solutionProjectPaths = @(Get-Content -LiteralPath $resolvedSolutionPath -Encoding UTF8 | ForEach-Object {
+    if ($_ -match '^Project\("[^"]+"\)\s*=\s*"[^"]+",\s*"([^"]+\.csproj)"') {
+        Convert-SolutionProjectPath -Path $Matches[1] -SolutionRoot $solutionRoot
+    }
+} | Where-Object { $_ -and (Test-PathInsideRoot -Path $_ -Root $resolvedExamplesRoot) })
+
+$solutionPathCounts = @{}
+foreach ($path in $solutionProjectPaths) {
+    $key = $path.ToUpperInvariant()
+    if (-not $solutionPathCounts.ContainsKey($key)) {
+        $solutionPathCounts[$key] = 0
+    }
+    $solutionPathCounts[$key]++
+}
+
+$missingProjects = @($projects | Where-Object { -not $solutionPathCounts.ContainsKey($_.FullPath.ToUpperInvariant()) })
+$duplicateProjects = @($projects | Where-Object { $solutionPathCounts[$_.FullPath.ToUpperInvariant()] -gt 1 })
+$diskProjectKeys = @{}
+foreach ($project in $projects) {
+    $diskProjectKeys[$project.FullPath.ToUpperInvariant()] = $true
+}
+$extraProjects = @($solutionProjectPaths | Where-Object { -not $diskProjectKeys.ContainsKey($_.ToUpperInvariant()) })
+
+$inventoryErrors = New-Object System.Collections.Generic.List[string]
+foreach ($project in $missingProjects) {
+    $inventoryErrors.Add("Example project is missing from SDL3-CS.sln: $($project.RelativePath)")
+}
+foreach ($project in $duplicateProjects) {
+    $inventoryErrors.Add("Example project appears more than once in SDL3-CS.sln: $($project.RelativePath)")
+}
+foreach ($path in $extraProjects) {
+    $inventoryErrors.Add("SDL3-CS.sln references an unknown example project: $path")
+}
+if ($inventoryErrors.Count -gt 0) {
+    $inventoryErrors | ForEach-Object { Write-Error $_ }
+    throw "Example project inventory validation failed with $($inventoryErrors.Count) error(s)."
+}
+
+$desktopProjects = @($projects | Where-Object { -not $_.IsAndroid })
+$androidProjects = @($projects | Where-Object IsAndroid)
+Write-Host "Example project inventory is valid: $($projects.Count) total, $($desktopProjects.Count) desktop, $($androidProjects.Count) Android."
+
+if ($ValidateOnly) {
+    return
+}
+
+$selectedProjects = switch ($Scope) {
+    'Desktop' { $desktopProjects }
+    'Android' { $androidProjects }
+    default { $projects }
+}
+if ($selectedProjects.Count -eq 0) {
+    throw "No example projects matched scope '$Scope'."
+}
+
+for ($index = 0; $index -lt $selectedProjects.Count; $index++) {
+    $project = $selectedProjects[$index]
+    Write-Host "[$($index + 1)/$($selectedProjects.Count)] Building $($project.RelativePath) ($Configuration)"
+    Invoke-ExampleBuild -ProjectPath $project.FullPath -BuildConfiguration $Configuration
+}
+
+Write-Host "All $($selectedProjects.Count) example project(s) in scope '$Scope' built successfully."

--- a/.github/release-tools/Test-ReleaseReadiness.ps1
+++ b/.github/release-tools/Test-ReleaseReadiness.ps1
@@ -62,6 +62,11 @@ Invoke-ReadinessStep -Name 'Release publish plan' -Script {
     & (Join-Path $PSScriptRoot 'Test-ReleasePublishPlan.ps1')
 }
 
+Invoke-ReadinessStep -Name 'GitHub Wiki generation contract' -Script {
+    & (Join-Path (Join-Path $PSScriptRoot '..') 'wiki-tools\Test-WikiTools.Tests.ps1')
+    & (Join-Path (Join-Path $PSScriptRoot '..') 'wiki-tools\Test-WikiReleaseContract.Tests.ps1')
+}
+
 $manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
 if ($PackageRevision -lt 0) {
     $PackageRevision = [int] $manifest.versioning.packageRevisionDefault

--- a/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
@@ -1,0 +1,74 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $WorkflowPath = '.github/workflows/release-native-packages.yml',
+    [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json')
+)
+
+$validator = Join-Path $PSScriptRoot 'Test-ReleaseWorkflow.ps1'
+if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+    throw "Release workflow validator was not found: $validator"
+}
+
+function Assert-WorkflowValidationFails {
+    param(
+        [Parameter(Mandatory)][string] $Description,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $failed = $false
+    try {
+        & $Action
+    }
+    catch {
+        $failed = $true
+    }
+
+    if (-not $failed) {
+        throw "Expected release workflow validation to fail: $Description"
+    }
+}
+
+$resolvedWorkflow = [System.IO.Path]::GetFullPath($WorkflowPath)
+$workflowText = Get-Content -LiteralPath $resolvedWorkflow -Raw -Encoding UTF8
+$pinnedLoginPattern = '(?m)^\s+uses:\s+NuGet/login@[0-9a-f]{40}\s+#\s+v1\s*$'
+if ($workflowText -notmatch $pinnedLoginPattern) {
+    throw 'Release workflow fixture must contain a SHA-pinned NuGet/login v1 action.'
+}
+
+& $validator -WorkflowPath $resolvedWorkflow -ManifestPath $ManifestPath
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-release-workflow-$([guid]::NewGuid().ToString('N'))"))
+if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe temporary workflow path: $tempRoot"
+}
+
+New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+$tempWorkflow = Join-Path $tempRoot 'release-native-packages.yml'
+
+try {
+    $unpinnedWorkflow = [regex]::Replace(
+        $workflowText,
+        $pinnedLoginPattern,
+        '        uses: NuGet/login@v1'
+    )
+    Set-Content -LiteralPath $tempWorkflow -Value $unpinnedWorkflow -Encoding UTF8
+
+    Assert-WorkflowValidationFails -Description 'unpinned NuGet/login action' -Action {
+        & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-release-workflow-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe temporary workflow path: $resolvedTempRoot"
+        }
+
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Release workflow tests passed.'

--- a/.github/release-tools/Test-ReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.ps1
@@ -144,7 +144,7 @@ Assert-WorkflowContains -Text $workflowText -Expected "Expand-Archive -LiteralPa
 Assert-WorkflowContains -Text $workflowText -Expected '$statePaths = @(' -Description 'publish job assembly state cleanup list'
 Assert-WorkflowContains -Text $workflowText -Expected 'Remove-Item -LiteralPath $path -Recurse -Force' -Description 'publish job assembly state cleanup'
 Assert-WorkflowContains -Text $workflowText -Expected "-StatePath '.'" -Description 'publish job imported assembly state validation'
-Assert-WorkflowContains -Text $workflowText -Expected 'uses: NuGet/login@v1' -Description 'publish job NuGet Trusted Publishing login action'
+Assert-WorkflowRegex -Text $workflowText -Pattern '(?m)^\s+uses:\s+NuGet/login@[0-9a-f]{40}\s+#\s+v1\s*$' -Description 'publish job SHA-pinned NuGet Trusted Publishing login action'
 Assert-WorkflowContains -Text $workflowText -Expected 'id: nuget_login' -Description 'publish job NuGet Trusted Publishing login id'
 Assert-WorkflowContains -Text $workflowText -Expected 'if: ${{ inputs.publish_nuget }}' -Description 'publish job NuGet login gate'
 Assert-WorkflowContains -Text $workflowText -Expected 'user: edwardgushchin' -Description 'publish job NuGet Trusted Publishing user'

--- a/.github/wiki-tools/Generate-ApiWiki.ps1
+++ b/.github/wiki-tools/Generate-ApiWiki.ps1
@@ -1,0 +1,767 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+    [string] $AssemblyPath,
+    [string] $XmlDocPath,
+    [string] $OutputPath,
+    [string] $RepositoryUrl = 'https://github.com/edwardgushchin/SDL3-CS',
+    [string] $WikiUrl = 'https://github.com/edwardgushchin/SDL3-CS/wiki',
+    [string] $HomePageName = ('SDL3' + [char]0x2010 + 'CS-Wiki'),
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $SourceCommit,
+    [string] $GeneratedAtUtc,
+    [string] $ManagedVersion
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$script:WikiMetadataLine = $null
+
+function Resolve-RepoPath {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $BasePath
+    )
+
+    if ([System.IO.Path]::IsPathRooted($Path)) {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $BasePath $Path))
+}
+
+function Assert-ChildPath {
+    param(
+        [Parameter(Mandatory)] [string] $ParentPath,
+        [Parameter(Mandatory)] [string] $ChildPath
+    )
+
+    $parentFull = [System.IO.Path]::GetFullPath($ParentPath).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+    $childFull = [System.IO.Path]::GetFullPath($ChildPath).TrimEnd([System.IO.Path]::DirectorySeparatorChar, [System.IO.Path]::AltDirectorySeparatorChar)
+
+    if ($childFull.Equals($parentFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "OutputPath must not be the repository root: $childFull"
+    }
+
+    $relative = [System.IO.Path]::GetRelativePath($parentFull, $childFull)
+    if ($relative.StartsWith('..') -or [System.IO.Path]::IsPathRooted($relative)) {
+        throw "OutputPath must stay inside ProjectRoot. ProjectRoot=$parentFull OutputPath=$childFull"
+    }
+}
+
+function Get-XmlMemberMap {
+    param([Parameter(Mandatory)] [string] $Path)
+
+    [xml] $document = Get-Content -LiteralPath $Path -Raw
+    $members = @{}
+    foreach ($member in $document.doc.members.member) {
+        $name = $member.GetAttribute('name')
+        if (-not [string]::IsNullOrWhiteSpace($name)) {
+            $members[$name] = $member
+        }
+    }
+
+    return $members
+}
+
+function Get-DocTypeName {
+    param([Parameter(Mandatory)] [System.Type] $Type)
+
+    if ($Type.IsByRef) {
+        return "$(Get-DocTypeName $Type.GetElementType())@"
+    }
+
+    if ($Type.IsPointer) {
+        return "$(Get-DocTypeName $Type.GetElementType())*"
+    }
+
+    if ($Type.IsArray) {
+        $rank = $Type.GetArrayRank()
+        $suffix = if ($rank -eq 1) { '[]' } else { '[' + (',' * ($rank - 1)) + ']' }
+        return "$(Get-DocTypeName $Type.GetElementType())$suffix"
+    }
+
+    if ($Type.IsGenericParameter) {
+        if ($null -ne $Type.DeclaringMethod) {
+            return '``' + $Type.GenericParameterPosition
+        }
+
+        return '`' + $Type.GenericParameterPosition
+    }
+
+    if ($Type.IsGenericType) {
+        $definition = $Type.GetGenericTypeDefinition()
+        $typeName = $definition.FullName.Replace('+', '.')
+        $typeName = $typeName -replace '`[0-9]+$', ''
+        $arguments = @($Type.GetGenericArguments() | ForEach-Object { Get-DocTypeName $_ })
+        return "$typeName{$($arguments -join ',')}"
+    }
+
+    return $Type.FullName.Replace('+', '.')
+}
+
+function Get-MethodXmlId {
+    param([Parameter(Mandatory)] [System.Reflection.MethodInfo] $Method)
+
+    $declaringType = $Method.DeclaringType.FullName.Replace('+', '.')
+    $methodName = $Method.Name
+
+    if ($Method.IsGenericMethod) {
+        $methodName += '``' + $Method.GetGenericArguments().Length
+    }
+
+    $parameters = @($Method.GetParameters() | ForEach-Object { Get-DocTypeName $_.ParameterType })
+    if ($parameters.Count -eq 0) {
+        return "M:$declaringType.$methodName"
+    }
+
+    return "M:$declaringType.$methodName($($parameters -join ','))"
+}
+
+$script:TypeAliases = @{
+    'System.Void' = 'void'
+    'System.Boolean' = 'bool'
+    'System.Byte' = 'byte'
+    'System.SByte' = 'sbyte'
+    'System.Char' = 'char'
+    'System.Int16' = 'short'
+    'System.UInt16' = 'ushort'
+    'System.Int32' = 'int'
+    'System.UInt32' = 'uint'
+    'System.Int64' = 'long'
+    'System.UInt64' = 'ulong'
+    'System.Single' = 'float'
+    'System.Double' = 'double'
+    'System.Decimal' = 'decimal'
+    'System.String' = 'string'
+    'System.Object' = 'object'
+    'System.IntPtr' = 'IntPtr'
+    'System.UIntPtr' = 'UIntPtr'
+}
+
+function Get-FriendlyTypeName {
+    param([Parameter(Mandatory)] [System.Type] $Type)
+
+    if ($Type.IsByRef) {
+        return Get-FriendlyTypeName $Type.GetElementType()
+    }
+
+    if ($Type.IsPointer) {
+        return "$(Get-FriendlyTypeName $Type.GetElementType())*"
+    }
+
+    if ($Type.IsArray) {
+        $rank = $Type.GetArrayRank()
+        $suffix = if ($rank -eq 1) { '[]' } else { '[' + (',' * ($rank - 1)) + ']' }
+        return "$(Get-FriendlyTypeName $Type.GetElementType())$suffix"
+    }
+
+    if ($Type.IsGenericParameter) {
+        return $Type.Name
+    }
+
+    if ($null -ne $Type.FullName -and $script:TypeAliases.ContainsKey($Type.FullName)) {
+        return $script:TypeAliases[$Type.FullName]
+    }
+
+    if ($Type.IsGenericType) {
+        $definition = $Type.GetGenericTypeDefinition()
+        $arguments = @($Type.GetGenericArguments() | ForEach-Object { Get-FriendlyTypeName $_ })
+
+        if ($definition.FullName -eq 'System.Nullable`1') {
+            return "$($arguments[0])?"
+        }
+
+        $name = $definition.Name -replace '`[0-9]+$', ''
+        if ($null -ne $definition.DeclaringType) {
+            $name = "$(Get-FriendlyTypeName $definition.DeclaringType).$name"
+        }
+
+        return "$name<$($arguments -join ', ')>"
+    }
+
+    if ($null -ne $Type.DeclaringType) {
+        return "$(Get-FriendlyTypeName $Type.DeclaringType).$($Type.Name)"
+    }
+
+    if ($Type.Namespace -eq 'SDL3') {
+        return $Type.Name
+    }
+
+    if ($Type.Namespace -eq 'System') {
+        return $Type.Name
+    }
+
+    return $Type.FullName.Replace('+', '.')
+}
+
+function Get-WikiIdentifier {
+    param([string] $Name)
+
+    if ($null -eq $Name) {
+        return ''
+    }
+
+    return $Name.Replace([string][char]0x0421, 'C').Replace([string][char]0x0441, 'c')
+}
+
+function Get-ParameterSignature {
+    param([Parameter(Mandatory)] [System.Reflection.ParameterInfo] $Parameter)
+
+    $type = $Parameter.ParameterType
+    $prefix = ''
+
+    if ($type.IsByRef) {
+        if ($Parameter.IsOut) {
+            $prefix = 'out '
+        } elseif ($Parameter.IsIn) {
+            $prefix = 'in '
+        } else {
+            $prefix = 'ref '
+        }
+        $type = $type.GetElementType()
+    }
+
+    if ($null -ne $Parameter.GetCustomAttributes([System.ParamArrayAttribute], $false) -and $Parameter.GetCustomAttributes([System.ParamArrayAttribute], $false).Count -gt 0) {
+        $prefix = 'params '
+    }
+
+    return "$prefix$(Get-FriendlyTypeName $type) $(Get-WikiIdentifier $Parameter.Name)"
+}
+
+function Get-MethodSignature {
+    param([Parameter(Mandatory)] [System.Reflection.MethodInfo] $Method)
+
+    $static = if ($Method.IsStatic) { 'static ' } else { '' }
+    $genericArguments = ''
+    if ($Method.IsGenericMethod) {
+        $genericArguments = '<' + (($Method.GetGenericArguments() | ForEach-Object { $_.Name }) -join ', ') + '>'
+    }
+
+    $parameters = @($Method.GetParameters() | ForEach-Object { Get-ParameterSignature $_ })
+    return "public $static$(Get-FriendlyTypeName $Method.ReturnType) $($Method.Name)$genericArguments($($parameters -join ', '));"
+}
+
+function Convert-CrefToText {
+    param([string] $Cref)
+
+    if ([string]::IsNullOrWhiteSpace($Cref)) {
+        return ''
+    }
+
+    $text = $Cref -replace '^[A-Z]:', ''
+    $text = $text -replace '\(.*$', ''
+    $text = $text -replace '``[0-9]+', ''
+    $text = $text -replace '^SDL3\.', ''
+    return $text
+}
+
+function Convert-SdlRelativeLinks {
+    param([string] $Text)
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return $Text
+    }
+
+    return [regex]::Replace(
+        $Text,
+        '\]\((?![a-z][a-z0-9+.-]*:|#|mailto:)([^)#]+)(#[^)]+)?\)',
+        {
+            param($match)
+            $target = $match.Groups[1].Value
+            $anchor = $match.Groups[2].Value
+            "](https://wiki.libsdl.org/SDL3/$target$anchor)"
+        })
+}
+
+function Convert-XmlChildToMarkdown {
+    param([Parameter(Mandatory)] [System.Xml.XmlNode] $Node)
+
+    switch ($Node.NodeType) {
+        ([System.Xml.XmlNodeType]::Text) {
+            return ([regex]::Replace($Node.Value, '\s+', ' '))
+        }
+        ([System.Xml.XmlNodeType]::CData) {
+            return ([regex]::Replace($Node.Value, '\s+', ' '))
+        }
+        ([System.Xml.XmlNodeType]::Element) {
+            switch ($Node.Name) {
+                'c' {
+                    return '`' + $Node.InnerText.Trim() + '`'
+                }
+                'code' {
+                    $code = $Node.InnerText.Trim()
+                    if ([string]::IsNullOrWhiteSpace($code)) {
+                        return ''
+                    }
+                    return "`n```c`n$code`n```n"
+                }
+                'para' {
+                    $text = Convert-XmlNodeToMarkdown $Node
+                    if ([string]::IsNullOrWhiteSpace($text)) {
+                        return ''
+                    }
+                    return "$text`n`n"
+                }
+                'see' {
+                    $cref = $Node.GetAttribute('cref')
+                    if (-not [string]::IsNullOrWhiteSpace($cref)) {
+                        return '`' + (Convert-CrefToText $cref) + '`'
+                    }
+
+                    $href = $Node.GetAttribute('href')
+                    if (-not [string]::IsNullOrWhiteSpace($href)) {
+                        $label = if ([string]::IsNullOrWhiteSpace($Node.InnerText)) { $href } else { $Node.InnerText.Trim() }
+                        return "[$label]($href)"
+                    }
+
+                    return $Node.InnerText.Trim()
+                }
+                'seealso' {
+                    $cref = $Node.GetAttribute('cref')
+                    if (-not [string]::IsNullOrWhiteSpace($cref)) {
+                        return '`' + (Convert-CrefToText $cref) + '`'
+                    }
+
+                    return $Node.InnerText.Trim()
+                }
+                'a' {
+                    $href = $Node.GetAttribute('href')
+                    $label = if ([string]::IsNullOrWhiteSpace($Node.InnerText)) { $href } else { $Node.InnerText.Trim() }
+                    if ([string]::IsNullOrWhiteSpace($href)) {
+                        return $label
+                    }
+                    if ($href -notmatch '^[a-z][a-z0-9+.-]*:' -and -not $href.StartsWith('#')) {
+                        $href = "https://wiki.libsdl.org/SDL3/$href"
+                    }
+                    return "[$label]($href)"
+                }
+                'paramref' {
+                    return '`' + $Node.GetAttribute('name') + '`'
+                }
+                'typeparamref' {
+                    return '`' + $Node.GetAttribute('name') + '`'
+                }
+                'list' {
+                    $items = @()
+                    foreach ($item in $Node.SelectNodes('item')) {
+                        $items += '- ' + (Convert-XmlNodeToMarkdown $item).Trim()
+                    }
+                    return "`n$($items -join "`n")`n"
+                }
+                default {
+                    return Convert-XmlNodeToMarkdown $Node
+                }
+            }
+        }
+        default {
+            return ''
+        }
+    }
+}
+
+function Convert-XmlNodeToMarkdown {
+    param([System.Xml.XmlNode] $Node)
+
+    if ($null -eq $Node) {
+        return ''
+    }
+
+    $parts = @()
+    foreach ($child in $Node.ChildNodes) {
+        $parts += Convert-XmlChildToMarkdown $child
+    }
+
+    $text = ($parts -join '')
+    $text = $text -replace "[ \t]+`n", "`n"
+    $text = $text -replace "`n[ \t]+", "`n"
+    $text = $text -replace ' {2,}', ' '
+    $text = $text -replace "(`n){3,}", "`n`n"
+    return (Convert-SdlRelativeLinks $text.Trim())
+}
+
+function Escape-MarkdownTableCell {
+    param([string] $Text)
+
+    if ($null -eq $Text) {
+        return ''
+    }
+
+    return ($Text -replace '\|', '\|' -replace "`r?`n", '<br>')
+}
+
+function Get-SurfaceName {
+    param([Parameter(Mandatory)] [System.Type] $Type)
+
+    $docTypeName = $Type.FullName.Replace('+', '.')
+    if (-not $docTypeName.StartsWith('SDL3.')) {
+        return $null
+    }
+
+    $parts = $docTypeName.Substring(5).Split('.')
+    return $parts[0]
+}
+
+function Get-TypeDisplayName {
+    param([Parameter(Mandatory)] [System.Type] $Type)
+
+    $name = $Type.FullName.Replace('+', '.')
+    if ($name.StartsWith('SDL3.')) {
+        return $name.Substring(5)
+    }
+
+    return $name
+}
+
+function Write-WikiFile {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string[]] $Content,
+        [Parameter(Mandatory)] [string] $Directory
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrWhiteSpace($script:WikiMetadataLine)) {
+        $lines.Add($script:WikiMetadataLine)
+        $lines.Add('')
+    }
+    foreach ($line in $Content) {
+        $lines.Add($line)
+    }
+    while ($lines.Count -gt 0 -and $lines[$lines.Count - 1] -eq '') {
+        $lines.RemoveAt($lines.Count - 1)
+    }
+
+    $path = Join-Path $Directory "$Name.md"
+    Set-Content -LiteralPath $path -Value ($lines -join "`n") -Encoding utf8NoBOM
+}
+
+function Get-WikiContentHash {
+    param([Parameter(Mandatory)][string] $Path)
+
+    $manifest = [System.Text.StringBuilder]::new()
+    foreach ($file in Get-ChildItem -LiteralPath $Path -Filter '*.md' -File | Sort-Object Name) {
+        $canonicalContent = [System.IO.File]::ReadAllText($file.FullName).Replace("`r`n", "`n").Replace("`r", "`n")
+        $fileHash = [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($canonicalContent))).ToLowerInvariant()
+        [void] $manifest.Append($file.Name).Append(':').Append($fileHash).Append("`n")
+    }
+
+    $manifestBytes = [System.Text.Encoding]::UTF8.GetBytes($manifest.ToString())
+    return [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
+}
+
+$ProjectRoot = [System.IO.Path]::GetFullPath($ProjectRoot)
+if ([string]::IsNullOrWhiteSpace($AssemblyPath)) {
+    $AssemblyPath = Join-Path $ProjectRoot 'SDL3-CS\bin\Release\net8.0\SDL3-CS.dll'
+}
+if ([string]::IsNullOrWhiteSpace($XmlDocPath)) {
+    $XmlDocPath = Join-Path $ProjectRoot 'SDL3-CS\bin\Release\SDL3-CS.xml'
+}
+if ([string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Join-Path $ProjectRoot 'artifacts\wiki\SDL3-CS'
+}
+
+$AssemblyPath = Resolve-RepoPath $AssemblyPath $ProjectRoot
+$XmlDocPath = Resolve-RepoPath $XmlDocPath $ProjectRoot
+$OutputPath = Resolve-RepoPath $OutputPath $ProjectRoot
+
+if (-not (Test-Path -LiteralPath $AssemblyPath)) {
+    throw "Assembly not found: $AssemblyPath. Run: dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore"
+}
+if (-not (Test-Path -LiteralPath $XmlDocPath)) {
+    throw "XML documentation not found: $XmlDocPath. Run: dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release --no-restore"
+}
+
+Assert-ChildPath -ParentPath $ProjectRoot -ChildPath $OutputPath
+
+if (Test-Path -LiteralPath $OutputPath) {
+    Get-ChildItem -LiteralPath $OutputPath -Force | Remove-Item -Recurse -Force
+} else {
+    New-Item -ItemType Directory -Path $OutputPath -Force | Out-Null
+}
+
+$memberMap = Get-XmlMemberMap $XmlDocPath
+$assembly = [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+$assemblyVersion = $assembly.GetName().Version.ToString()
+if ([string]::IsNullOrWhiteSpace($ManagedVersion)) {
+    $ManagedVersion = $assemblyVersion
+}
+if ($ManagedVersion -notmatch '^\d+\.\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+    throw "ManagedVersion must be a four-part package version: $ManagedVersion"
+}
+if ([string]::IsNullOrWhiteSpace($SourceCommit)) {
+    $SourceCommit = ((& git -C $ProjectRoot rev-parse HEAD 2>$null) | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or $SourceCommit -notmatch '^[0-9a-fA-F]{40}$') {
+        throw 'SourceCommit was not provided and could not be resolved from ProjectRoot.'
+    }
+}
+$SourceCommit = $SourceCommit.ToLowerInvariant()
+
+if ([string]::IsNullOrWhiteSpace($GeneratedAtUtc)) {
+    $commitTimestamp = ((& git -C $ProjectRoot show -s --format=%cI $SourceCommit 2>$null) | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($commitTimestamp)) {
+        throw 'GeneratedAtUtc was not provided and could not be resolved from SourceCommit.'
+    }
+    $GeneratedAtUtc = $commitTimestamp
+}
+
+$parsedGeneratedAt = [DateTimeOffset]::MinValue
+if (-not [DateTimeOffset]::TryParse($GeneratedAtUtc, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::AllowWhiteSpaces, [ref] $parsedGeneratedAt)) {
+    throw "GeneratedAtUtc is not a valid timestamp: $GeneratedAtUtc"
+}
+$GeneratedAtUtc = $parsedGeneratedAt.UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ', [System.Globalization.CultureInfo]::InvariantCulture)
+$script:WikiMetadataLine = "<!-- sdl3-cs-wiki managed-version=`"$ManagedVersion`" source-commit=`"$SourceCommit`" generated-at=`"$GeneratedAtUtc`" -->"
+
+$surfaces = [ordered]@{
+    SDL = @{
+        Title = 'SDL core API'
+        Page = 'API-SDL'
+        Description = 'Core SDL3 wrapper functions and nested helper surfaces.'
+    }
+    Image = @{
+        Title = 'SDL_image API'
+        Page = 'API-Image'
+        Description = 'Image loading, saving, animation, and metadata functions.'
+    }
+    Mixer = @{
+        Title = 'SDL_mixer API'
+        Page = 'API-Mixer'
+        Description = 'Audio mixer, track, group, and decoder functions.'
+    }
+    TTF = @{
+        Title = 'SDL_ttf API'
+        Page = 'API-TTF'
+        Description = 'Font loading, text shaping, measurement, and rendering functions.'
+    }
+    ShaderCross = @{
+        Title = 'SDL_shadercross API'
+        Page = 'API-ShaderCross'
+        Description = 'Shader translation, compilation, and reflection functions.'
+    }
+}
+
+$publicMethods = @()
+foreach ($type in $assembly.GetTypes()) {
+    if (-not ($type.IsPublic -or $type.IsNestedPublic)) {
+        continue
+    }
+    if ([System.Delegate].IsAssignableFrom($type)) {
+        continue
+    }
+
+    $surface = Get-SurfaceName $type
+    if ([string]::IsNullOrWhiteSpace($surface) -or -not $surfaces.Contains($surface)) {
+        continue
+    }
+
+    foreach ($method in $type.GetMethods([System.Reflection.BindingFlags]'Public, Static, Instance, DeclaredOnly')) {
+        if ($method.IsSpecialName) {
+            continue
+        }
+
+        $xmlId = Get-MethodXmlId $method
+        $doc = $null
+        if ($memberMap.ContainsKey($xmlId)) {
+            $doc = $memberMap[$xmlId]
+        }
+
+        $publicMethods += [pscustomobject]@{
+            Surface = $surface
+            DeclaringType = Get-TypeDisplayName $method.DeclaringType
+            MethodName = $method.Name
+            Signature = Get-MethodSignature $method
+            XmlId = $xmlId
+            Method = $method
+            Documentation = $doc
+            HasDocumentation = ($null -ne $doc)
+        }
+    }
+}
+
+$publicMethods = @($publicMethods | Sort-Object Surface, DeclaringType, MethodName, Signature)
+
+$homePage = @(
+    'This Wiki contains a generated reference for the public SDL3-CS function API.',
+    '',
+    "- Repository: [$RepositoryUrl]($RepositoryUrl)",
+    "- Wiki: [$WikiUrl]($WikiUrl)",
+    ('- Managed version: `{0}`' -f $ManagedVersion),
+    ('- Source commit: `{0}`' -f $SourceCommit),
+    ('- Generated at (UTC): `{0}`' -f $GeneratedAtUtc),
+    '',
+    '## Sections',
+    '',
+    '- [API Reference](API-Reference)',
+    '- [SDL core API](API-SDL)',
+    '- [SDL_image API](API-Image)',
+    '- [SDL_mixer API](API-Mixer)',
+    '- [SDL_ttf API](API-TTF)',
+    '- [SDL_shadercross API](API-ShaderCross)'
+)
+Write-WikiFile -Name $HomePageName -Content $homePage -Directory $OutputPath
+
+$sidebar = @(
+    "* [SDL3-CS Wiki]($HomePageName)",
+    '* [API Reference](API-Reference)',
+    '  * [SDL core API](API-SDL)',
+    '  * [SDL_image API](API-Image)',
+    '  * [SDL_mixer API](API-Mixer)',
+    '  * [SDL_ttf API](API-TTF)',
+    '  * [SDL_shadercross API](API-ShaderCross)'
+)
+Write-WikiFile -Name '_Sidebar' -Content $sidebar -Directory $OutputPath
+
+$reference = @(
+    '# API Reference',
+    '',
+    'Index of public SDL3-CS functions grouped by the main API surfaces.',
+    '',
+    '| Surface | Page | Functions | With XML docs | Description |',
+    '|---|---:|---:|---:|---|'
+)
+foreach ($surfaceName in $surfaces.Keys) {
+    $surfaceMethods = @($publicMethods | Where-Object Surface -eq $surfaceName)
+    $documented = @($surfaceMethods | Where-Object HasDocumentation).Count
+    $reference += ('| `{0}` | [{1}]({2}) | {3} | {4} | {5} |' -f $surfaceName, $surfaces[$surfaceName].Title, $surfaces[$surfaceName].Page, $surfaceMethods.Count, $documented, $surfaces[$surfaceName].Description)
+}
+Write-WikiFile -Name 'API-Reference' -Content $reference -Directory $OutputPath
+
+foreach ($surfaceName in $surfaces.Keys) {
+    $surface = $surfaces[$surfaceName]
+    $surfaceMethods = @($publicMethods | Where-Object Surface -eq $surfaceName)
+    $documented = @($surfaceMethods | Where-Object HasDocumentation).Count
+    $page = @(
+        "# $($surface.Title)",
+        '',
+        '[Back to API Reference](API-Reference)',
+        '',
+        $surface.Description,
+        '',
+        "- Functions: $($surfaceMethods.Count)",
+        "- Functions with XML docs: $documented",
+        ''
+    )
+
+    foreach ($typeGroup in ($surfaceMethods | Group-Object DeclaringType | Sort-Object Name)) {
+        $page += ('## `{0}`' -f $typeGroup.Name)
+        $page += ''
+
+        foreach ($entry in ($typeGroup.Group | Sort-Object MethodName, Signature)) {
+            $method = [System.Reflection.MethodInfo] $entry.Method
+            $doc = [System.Xml.XmlElement] $entry.Documentation
+
+            $page += ('### `{0}.{1}`' -f $entry.DeclaringType, $entry.MethodName)
+            $page += ''
+            $page += '```csharp'
+            $page += $entry.Signature
+            $page += '```'
+            $page += ''
+
+            if ($null -ne $doc) {
+                $nativeDeclaration = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('code'))
+                if (-not [string]::IsNullOrWhiteSpace($nativeDeclaration)) {
+                    $page += '**SDL declaration**'
+                    $page += ''
+                    $page += $nativeDeclaration
+                    $page += ''
+                }
+
+                $summary = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('summary'))
+                if (-not [string]::IsNullOrWhiteSpace($summary)) {
+                    $page += $summary
+                    $page += ''
+                }
+
+                $parameters = @($method.GetParameters())
+                if ($parameters.Count -gt 0) {
+                    $page += '**Parameters**'
+                    $page += ''
+                    $page += '| Name | Type | Description |'
+                    $page += '|---|---|---|'
+                    foreach ($parameter in $parameters) {
+                        $parameterType = $parameter.ParameterType
+                        $direction = ''
+                        if ($parameterType.IsByRef) {
+                            if ($parameter.IsOut) {
+                                $direction = 'out '
+                            } elseif ($parameter.IsIn) {
+                                $direction = 'in '
+                            } else {
+                                $direction = 'ref '
+                            }
+                            $parameterType = $parameterType.GetElementType()
+                        }
+
+                        $descriptionNode = $doc.SelectSingleNode("param[@name='$($parameter.Name)']")
+                        $description = Convert-XmlNodeToMarkdown $descriptionNode
+                        $page += ('| `{0}` | `{1}{2}` | {3} |' -f (Get-WikiIdentifier $parameter.Name), $direction, (Get-FriendlyTypeName $parameterType), (Escape-MarkdownTableCell $description))
+                    }
+                    $page += ''
+                }
+
+                $returns = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('returns'))
+                if (-not [string]::IsNullOrWhiteSpace($returns)) {
+                    $page += '**Returns**'
+                    $page += ''
+                    $page += $returns
+                    $page += ''
+                }
+
+                $remarks = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('remarks'))
+                if (-not [string]::IsNullOrWhiteSpace($remarks)) {
+                    $page += '**Remarks**'
+                    $page += ''
+                    $page += $remarks
+                    $page += ''
+                }
+
+                $threadSafety = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('threadsafety'))
+                if (-not [string]::IsNullOrWhiteSpace($threadSafety)) {
+                    $page += '**Thread safety**'
+                    $page += ''
+                    $page += $threadSafety
+                    $page += ''
+                }
+
+                $since = Convert-XmlNodeToMarkdown ($doc.SelectSingleNode('since'))
+                if (-not [string]::IsNullOrWhiteSpace($since)) {
+                    $page += "**Since:** $since"
+                    $page += ''
+                }
+
+                $seeAlsoNodes = @($doc.SelectNodes('seealso'))
+                if ($seeAlsoNodes.Count -gt 0) {
+                    $seeAlso = @($seeAlsoNodes | ForEach-Object { Convert-XmlNodeToMarkdown $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                    if ($seeAlso.Count -gt 0) {
+                        $page += '**See also:** ' + ($seeAlso -join ', ')
+                        $page += ''
+                    }
+                }
+            } else {
+                $page += '_XML documentation is not available for this function._'
+                $page += ''
+            }
+
+            $page += ('**XML member id:** `{0}`' -f $entry.XmlId)
+            $page += ''
+        }
+    }
+
+    Write-WikiFile -Name $surface.Page -Content $page -Directory $OutputPath
+}
+
+$summary = [pscustomobject]@{
+    OutputPath = $OutputPath
+    Pages = @(Get-ChildItem -LiteralPath $OutputPath -Filter '*.md' | Select-Object -ExpandProperty Name)
+    ManagedVersion = $ManagedVersion
+    AssemblyVersion = $assemblyVersion
+    SourceCommit = $SourceCommit
+    GeneratedAtUtc = $GeneratedAtUtc
+    ContentHash = Get-WikiContentHash -Path $OutputPath
+    FunctionCount = $publicMethods.Count
+    DocumentedFunctionCount = @($publicMethods | Where-Object HasDocumentation).Count
+    MissingXmlDocCount = @($publicMethods | Where-Object { -not $_.HasDocumentation }).Count
+}
+
+$summary | ConvertTo-Json -Depth 4 -Compress

--- a/.github/wiki-tools/Publish-ApiWiki.ps1
+++ b/.github/wiki-tools/Publish-ApiWiki.ps1
@@ -1,0 +1,153 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string] $CandidatePath,
+    [string] $WikiRepositoryUrl = 'https://github.com/edwardgushchin/SDL3-CS.wiki.git',
+    [string] $WorkingRoot = (Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path '.agents\wiki-publication'),
+    [string] $ExpectedManagedVersion,
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $ExpectedSourceCommit,
+    [string] $ExpectedGeneratedAtUtc,
+    [ValidatePattern('^[0-9a-fA-F]{64}$')]
+    [string] $ExpectedContentHash,
+    [string] $CommitUserName = 'SDL3-CS Release Automation',
+    [string] $CommitUserEmail = '41898282+github-actions[bot]@users.noreply.github.com',
+    [switch] $Push,
+    [switch] $KeepWorkingCopy
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$CandidatePath = [System.IO.Path]::GetFullPath($CandidatePath)
+$WorkingRoot = [System.IO.Path]::GetFullPath($WorkingRoot)
+$validator = Join-Path $PSScriptRoot 'Test-ApiWiki.ps1'
+if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+    throw "Wiki validator was not found: $validator"
+}
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw "Git CLI is required to publish the Wiki."
+}
+
+$validationParameters = @{
+    WikiPath = $CandidatePath
+    RequireExactPages = $true
+}
+if ($ExpectedManagedVersion) { $validationParameters.ExpectedManagedVersion = $ExpectedManagedVersion }
+if ($ExpectedSourceCommit) { $validationParameters.ExpectedSourceCommit = $ExpectedSourceCommit }
+if ($ExpectedGeneratedAtUtc) { $validationParameters.ExpectedGeneratedAtUtc = $ExpectedGeneratedAtUtc }
+if ($ExpectedContentHash) { $validationParameters.ExpectedContentHash = $ExpectedContentHash }
+$candidateValidation = (& $validator @validationParameters | ConvertFrom-Json)
+
+$managedPages = @(
+    ('SDL3' + [char]0x2010 + 'CS-Wiki.md'),
+    '_Sidebar.md',
+    'API-Reference.md',
+    'API-SDL.md',
+    'API-Image.md',
+    'API-Mixer.md',
+    'API-TTF.md',
+    'API-ShaderCross.md'
+)
+
+function Invoke-WikiGit {
+    param(
+        [Parameter(Mandatory)][string] $RepositoryPath,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $output = & git -C $RepositoryPath @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $($output | Out-String)"
+    }
+
+    return (($output | Out-String).Trim())
+}
+
+New-Item -ItemType Directory -Force -Path $WorkingRoot | Out-Null
+$runName = "run-$([guid]::NewGuid().ToString('N'))"
+$clonePath = [System.IO.Path]::GetFullPath((Join-Path $WorkingRoot $runName))
+$relativeClonePath = [System.IO.Path]::GetRelativePath($WorkingRoot, $clonePath)
+if ($relativeClonePath.StartsWith('..') -or [System.IO.Path]::IsPathRooted($relativeClonePath) -or -not $runName.StartsWith('run-', [System.StringComparison]::Ordinal)) {
+    throw "Unsafe Wiki publication working path: $clonePath"
+}
+
+$result = $null
+try {
+    $cloneOutput = & git clone --no-tags -- $WikiRepositoryUrl $clonePath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to clone Wiki repository '$WikiRepositoryUrl': $($cloneOutput | Out-String)"
+    }
+
+    $initialStatus = Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('status', '--porcelain', '--untracked-files=all')
+    if ($initialStatus) {
+        throw "Fresh Wiki clone is unexpectedly dirty: $initialStatus"
+    }
+
+    foreach ($page in $managedPages) {
+        [System.IO.File]::Copy((Join-Path $CandidatePath $page), (Join-Path $clonePath $page), $true)
+    }
+
+    Invoke-WikiGit -RepositoryPath $clonePath -Arguments (@('add', '--') + $managedPages) | Out-Null
+    & git -C $clonePath diff --cached --quiet -- @managedPages
+    $diffExitCode = $LASTEXITCODE
+    if ($diffExitCode -notin @(0, 1)) {
+        throw "Failed to compare staged Wiki pages (git exit code $diffExitCode)."
+    }
+    $hasChanges = $diffExitCode -eq 1
+    $changes = if ($hasChanges) {
+        Invoke-WikiGit -RepositoryPath $clonePath -Arguments (@('diff', '--cached', '--name-status', '--') + $managedPages)
+    } else {
+        ''
+    }
+    $status = if (-not $hasChanges) { 'NoChange' } elseif ($Push) { 'Published' } else { 'Planned' }
+    $wikiCommit = $null
+    if (-not $hasChanges) {
+        $wikiCommit = Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('rev-parse', '--verify', 'HEAD')
+    }
+
+    if ($hasChanges -and $Push) {
+        $commitMessage = "docs: update wiki for SDL3-CS $($candidateValidation.ManagedVersion)"
+        Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('-c', "user.name=$CommitUserName", '-c', "user.email=$CommitUserEmail", 'commit', '-m', $commitMessage) | Out-Null
+        $wikiCommit = Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('rev-parse', 'HEAD')
+        Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('push', 'origin', 'HEAD:master') | Out-Null
+
+        $remoteLine = Invoke-WikiGit -RepositoryPath $clonePath -Arguments @('ls-remote', '--heads', 'origin', 'refs/heads/master')
+        $remoteCommit = @($remoteLine -split '\s+')[0]
+        if ($remoteCommit -ne $wikiCommit) {
+            throw "Wiki push verification failed: local $wikiCommit, remote $remoteCommit"
+        }
+
+        $postPushParameters = $validationParameters.Clone()
+        $postPushParameters.WikiPath = $clonePath
+        $postPushParameters.ExpectedContentHash = $candidateValidation.ContentHash
+        [void] $postPushParameters.Remove('RequireExactPages')
+        & $validator @postPushParameters | Out-Null
+    }
+
+    $result = [pscustomobject]@{
+        Status = $status
+        ManagedVersion = $candidateValidation.ManagedVersion
+        SourceCommit = $candidateValidation.SourceCommit
+        GeneratedAtUtc = $candidateValidation.GeneratedAtUtc
+        ContentHash = $candidateValidation.ContentHash
+        WikiCommit = $wikiCommit
+        WikiRepositoryUrl = $WikiRepositoryUrl
+        ChangedPages = @($changes -split "`r?`n" | Where-Object { $_ })
+        Push = $Push.IsPresent
+    }
+}
+finally {
+    if (-not $KeepWorkingCopy -and (Test-Path -LiteralPath $clonePath)) {
+        $resolvedClonePath = [System.IO.Path]::GetFullPath($clonePath)
+        $relative = [System.IO.Path]::GetRelativePath($WorkingRoot, $resolvedClonePath)
+        if ($relative.StartsWith('..') -or [System.IO.Path]::IsPathRooted($relative) -or
+            -not ([System.IO.Path]::GetFileName($resolvedClonePath)).StartsWith('run-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe Wiki publication path: $resolvedClonePath"
+        }
+
+        Remove-Item -LiteralPath $resolvedClonePath -Recurse -Force
+    }
+}
+
+$result | ConvertTo-Json -Depth 4 -Compress

--- a/.github/wiki-tools/Test-ApiWiki.ps1
+++ b/.github/wiki-tools/Test-ApiWiki.ps1
@@ -1,0 +1,183 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string] $WikiPath,
+    [string] $HomePageName = ('SDL3' + [char]0x2010 + 'CS-Wiki'),
+    [string] $ExpectedManagedVersion,
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $ExpectedSourceCommit,
+    [string] $ExpectedGeneratedAtUtc,
+    [ValidatePattern('^[0-9a-fA-F]{64}$')]
+    [string] $ExpectedContentHash,
+    [switch] $RequireExactPages
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$WikiPath = [System.IO.Path]::GetFullPath($WikiPath)
+if (-not (Test-Path -LiteralPath $WikiPath)) {
+    throw "WikiPath not found: $WikiPath"
+}
+
+$requiredPages = @(
+    "$HomePageName.md",
+    '_Sidebar.md',
+    'API-Reference.md',
+    'API-SDL.md',
+    'API-Image.md',
+    'API-Mixer.md',
+    'API-TTF.md',
+    'API-ShaderCross.md'
+)
+
+$errors = [System.Collections.Generic.List[string]]::new()
+$metadataPattern = '(?m)^<!-- sdl3-cs-wiki managed-version="([^"]+)" source-commit="([0-9a-fA-F]{40})" generated-at="([^"]+)" -->\r?$'
+$metadata = $null
+
+function Get-WikiContentHash {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string[]] $FileNames
+    )
+
+    $manifest = [System.Text.StringBuilder]::new()
+    foreach ($fileName in $FileNames | Sort-Object) {
+        $filePath = Join-Path $Path $fileName
+        if (-not (Test-Path -LiteralPath $filePath -PathType Leaf)) {
+            continue
+        }
+        $canonicalContent = [System.IO.File]::ReadAllText($filePath).Replace("`r`n", "`n").Replace("`r", "`n")
+        $fileHash = [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData([System.Text.Encoding]::UTF8.GetBytes($canonicalContent))).ToLowerInvariant()
+        [void] $manifest.Append($fileName).Append(':').Append($fileHash).Append("`n")
+    }
+
+    $manifestBytes = [System.Text.Encoding]::UTF8.GetBytes($manifest.ToString())
+    return [Convert]::ToHexString([System.Security.Cryptography.SHA256]::HashData($manifestBytes)).ToLowerInvariant()
+}
+
+foreach ($page in $requiredPages) {
+    $path = Join-Path $WikiPath $page
+    if (-not (Test-Path -LiteralPath $path)) {
+        $errors.Add("Missing required page: $page")
+        continue
+    }
+
+    $item = Get-Item -LiteralPath $path
+    if ($item.Length -lt 20) {
+        $errors.Add("Page is unexpectedly small: $page")
+    }
+
+    $content = Get-Content -LiteralPath $path -Raw
+    $match = [regex]::Match($content, $metadataPattern)
+    if (-not $match.Success) {
+        $errors.Add("Page is missing valid Wiki metadata: $page")
+        continue
+    }
+
+    $pageMetadata = [pscustomobject]@{
+        ManagedVersion = $match.Groups[1].Value
+        SourceCommit = $match.Groups[2].Value.ToLowerInvariant()
+        GeneratedAtUtc = $match.Groups[3].Value
+    }
+    $parsedTimestamp = [DateTimeOffset]::MinValue
+    if (-not [DateTimeOffset]::TryParse($pageMetadata.GeneratedAtUtc, [ref] $parsedTimestamp)) {
+        $errors.Add("Page has invalid generated-at timestamp: $page")
+    }
+
+    if ($null -eq $metadata) {
+        $metadata = $pageMetadata
+    }
+    elseif ($pageMetadata.ManagedVersion -ne $metadata.ManagedVersion -or
+        $pageMetadata.SourceCommit -ne $metadata.SourceCommit -or
+        $pageMetadata.GeneratedAtUtc -ne $metadata.GeneratedAtUtc) {
+        $errors.Add("Page metadata differs from the other managed pages: $page")
+    }
+}
+
+if ($RequireExactPages) {
+    $actualPages = @(Get-ChildItem -LiteralPath $WikiPath -Filter '*.md' -File | Select-Object -ExpandProperty Name | Sort-Object)
+    $expectedPages = @($requiredPages | Sort-Object)
+    foreach ($difference in Compare-Object -ReferenceObject $expectedPages -DifferenceObject $actualPages) {
+        $errors.Add("Managed Wiki page set differs: $($difference.SideIndicator) $($difference.InputObject)")
+    }
+}
+
+foreach ($page in $requiredPages | Where-Object { $_ -like 'API-*.md' -and $_ -ne 'API-Reference.md' }) {
+    $path = Join-Path $WikiPath $page
+    if (Test-Path -LiteralPath $path) {
+        $content = Get-Content -LiteralPath $path -Raw
+        if ($content -notmatch '(?m)^### `') {
+            $errors.Add("API page has no function headings: $page")
+        }
+        if ($content -match 'TODO|TBD') {
+            $errors.Add("API page contains TODO/TBD marker: $page")
+        }
+    }
+}
+
+$localLinks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($file in Get-ChildItem -LiteralPath $WikiPath -Filter '*.md') {
+    $content = Get-Content -LiteralPath $file.FullName -Raw
+    foreach ($match in [regex]::Matches($content, '\[[^\]]+\]\(([^)]+)\)')) {
+        $target = $match.Groups[1].Value
+        if ($target -match '^[a-z]+://' -or $target.StartsWith('#') -or $target.StartsWith('mailto:')) {
+            continue
+        }
+
+        $targetPage = ($target -split '#')[0]
+        if ([string]::IsNullOrWhiteSpace($targetPage)) {
+            continue
+        }
+        if (-not $targetPage.EndsWith('.md', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $targetPage += '.md'
+        }
+
+        [void] $localLinks.Add($targetPage)
+    }
+}
+
+foreach ($targetPage in $localLinks) {
+    $targetPath = Join-Path $WikiPath $targetPage
+    if (-not (Test-Path -LiteralPath $targetPath)) {
+        $errors.Add("Broken local wiki link: $targetPage")
+    }
+}
+
+if ($null -ne $metadata) {
+    if ($ExpectedManagedVersion -and $metadata.ManagedVersion -ne $ExpectedManagedVersion) {
+        $errors.Add("Managed version mismatch: expected $ExpectedManagedVersion, actual $($metadata.ManagedVersion)")
+    }
+    if ($ExpectedSourceCommit -and $metadata.SourceCommit -ne $ExpectedSourceCommit.ToLowerInvariant()) {
+        $errors.Add("Source commit mismatch: expected $ExpectedSourceCommit, actual $($metadata.SourceCommit)")
+    }
+    if ($ExpectedGeneratedAtUtc) {
+        $expectedTimestamp = [DateTimeOffset]::Parse($ExpectedGeneratedAtUtc).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        $actualTimestamp = [DateTimeOffset]::Parse($metadata.GeneratedAtUtc).UtcDateTime.ToString('yyyy-MM-ddTHH:mm:ssZ')
+        if ($actualTimestamp -ne $expectedTimestamp) {
+            $errors.Add("Generated-at mismatch: expected $expectedTimestamp, actual $actualTimestamp")
+        }
+    }
+}
+
+$contentHash = Get-WikiContentHash -Path $WikiPath -FileNames $requiredPages
+if ($ExpectedContentHash -and $contentHash -ne $ExpectedContentHash.ToLowerInvariant()) {
+    $errors.Add("Wiki content hash mismatch: expected $ExpectedContentHash, actual $contentHash")
+}
+
+if ($errors.Count -gt 0) {
+    $errors | ForEach-Object { Write-Error $_ }
+    throw "Wiki validation failed with $($errors.Count) error(s)."
+}
+
+[pscustomobject]@{
+    WikiPath = $WikiPath
+    Pages = @(Get-ChildItem -LiteralPath $WikiPath -Filter '*.md').Count
+    RequiredPages = $requiredPages.Count
+    LocalLinks = $localLinks.Count
+    ManagedVersion = if ($null -ne $metadata) { $metadata.ManagedVersion } else { $null }
+    SourceCommit = if ($null -ne $metadata) { $metadata.SourceCommit } else { $null }
+    GeneratedAtUtc = if ($null -ne $metadata) { $metadata.GeneratedAtUtc } else { $null }
+    ContentHash = $contentHash
+    Status = 'Passed'
+} | ConvertTo-Json -Depth 3 -Compress

--- a/.github/wiki-tools/Test-PublishedApiWiki.ps1
+++ b/.github/wiki-tools/Test-PublishedApiWiki.ps1
@@ -1,0 +1,84 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $WikiRepositoryUrl = 'https://github.com/edwardgushchin/SDL3-CS.wiki.git',
+    [string] $WorkingRoot = (Join-Path (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path '.agents\wiki-verification'),
+    [Parameter(Mandatory)][string] $ExpectedManagedVersion,
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string] $ExpectedSourceCommit,
+    [string] $ExpectedGeneratedAtUtc,
+    [ValidatePattern('^[0-9a-fA-F]{64}$')]
+    [string] $ExpectedContentHash,
+    [switch] $KeepWorkingCopy
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($WikiRepositoryUrl.StartsWith('-', [System.StringComparison]::Ordinal)) {
+    throw 'WikiRepositoryUrl must not start with a command-line option prefix.'
+}
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    throw 'Git CLI is required to verify the published Wiki.'
+}
+
+$validator = Join-Path $PSScriptRoot 'Test-ApiWiki.ps1'
+if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+    throw "Wiki validator was not found: $validator"
+}
+
+$WorkingRoot = [System.IO.Path]::GetFullPath($WorkingRoot)
+New-Item -ItemType Directory -Force -Path $WorkingRoot | Out-Null
+$runName = "run-$([guid]::NewGuid().ToString('N'))"
+$clonePath = [System.IO.Path]::GetFullPath((Join-Path $WorkingRoot $runName))
+$relativeClonePath = [System.IO.Path]::GetRelativePath($WorkingRoot, $clonePath)
+if ($relativeClonePath.StartsWith('..') -or [System.IO.Path]::IsPathRooted($relativeClonePath)) {
+    throw "Unsafe published Wiki verification path: $clonePath"
+}
+
+$result = $null
+try {
+    $cloneOutput = & git clone --no-tags --depth 1 --branch master $WikiRepositoryUrl $clonePath 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to clone published Wiki '$WikiRepositoryUrl': $($cloneOutput | Out-String)"
+    }
+
+    $validationParameters = @{
+        WikiPath = $clonePath
+        ExpectedManagedVersion = $ExpectedManagedVersion
+        ExpectedSourceCommit = $ExpectedSourceCommit
+    }
+    if ($ExpectedGeneratedAtUtc) { $validationParameters.ExpectedGeneratedAtUtc = $ExpectedGeneratedAtUtc }
+    if ($ExpectedContentHash) { $validationParameters.ExpectedContentHash = $ExpectedContentHash }
+    $validation = (& $validator @validationParameters | ConvertFrom-Json)
+
+    $wikiCommit = ((& git -C $clonePath rev-parse HEAD 2>&1) | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or $wikiCommit -notmatch '^[0-9a-fA-F]{40}$') {
+        throw 'Failed to resolve the published Wiki commit.'
+    }
+
+    $result = [pscustomobject]@{
+        Status = 'Current'
+        ManagedVersion = $validation.ManagedVersion
+        SourceCommit = $validation.SourceCommit
+        GeneratedAtUtc = $validation.GeneratedAtUtc
+        ContentHash = $validation.ContentHash
+        WikiCommit = $wikiCommit.ToLowerInvariant()
+        WikiRepositoryUrl = $WikiRepositoryUrl
+    }
+}
+finally {
+    if (-not $KeepWorkingCopy -and (Test-Path -LiteralPath $clonePath)) {
+        $resolvedClonePath = [System.IO.Path]::GetFullPath($clonePath)
+        $relative = [System.IO.Path]::GetRelativePath($WorkingRoot, $resolvedClonePath)
+        if ($relative.StartsWith('..') -or [System.IO.Path]::IsPathRooted($relative) -or
+            -not ([System.IO.Path]::GetFileName($resolvedClonePath)).StartsWith('run-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe published Wiki verification path: $resolvedClonePath"
+        }
+
+        Remove-Item -LiteralPath $resolvedClonePath -Recurse -Force
+    }
+}
+
+$result | ConvertTo-Json -Depth 3 -Compress

--- a/.github/wiki-tools/Test-WikiReleaseContract.Tests.ps1
+++ b/.github/wiki-tools/Test-WikiReleaseContract.Tests.ps1
@@ -1,0 +1,35 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory)][string] $Text,
+        [Parameter(Mandatory)][string] $Expected,
+        [Parameter(Mandatory)][string] $Description
+    )
+
+    if (-not $Text.Contains($Expected, [System.StringComparison]::Ordinal)) {
+        throw "$Description is missing expected text: $Expected"
+    }
+}
+
+$ci = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github/workflows/ci.yml') -Raw
+$readiness = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github/release-tools/Test-ReleaseReadiness.ps1') -Raw
+$publisher = Get-Content -LiteralPath (Join-Path $ProjectRoot '.github/release-tools/Publish-Release.ps1') -Raw
+$policy = Get-Content -LiteralPath (Join-Path $ProjectRoot 'RELEASING.md') -Raw
+
+Assert-Contains -Text $ci -Expected './.github/wiki-tools/Test-WikiTools.Tests.ps1' -Description 'CI Wiki candidate verification'
+Assert-Contains -Text $readiness -Expected "Test-WikiTools.Tests.ps1" -Description 'release readiness Wiki tooling verification'
+Assert-Contains -Text $publisher -Expected "Test-PublishedApiWiki.ps1" -Description 'production publish Wiki freshness gate'
+Assert-Contains -Text $publisher -Expected '-ExpectedManagedVersion $wrapper.PackageVersion' -Description 'Wiki managed version gate'
+Assert-Contains -Text $publisher -Expected '-ExpectedSourceCommit $releaseTarget' -Description 'Wiki exact release commit gate'
+Assert-Contains -Text $policy -Expected 'GitHub Wiki' -Description 'release policy Wiki section'
+Assert-Contains -Text $policy -Expected 'A Wiki publication failure' -Description 'release policy fail-closed Wiki rule'
+
+Write-Host 'Wiki release contract tests passed.'

--- a/.github/wiki-tools/Test-WikiTools.Tests.ps1
+++ b/.github/wiki-tools/Test-WikiTools.Tests.ps1
@@ -1,0 +1,201 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $ProjectRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+    [string] $AssemblyPath,
+    [string] $XmlDocPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$generator = Join-Path $PSScriptRoot 'Generate-ApiWiki.ps1'
+$validator = Join-Path $PSScriptRoot 'Test-ApiWiki.ps1'
+$publisher = Join-Path $PSScriptRoot 'Publish-ApiWiki.ps1'
+$remoteValidator = Join-Path $PSScriptRoot 'Test-PublishedApiWiki.ps1'
+foreach ($dependency in @($generator, $validator, $publisher, $remoteValidator)) {
+    if (-not (Test-Path -LiteralPath $dependency -PathType Leaf)) {
+        throw "Wiki tooling dependency was not found: $dependency"
+    }
+}
+
+if (-not $AssemblyPath) {
+    $AssemblyPath = Join-Path $ProjectRoot 'SDL3-CS\bin\Release\net8.0\SDL3-CS.dll'
+}
+if (-not $XmlDocPath) {
+    $XmlDocPath = Join-Path $ProjectRoot 'SDL3-CS\bin\Release\SDL3-CS.xml'
+}
+foreach ($buildOutput in @($AssemblyPath, $XmlDocPath)) {
+    if (-not (Test-Path -LiteralPath $buildOutput -PathType Leaf)) {
+        throw "Wiki tooling tests require Release build output: $buildOutput"
+    }
+}
+
+function Invoke-JsonScript {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][hashtable] $Parameters
+    )
+
+    $output = @(& $Path @Parameters)
+    $json = @($output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1)
+    if ($json.Count -ne 1) {
+        throw "Script did not return one-line JSON: $Path`n$($output | Out-String)"
+    }
+
+    return $json[0] | ConvertFrom-Json
+}
+
+function Assert-ActionFails {
+    param(
+        [Parameter(Mandatory)][string] $Description,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $failed = $false
+    try {
+        & $Action
+    }
+    catch {
+        $failed = $true
+    }
+
+    if (-not $failed) {
+        throw "Expected Wiki tooling action to fail: $Description"
+    }
+}
+
+function Invoke-TestGit {
+    param(
+        [Parameter(Mandatory)][string] $RepositoryPath,
+        [Parameter(Mandatory)][string[]] $Arguments
+    )
+
+    $output = & git -C $RepositoryPath @Arguments 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git $($Arguments -join ' ') failed: $($output | Out-String)"
+    }
+
+    return (($output | Out-String).Trim())
+}
+
+$sourceCommit = (Invoke-TestGit -RepositoryPath $ProjectRoot -Arguments @('rev-parse', 'HEAD')).Trim()
+$managedVersion = [System.Reflection.AssemblyName]::GetAssemblyName([System.IO.Path]::GetFullPath($AssemblyPath)).Version.ToString()
+$generatedAtUtc = '2026-07-29T13:05:28Z'
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = [System.IO.Path]::GetFullPath((Join-Path $tempBase "sdl3-cs-wiki-tools-$([guid]::NewGuid().ToString('N'))"))
+if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Unsafe Wiki test path: $tempRoot"
+}
+
+$candidateA = Join-Path $tempRoot 'candidate-a'
+$candidateB = Join-Path $tempRoot 'candidate-b'
+$tamperedCandidate = Join-Path $tempRoot 'candidate-tampered'
+$bareRemote = Join-Path $tempRoot 'wiki-remote.git'
+$publishRoot = Join-Path $tempRoot 'publish-work'
+
+try {
+    New-Item -ItemType Directory -Force -Path $tempRoot | Out-Null
+
+    $generationParameters = @{
+        ProjectRoot = $tempRoot
+        AssemblyPath = [System.IO.Path]::GetFullPath($AssemblyPath)
+        XmlDocPath = [System.IO.Path]::GetFullPath($XmlDocPath)
+        SourceCommit = $sourceCommit
+        GeneratedAtUtc = $generatedAtUtc
+    }
+    & $generator @generationParameters -OutputPath $candidateA | Out-Null
+    & $generator @generationParameters -OutputPath $candidateB | Out-Null
+
+    $validationParameters = @{
+        ExpectedManagedVersion = $managedVersion
+        ExpectedSourceCommit = $sourceCommit
+        ExpectedGeneratedAtUtc = $generatedAtUtc
+        RequireExactPages = $true
+    }
+    $first = Invoke-JsonScript -Path $validator -Parameters ($validationParameters + @{ WikiPath = $candidateA })
+    $second = Invoke-JsonScript -Path $validator -Parameters ($validationParameters + @{ WikiPath = $candidateB })
+    if ($first.ContentHash -ne $second.ContentHash) {
+        throw "Repeated Wiki generation is not deterministic: $($first.ContentHash) != $($second.ContentHash)"
+    }
+
+    Assert-ActionFails -Description 'stale source commit metadata' -Action {
+        $staleParameters = $validationParameters.Clone()
+        $staleParameters.ExpectedSourceCommit = ('f' * 40)
+        & $validator @staleParameters -WikiPath $candidateA *> $null
+    }
+
+    Copy-Item -LiteralPath $candidateA -Destination $tamperedCandidate -Recurse
+    Add-Content -LiteralPath (Join-Path $tamperedCandidate 'API-SDL.md') -Value "`nTampered content" -Encoding utf8NoBOM
+    Assert-ActionFails -Description 'unexpected content hash' -Action {
+        & $validator @validationParameters -WikiPath $tamperedCandidate -ExpectedContentHash $first.ContentHash *> $null
+    }
+
+    & git init --bare --initial-branch=master $bareRemote *> $null
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Failed to initialize local Wiki publication remote.'
+    }
+
+    $publishParameters = @{
+        CandidatePath = $candidateA
+        WikiRepositoryUrl = $bareRemote
+        WorkingRoot = $publishRoot
+        ExpectedManagedVersion = $managedVersion
+        ExpectedSourceCommit = $sourceCommit
+        ExpectedGeneratedAtUtc = $generatedAtUtc
+        ExpectedContentHash = $first.ContentHash
+        Push = $true
+    }
+    $published = Invoke-JsonScript -Path $publisher -Parameters $publishParameters
+    if ($published.Status -ne 'Published') {
+        throw "Initial Wiki publication returned unexpected status: $($published.Status)"
+    }
+    $commitCount = [int]((& git --git-dir=$bareRemote rev-list --count master).Trim())
+
+    $noChange = Invoke-JsonScript -Path $publisher -Parameters $publishParameters
+    if ($noChange.Status -ne 'NoChange') {
+        throw "Repeated Wiki publication returned unexpected status: $($noChange.Status)"
+    }
+    $repeatedCommitCount = [int]((& git --git-dir=$bareRemote rev-list --count master).Trim())
+    if ($repeatedCommitCount -ne $commitCount) {
+        throw 'Idempotent Wiki publication created an extra commit.'
+    }
+
+    $remoteValidation = Invoke-JsonScript -Path $remoteValidator -Parameters @{
+        WikiRepositoryUrl = $bareRemote
+        WorkingRoot = (Join-Path $tempRoot 'remote-verification')
+        ExpectedManagedVersion = $managedVersion
+        ExpectedSourceCommit = $sourceCommit
+        ExpectedGeneratedAtUtc = $generatedAtUtc
+        ExpectedContentHash = $first.ContentHash
+    }
+    if ($remoteValidation.ContentHash -ne $first.ContentHash) {
+        throw 'Published Wiki verification returned an unexpected content hash.'
+    }
+    Assert-ActionFails -Description 'published Wiki managed version mismatch' -Action {
+        & $remoteValidator `
+            -WikiRepositoryUrl $bareRemote `
+            -WorkingRoot (Join-Path $tempRoot 'remote-verification-failure') `
+            -ExpectedManagedVersion '9.9.9.9' `
+            -ExpectedSourceCommit $sourceCommit *> $null
+    }
+
+    Assert-ActionFails -Description 'unavailable Wiki remote' -Action {
+        $failedPublishParameters = $publishParameters.Clone()
+        $failedPublishParameters.WikiRepositoryUrl = Join-Path $tempRoot 'missing-remote.git'
+        & $publisher @failedPublishParameters *> $null
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+        if (-not $resolvedTempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -or
+            -not ([System.IO.Path]::GetFileName($resolvedTempRoot)).StartsWith('sdl3-cs-wiki-tools-', [System.StringComparison]::Ordinal)) {
+            throw "Refusing to remove unsafe Wiki test path: $resolvedTempRoot"
+        }
+
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Host 'Wiki tooling tests passed.'

--- a/.github/wiki-tools/Test-WikiTools.Tests.ps1
+++ b/.github/wiki-tools/Test-WikiTools.Tests.ps1
@@ -198,4 +198,7 @@ finally {
     }
 }
 
+# Expected negative-path native commands can leave a non-zero status even when
+# every assertion passed. Do not leak that status into a calling CI shell.
+$global:LASTEXITCODE = 0
 Write-Host 'Wiki tooling tests passed.'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,53 @@ jobs:
       - name: Audit public wrapper XML documentation
         shell: pwsh
         run: ./.github/release-tools/Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
+
+  examples-desktop:
+    name: Build desktop examples (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            runner: windows-2025
+          - name: Linux
+            runner: ubuntu-latest
+          - name: macOS
+            runner: macos-15
+
+    steps:
+      - name: Checkout SDL3-CS
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build all desktop examples
+        shell: pwsh
+        run: ./.github/release-tools/Test-ExampleProjects.ps1 -Configuration Release -Scope Desktop
+
+  examples-android:
+    name: Build Android example
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout SDL3-CS
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install Android .NET workload
+        shell: pwsh
+        run: dotnet workload install android --source https://api.nuget.org/v3/index.json
+
+      - name: Build all Android examples
+        shell: pwsh
+        run: ./.github/release-tools/Test-ExampleProjects.ps1 -Configuration Release -Scope Android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         shell: pwsh
         run: ./.github/release-tools/Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS
 
+      - name: Validate generated GitHub Wiki contract
+        shell: pwsh
+        run: |
+          ./.github/wiki-tools/Test-WikiTools.Tests.ps1
+          ./.github/wiki-tools/Test-WikiReleaseContract.Tests.ps1
+
   examples-desktop:
     name: Build desktop examples (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for helping improve SDL3-CS. Contributions are welcome for managed bin
 - Search the [existing issues](https://github.com/edwardgushchin/SDL3-CS/issues) and [discussions](https://github.com/edwardgushchin/SDL3-CS/discussions) before opening a new report.
 - Use [GitHub Discussions](https://github.com/edwardgushchin/SDL3-CS/discussions) for usage questions. The [support guide](SUPPORT.md) explains where each type of request belongs.
 - Report suspected vulnerabilities privately as described in the [security policy](SECURITY.md).
+- Follow the [release policy](RELEASING.md) for changes assigned to a patch or hotfix release.
 - For a substantial API, ABI, packaging, or release change, open an issue first so the scope and upstream SDL baseline can be agreed on.
 
 ## Development Setup

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,96 @@
+# SDL3-CS Release Policy
+
+This document defines the process for preparing SDL3-CS patch and hotfix releases. It applies to the managed wrapper, native NuGet packages, release tooling, and GitHub Releases. Instructions for reporting vulnerabilities are available in the [security policy](SECURITY.md).
+
+## Severity Levels
+
+Every confirmed defect must have exactly one severity label. The target release window starts when the fix has been implemented, verified, and declared ready for release.
+
+| Label | Criteria | Target release window |
+| --- | --- | --- |
+| `severity: critical` | A vulnerability, memory or data corruption, an ABI defect causing widespread crashes, or the inability to install or load a published package | Emergency hotfix within 24 hours |
+| `severity: high` | A serious regression or an unavailable key capability with no practical workaround | Release within 2–3 days |
+| `severity: medium` | A localized defect, missing binding, or missing typed API for which a workaround exists | The next scheduled patch release, usually within 7–14 days |
+| `severity: low` | Documentation, API usability, or minor behavior with no significant effect on usage | The next appropriate scheduled release |
+
+The `release: blocker` label is applied separately from severity when an issue makes a specific release unsafe or technically impossible. Publication is prohibited while a milestone contains an open blocker.
+
+## Scheduled Release Cadence
+
+A scheduled patch release is prepared when at least one user-facing fix is available and any one of the following conditions is met:
+
+- 3–5 verified fixes have accumulated;
+- 14 calendar days have passed since the previous patch release in the current release line;
+- a `severity: high` fix is ready and cannot wait for the regular release window.
+
+Documentation, workflow-only changes, and GitHub Actions updates do not require a new NuGet release by themselves. Empty releases are not created solely because a calendar date has been reached.
+
+## Emergency Hotfix
+
+A `severity: critical` issue overrides the regular schedule. An emergency release must contain the minimum necessary change, regression tests, and only compatible accompanying fixes that have already passed verification. The reason for the expedited release and any residual risks must be stated in the release notes.
+
+Mandatory checks must not be skipped, branch parity must not be violated, and unverified packages must not be published even for an emergency hotfix. If a safe fix is not yet ready, the maintainer communicates the status and any available temporary mitigation instead of publishing a knowingly defective package.
+
+## Branches and Main Parity
+
+Changes for the current release line follow this path:
+
+1. The fix, documentation, and tests are created and committed on the active `release-*` branch.
+2. The `release-*` branch is pushed to GitHub.
+3. A pull request is opened from `release-*` into `main`; direct writes to `main` are prohibited.
+4. The pull request is merged only after successful CI and review of the applicable changes.
+5. Before publication, confirm that the release commit or an equivalent change is already present in `main`.
+6. The release is published from the verified release branch only after an explicit maintainer decision.
+
+A release branch must not contain release-only fixes that are absent from `main`.
+
+## Milestones and Labels
+
+Every planned release has a separate milestone with the exact version and target date. An issue or pull request is included in a milestone only when the change is genuinely intended for that release.
+
+- `bug`, `enhancement`, `documentation`, and similar labels describe the type of work.
+- `severity: *` describes the impact of a confirmed defect and does not replace the type label.
+- `release: blocker` prohibits publication until the issue is closed or explicitly removed from the milestone.
+- Workflow-only Dependabot pull requests are not added to a managed patch release milestone unless they resolve a build or publication problem affecting that release.
+
+## Release Readiness
+
+Before publication, the maintainer confirms that:
+
+- the milestone contains no open `release: blocker` items, and every included change has a clear status;
+- `severity: critical` and `severity: high` issues associated with the release are closed or explicitly deferred with a documented reason;
+- the specification, implementation documentation, wrapper, and automated tests are aligned for every runtime or API change;
+- CI for the target release branch and the pull request into `main` completed successfully;
+- the release branch and `main` have the required parity;
+- the version, package scope, and release notes match the actual release contents;
+- the readiness check completed successfully:
+
+```powershell
+pwsh .\.github\release-tools\Test-ReleaseReadiness.ps1 -FailOnError
+```
+
+For a managed-only release, only inapplicable native artifact or toolchain steps may be skipped. The reason for each skip must follow from the milestone and the actual diff; managed build, tests, package validation, and release-scope validation remain mandatory.
+
+## GitHub Wiki Freshness
+
+The public API reference in the GitHub Wiki is a generated release artifact. The public C# API and XML documentation from the exact release commit remain the source of truth.
+
+- The accumulation task creates and verifies a Wiki candidate after merge and main parity, but does not publish it.
+- Before the production release, the release task rebuilds the exact release commit, generates the eight managed Wiki pages, and publishes them to `SDL3-CS.wiki.git` with a regular fast-forward push to `master`.
+- Every managed page must contain the same managed version, full source commit, and UTC generation timestamp.
+- After the push, a fresh read-only verification of the remote Wiki against the exact version, source commit, and SHA-256 content hash is mandatory.
+- A matching content hash must not create a duplicate Wiki commit.
+
+A Wiki publication failure, stale metadata, mismatched content hash, or inability to verify the remote Wiki blocks the production workflow. Until that blocker is resolved, NuGet packages and the GitHub Release must not be published, issues must not be commented on or closed, and the milestone must not be closed.
+
+The fast-forward push of the eight managed Wiki pages by the `sdl3-cs-2` task is a narrow exception to the general prohibition on scheduled tasks performing pushes. This exception applies only after a verified Wiki candidate and does not authorize changes to repository branches, source files, issues, or milestones.
+
+## Release Decision
+
+The readiness review produces one of three outcomes:
+
+- `Release now` — the release threshold has been met, no blockers remain, and all mandatory checks have passed;
+- `Wait` — verified fixes are ready, but the regular threshold has not yet been met and there is no urgency;
+- `Blocked` — a blocker, failing CI, branch parity violation, or incomplete mandatory check is present.
+
+Scheduled tasks may collect facts and recommend an outcome, but they must not publish NuGet packages or a GitHub Release, perform a push or merge, or replace an explicit maintainer decision, except for the explicitly described fast-forward push of managed Wiki pages by the `sdl3-cs-2` task.


### PR DESCRIPTION
## Summary

- validate the complete desktop and Android example-project inventory in CI;
- accept SHA-pinned `NuGet/login` while preserving the trusted-publishing contract;
- add the English SDL3-CS release policy and contributor guidance;
- generate, validate, publish, and remotely verify the API Wiki as a fail-closed release gate.

## Commits

- `ci: validate all example projects`
- `test: validate pinned NuGet login action`
- `docs: add release policy`
- `build: enforce Wiki release freshness`

## Verification

- all 47 desktop example projects build in Release with zero warnings and errors;
- example inventory and negative fixture tests pass;
- release workflow regression and manifest contract tests pass;
- Wiki tooling and release-contract tests pass;
- wrapper Release build completes with zero warnings and errors;
- workflow YAML parses successfully.

## Release scope

Release tooling, CI, and documentation only. Native packages do not require rebuilding.