### PR TITLE
Adopt trunk-based release lifecycle

### DIFF
--- a/.github/release-tools/Test-TrunkBasedReleaseLifecycle.Tests.ps1
+++ b/.github/release-tools/Test-TrunkBasedReleaseLifecycle.Tests.ps1
@@ -1,0 +1,94 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$validator = Join-Path $PSScriptRoot 'Test-TrunkBasedReleaseLifecycle.ps1'
+if (-not (Test-Path -LiteralPath $validator -PathType Leaf)) {
+    throw "Trunk-based lifecycle validator was not found: $validator"
+}
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tempParent = Join-Path $repositoryRoot '.agents\trunk-lifecycle-tests'
+$tempRoot = Join-Path $tempParent ([guid]::NewGuid().ToString('N'))
+
+function Write-Fixture {
+    param(
+        [Parameter(Mandatory)][string] $Root,
+        [Parameter(Mandatory)][bool] $TrunkBased
+    )
+
+    New-Item -ItemType Directory -Force -Path (Join-Path $Root '.github\workflows') | Out-Null
+
+    if ($TrunkBased) {
+        Set-Content -LiteralPath (Join-Path $Root 'AGENTS.md') -Encoding utf8NoBOM -Value @'
+## Short-Lived SDL3-CS Branch Lifecycle
+Use a short-lived topic branch and release from an exact verified commit from `main`.
+'@
+        Set-Content -LiteralPath (Join-Path $Root 'RELEASING.md') -Encoding utf8NoBOM -Value @'
+## Branches and Main
+Create a short-lived topic branch. The release source is the exact verified commit from `main`.
+'@
+        Set-Content -LiteralPath (Join-Path $Root 'CONTRIBUTING.md') -Encoding utf8NoBOM -Value 'Pull requests target `main`.'
+        Set-Content -LiteralPath (Join-Path $Root 'README.md') -Encoding utf8NoBOM -Value 'Published packages can lag behind the development state in `main`.'
+        Set-Content -LiteralPath (Join-Path $Root '.github\workflows\ci.yml') -Encoding utf8NoBOM -Value @'
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+'@
+    }
+    else {
+        Set-Content -LiteralPath (Join-Path $Root 'AGENTS.md') -Encoding utf8NoBOM -Value '## Release Branch Mainline Parity'
+        Set-Content -LiteralPath (Join-Path $Root 'RELEASING.md') -Encoding utf8NoBOM -Value 'Work on the active `release-*` branch and publish from the verified release branch.'
+        Set-Content -LiteralPath (Join-Path $Root 'CONTRIBUTING.md') -Encoding utf8NoBOM -Value 'Pull requests target the current `release-*` branch.'
+        Set-Content -LiteralPath (Join-Path $Root 'README.md') -Encoding utf8NoBOM -Value 'Packages can lag behind a release branch.'
+        Set-Content -LiteralPath (Join-Path $Root '.github\workflows\ci.yml') -Encoding utf8NoBOM -Value @'
+on:
+  push:
+    branches:
+      - main
+      - "release-*"
+'@
+    }
+}
+
+try {
+    $legacyRoot = Join-Path $tempRoot 'legacy'
+    Write-Fixture -Root $legacyRoot -TrunkBased $false
+    $legacyFailed = $false
+    try {
+        & $validator -RepositoryRoot $legacyRoot *> $null
+    }
+    catch {
+        $legacyFailed = $true
+    }
+    if (-not $legacyFailed) {
+        throw 'The validator accepted a persistent release-branch fixture.'
+    }
+
+    $trunkRoot = Join-Path $tempRoot 'trunk'
+    Write-Fixture -Root $trunkRoot -TrunkBased $true
+    $result = & $validator -RepositoryRoot $trunkRoot | ConvertFrom-Json
+    if ($result.Status -ne 'Passed') {
+        throw "Unexpected validator status: $($result.Status)"
+    }
+
+    Write-Host 'Trunk-based release lifecycle tests passed.'
+}
+finally {
+    if (Test-Path -LiteralPath $tempRoot) {
+        $resolvedParent = [System.IO.Path]::GetFullPath($tempParent)
+        $resolvedTemp = [System.IO.Path]::GetFullPath($tempRoot)
+        $relative = [System.IO.Path]::GetRelativePath($resolvedParent, $resolvedTemp)
+        if ([System.IO.Path]::IsPathRooted($relative) -or $relative.StartsWith('..')) {
+            throw "Unsafe test cleanup path: $resolvedTemp"
+        }
+        Remove-Item -LiteralPath $resolvedTemp -Recurse -Force
+    }
+}

--- a/.github/release-tools/Test-TrunkBasedReleaseLifecycle.ps1
+++ b/.github/release-tools/Test-TrunkBasedReleaseLifecycle.ps1
@@ -1,0 +1,75 @@
+#requires -Version 7.0
+[CmdletBinding()]
+param(
+    [string] $RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$requiredFiles = @{
+    Agents = 'AGENTS.md'
+    Releasing = 'RELEASING.md'
+    Contributing = 'CONTRIBUTING.md'
+    Readme = 'README.md'
+    Ci = '.github\workflows\ci.yml'
+}
+$content = @{}
+$errors = [System.Collections.Generic.List[string]]::new()
+
+foreach ($entry in $requiredFiles.GetEnumerator()) {
+    $path = Join-Path $root $entry.Value
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        $errors.Add("Required lifecycle file is missing: $($entry.Value)")
+        continue
+    }
+
+    $content[$entry.Key] = Get-Content -LiteralPath $path -Raw
+}
+
+if ($errors.Count -eq 0) {
+    if ($content.Agents -notmatch '(?m)^## Short-Lived SDL3-CS Branch Lifecycle\s*$') {
+        $errors.Add('AGENTS.md does not define the short-lived SDL3-CS branch lifecycle.')
+    }
+    if ($content.Agents -notmatch 'exact verified commit from `main`') {
+        $errors.Add('AGENTS.md does not require an exact verified commit from main.')
+    }
+    if ($content.Agents -match '(?m)^## Release Branch Mainline Parity\s*$') {
+        $errors.Add('AGENTS.md still defines persistent release-branch parity.')
+    }
+
+    if ($content.Releasing -notmatch 'short-lived topic branch') {
+        $errors.Add('RELEASING.md does not require short-lived topic branches.')
+    }
+    if ($content.Releasing -notmatch 'exact verified commit from `main`') {
+        $errors.Add('RELEASING.md does not identify the exact verified main commit as the release source.')
+    }
+    if ($content.Releasing -match 'active `release-\*` branch|verified release branch') {
+        $errors.Add('RELEASING.md still requires a persistent wrapper release branch.')
+    }
+
+    if ($content.Contributing -notmatch 'Pull requests (?:should )?target `main`') {
+        $errors.Add('CONTRIBUTING.md does not direct pull requests to main.')
+    }
+    if ($content.Readme -match '(?i)release branch') {
+        $errors.Add('README.md still describes a wrapper release branch.')
+    }
+
+    if ($content.Ci -notmatch '(?m)^\s*- main\s*$') {
+        $errors.Add('CI does not target main.')
+    }
+    if ($content.Ci -match '(?m)^\s*- ["'']?release-\*["'']?\s*$') {
+        $errors.Add('CI still targets persistent release-* wrapper branches.')
+    }
+}
+
+if ($errors.Count -gt 0) {
+    throw "Trunk-based release lifecycle validation failed:`n- $($errors -join "`n- ")"
+}
+
+[ordered]@{
+    Status = 'Passed'
+    RepositoryRoot = $root
+    CheckedFiles = $requiredFiles.Values.Count
+} | ConvertTo-Json -Compress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - main
-      - "release-*"
   push:
     branches:
       - main
-      - "release-*"
   workflow_dispatch:
 
 permissions:
@@ -91,6 +89,12 @@ jobs:
         run: |
           ./.github/wiki-tools/Test-WikiTools.Tests.ps1
           ./.github/wiki-tools/Test-WikiReleaseContract.Tests.ps1
+
+      - name: Validate trunk-based release lifecycle
+        shell: pwsh
+        run: |
+          ./.github/release-tools/Test-TrunkBasedReleaseLifecycle.Tests.ps1
+          ./.github/release-tools/Test-TrunkBasedReleaseLifecycle.ps1
 
   examples-desktop:
     name: Build desktop examples (${{ matrix.name }})

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,13 +174,15 @@ dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release
 ## Main Branch Integration Gate
 - Never cherry-pick, commit, merge, or otherwise write directly to `main` as an agent workflow shortcut.
 - Changes may reach `main` only through a pull request, and only when the user explicitly asks for that pull request in the current conversation.
-- When release branch work needs mainline parity, do not satisfy it by switching to `main` and cherry-picking locally. Document the missing parity in `TASKS.md` and the development diary, then wait for an explicit user request to open or prepare a pull request.
+- Create every change on a short-lived topic branch from the latest `origin/main`, open a pull request to `main`, and merge only after the required review and CI checks succeed.
 - If the user asks to undo a direct local `main` change made by the agent, remove only the agent-created local change and preserve unrelated user work.
 
-## Release Branch Mainline Parity
-- Any change made on a release branch must also exist on the main branch. Release branches must not contain release-only fixes, documentation updates, workflow changes, native source pin updates, or wrapper changes that are absent from main.
-- Before considering release branch work ready, verify that the same commits or equivalent changes are already present on main, or explicitly port them to main first. If parity cannot be verified, keep the release work open and document the missing mainline parity in `TASKS.md` and the development diary.
-- This rule applies to project source, release tooling, GitHub Actions workflows, native package metadata, wrapper code, XML documentation, specifications, implementation documentation, tests, and agent instructions.
+## Short-Lived SDL3-CS Branch Lifecycle
+- `main` is the only persistent branch in the SDL3-CS wrapper repository. Do not create or retain persistent wrapper `release-*` or `preview-*` branches.
+- Product changes, documentation, release tooling, workflows, native source pins, specifications, and tests must be developed on a short-lived topic branch created from the latest `origin/main` and integrated through a pull request to `main`.
+- Delete the topic branch after the pull request is merged. Git tags and GitHub Releases preserve published history; working branches do not serve as release archives.
+- A release must be built and published from an exact verified commit from `main`. Confirm that every milestone change is an ancestor of that commit and that required pull-request and `main` CI checks succeeded for the same contents.
+- The native fork release branches required below are an explicit exception: they preserve exact upstream tag commits in the separate SDL-family fork repositories and are not SDL3-CS wrapper development branches.
 
 ## Native Fork And Wrapper Alignment Policy
 - Native repositories used by release tooling include `SDL`, `SDL_image`, `SDL_mixer`, `SDL_ttf`, and `SDL_shadercross`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ dotnet restore .\SDL3-CS\SDL3-CS.csproj
 dotnet restore .\SDL3-CS.Tests\SDL3-CS.Tests.csproj
 ```
 
-Create a focused branch from the active development branch. Unless an issue or maintainer says otherwise, pull requests should target the current `release-*` branch; release branches are subsequently integrated into `main`.
+Create a focused, short-lived topic branch from the latest `main`. Pull requests should target `main`; delete the topic branch after it is merged.
 
 ## Binding Changes
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This source tree targets the following release lines:
 
 `{Platform}` is one of `Windows`, `Linux`, `MacOS`, `Android`, `iOS`, or `tvOS`.
 
-Published NuGet packages can lag behind a release branch while native packages are being assembled. The NuGet badge, package pages, and [GitHub Releases](https://github.com/edwardgushchin/SDL3-CS/releases) are authoritative for what is currently published.
+Published NuGet packages can lag behind the development state in `main` while native packages are being assembled. The NuGet badge, package pages, and [GitHub Releases](https://github.com/edwardgushchin/SDL3-CS/releases) are authoritative for what is currently published.
 
 ## 📚 Documentation
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,20 +29,20 @@ Documentation, workflow-only changes, and GitHub Actions updates do not require 
 
 A `severity: critical` issue overrides the regular schedule. An emergency release must contain the minimum necessary change, regression tests, and only compatible accompanying fixes that have already passed verification. The reason for the expedited release and any residual risks must be stated in the release notes.
 
-Mandatory checks must not be skipped, branch parity must not be violated, and unverified packages must not be published even for an emergency hotfix. If a safe fix is not yet ready, the maintainer communicates the status and any available temporary mitigation instead of publishing a knowingly defective package.
+Mandatory checks must not be skipped, the exact release commit must be verified, and unverified packages must not be published even for an emergency hotfix. If a safe fix is not yet ready, the maintainer communicates the status and any available temporary mitigation instead of publishing a knowingly defective package.
 
-## Branches and Main Parity
+## Branches and Main
 
 Changes for the current release line follow this path:
 
-1. The fix, documentation, and tests are created and committed on the active `release-*` branch.
-2. The `release-*` branch is pushed to GitHub.
-3. A pull request is opened from `release-*` into `main`; direct writes to `main` are prohibited.
-4. The pull request is merged only after successful CI and review of the applicable changes.
-5. Before publication, confirm that the release commit or an equivalent change is already present in `main`.
-6. The release is published from the verified release branch only after an explicit maintainer decision.
+1. Create a short-lived topic branch from the latest `origin/main` for each coherent change or tightly related group of changes.
+2. Commit the implementation, documentation, and tests on that topic branch and push it to GitHub.
+3. Open a pull request from the topic branch into `main`; direct writes to `main` are prohibited.
+4. Merge the pull request only after successful CI and review of the applicable changes, then delete the topic branch.
+5. Select the exact verified commit from `main` that contains every change assigned to the milestone and record its full 40-character SHA.
+6. Build, validate, tag, and publish the release from that exact commit.
 
-A release branch must not contain release-only fixes that are absent from `main`.
+`main` is the only persistent branch in the SDL3-CS wrapper repository. Git tags and GitHub Releases preserve published history; persistent wrapper `release-*` and `preview-*` branches are not used. Native SDL-family forks retain their exact upstream `release-*` branches as required by the native fork alignment policy; those branches are not wrapper development branches.
 
 ## Milestones and Labels
 
@@ -60,8 +60,8 @@ Before publication, the maintainer confirms that:
 - the milestone contains no open `release: blocker` items, and every included change has a clear status;
 - `severity: critical` and `severity: high` issues associated with the release are closed or explicitly deferred with a documented reason;
 - the specification, implementation documentation, wrapper, and automated tests are aligned for every runtime or API change;
-- CI for the target release branch and the pull request into `main` completed successfully;
-- the release branch and `main` have the required parity;
+- every included pull request is merged into `main`, and each included change is an ancestor of the selected release commit;
+- CI for the included pull requests and the selected exact `main` commit completed successfully;
 - the version, package scope, and release notes match the actual release contents;
 - the readiness check completed successfully:
 
@@ -75,7 +75,7 @@ For a managed-only release, only inapplicable native artifact or toolchain steps
 
 The public API reference in the GitHub Wiki is a generated release artifact. The public C# API and XML documentation from the exact release commit remain the source of truth.
 
-- The accumulation task creates and verifies a Wiki candidate after merge and main parity, but does not publish it.
+- The accumulation task creates and verifies a Wiki candidate after the pull request is merged and its exact `main` commit is confirmed, but does not publish it.
 - Before the production release, the release task rebuilds the exact release commit, generates the eight managed Wiki pages, and publishes them to `SDL3-CS.wiki.git` with a regular fast-forward push to `master`.
 - Every managed page must contain the same managed version, full source commit, and UTC generation timestamp.
 - After the push, a fresh read-only verification of the remote Wiki against the exact version, source commit, and SHA-256 content hash is mandatory.
@@ -91,6 +91,6 @@ The readiness review produces one of three outcomes:
 
 - `Release now` — the release threshold has been met, no blockers remain, and all mandatory checks have passed;
 - `Wait` — verified fixes are ready, but the regular threshold has not yet been met and there is no urgency;
-- `Blocked` — a blocker, failing CI, branch parity violation, or incomplete mandatory check is present.
+- `Blocked` — a blocker, failing CI, an unverifiable release commit, or an incomplete mandatory check is present.
 
 Scheduled tasks may collect facts and recommend an outcome, but they must not publish NuGet packages or a GitHub Release, perform a push or merge, or replace an explicit maintainer decision, except for the explicitly described fast-forward push of managed Wiki pages by the `sdl3-cs-2` task.


### PR DESCRIPTION
## Summary
- make main the only persistent SDL3-CS wrapper branch
- release from an exact verified main commit
- validate the lifecycle contract in CI
- preserve release branches only in the separate native forks

## Verification
- pwsh ./.github/release-tools/Test-TrunkBasedReleaseLifecycle.Tests.ps1
- pwsh ./.github/release-tools/Test-TrunkBasedReleaseLifecycle.ps1
- pwsh ./.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
- pwsh ./.github/release-tools/Test-ReleaseWorkflow.ps1
- git diff --check