### PR TITLE
Enforce uniform native package revisions

### DIFF
--- a/.github/release-tools/New-NativePackageRepack.ps1
+++ b/.github/release-tools/New-NativePackageRepack.ps1
@@ -10,6 +10,7 @@ param(
     [string] $AdditionalFilePath = 'SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING',
     [string] $AdditionalPackagePath = 'licenses/libwebp/COPYING',
     [string] $RepositoryCommit,
+    [switch] $VersionOnly,
     [switch] $SkipSourceSignatureValidation
 )
 
@@ -111,17 +112,25 @@ New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
 if ($PreviousPackageDir) {
     $PreviousPackageDir = Resolve-ReleasePath $PreviousPackageDir
 }
-$additionalFile = Resolve-ReleasePath $AdditionalFilePath
-if (-not (Test-Path -LiteralPath $additionalFile -PathType Leaf)) {
-    throw "Additional repack file was not found: $additionalFile"
+$additionalFile = $null
+if ($VersionOnly) {
+    if ($PSBoundParameters.ContainsKey('AdditionalFilePath') -or $PSBoundParameters.ContainsKey('AdditionalPackagePath')) {
+        throw 'VersionOnly cannot be combined with an additional file or package path.'
+    }
 }
-$additionalPackageSegments = @($AdditionalPackagePath.Replace('\', '/').Split('/'))
-if ([string]::IsNullOrWhiteSpace($AdditionalPackagePath) -or
-    $AdditionalPackagePath.StartsWith('/', [System.StringComparison]::Ordinal) -or
-    $additionalPackageSegments -contains '' -or
-    $additionalPackageSegments -contains '.' -or
-    $additionalPackageSegments -contains '..') {
-    throw "AdditionalPackagePath must be a safe relative package path: $AdditionalPackagePath"
+else {
+    $additionalFile = Resolve-ReleasePath $AdditionalFilePath
+    if (-not (Test-Path -LiteralPath $additionalFile -PathType Leaf)) {
+        throw "Additional repack file was not found: $additionalFile"
+    }
+    $additionalPackageSegments = @($AdditionalPackagePath.Replace('\', '/').Split('/'))
+    if ([string]::IsNullOrWhiteSpace($AdditionalPackagePath) -or
+        $AdditionalPackagePath.StartsWith('/', [System.StringComparison]::Ordinal) -or
+        $additionalPackageSegments -contains '' -or
+        $additionalPackageSegments -contains '.' -or
+        $additionalPackageSegments -contains '..') {
+        throw "AdditionalPackagePath must be a safe relative package path: $AdditionalPackagePath"
+    }
 }
 if (-not $RepositoryCommit) {
     $RepositoryCommit = (& git -C (Get-ReleaseRepoRoot) rev-parse HEAD 2>&1 | Out-String).Trim()
@@ -192,7 +201,7 @@ try {
 
         $sourceZip = [System.IO.Compression.ZipFile]::OpenRead($previousPath)
         try {
-            if ($sourceZip.GetEntry($AdditionalPackagePath)) {
+            if (-not $VersionOnly -and $sourceZip.GetEntry($AdditionalPackagePath)) {
                 throw "Previous package already contains target additional entry: $($previous.Id) -> $AdditionalPackagePath"
             }
             $targetStream = [System.IO.File]::Open($targetPath, [System.IO.FileMode]::CreateNew)
@@ -221,7 +230,7 @@ try {
                             Set-XmlElementValue -Xml $coreProperties -LocalName 'version' -Value $target.PackageVersion
                             $bytes = Convert-XmlToBytes -Xml $coreProperties
                         }
-                        elseif ($entryName -eq '[Content_Types].xml') {
+                        elseif (-not $VersionOnly -and $entryName -eq '[Content_Types].xml') {
                             [xml] $contentTypes = Convert-BytesToXml -Bytes $bytes
                             $namespace = $contentTypes.DocumentElement.NamespaceURI
                             $override = $contentTypes.CreateElement('Override', $namespace)
@@ -242,14 +251,16 @@ try {
                         }
                     }
 
-                    $additionalBytes = [System.IO.File]::ReadAllBytes($additionalFile)
-                    $additionalEntry = $targetZip.CreateEntry($AdditionalPackagePath, [System.IO.Compression.CompressionLevel]::Optimal)
-                    $additionalStream = $additionalEntry.Open()
-                    try {
-                        $additionalStream.Write($additionalBytes, 0, $additionalBytes.Length)
-                    }
-                    finally {
-                        $additionalStream.Dispose()
+                    if (-not $VersionOnly) {
+                        $additionalBytes = [System.IO.File]::ReadAllBytes($additionalFile)
+                        $additionalEntry = $targetZip.CreateEntry($AdditionalPackagePath, [System.IO.Compression.CompressionLevel]::Optimal)
+                        $additionalStream = $additionalEntry.Open()
+                        try {
+                            $additionalStream.Write($additionalBytes, 0, $additionalBytes.Length)
+                        }
+                        finally {
+                            $additionalStream.Dispose()
+                        }
                     }
                 }
                 finally {
@@ -274,6 +285,7 @@ try {
             Package = $target.Id
             SourceVersion = $previous.PackageVersion
             TargetVersion = $target.PackageVersion
+            Mode = if ($VersionOnly) { 'version-only' } else { 'content-add' }
             Output = $targetPath
         }
     }

--- a/.github/release-tools/Publish-NativePackageRepack.ps1
+++ b/.github/release-tools/Publish-NativePackageRepack.ps1
@@ -6,6 +6,7 @@ param(
     [Parameter(Mandatory)][string[]] $PackageIds,
     [string] $ManifestPath = (Join-Path $PSScriptRoot 'release-manifest.json'),
     [string] $PackageDir,
+    [switch] $VersionOnly,
     [switch] $NuGetPush,
     [switch] $DryRun
 )
@@ -26,12 +27,17 @@ $PackageDir = Resolve-ReleasePath $PackageDir
     -ManifestPath $ManifestPath `
     -PackageDir $PackageDir `
     -PackageIds $PackageIds
-& (Join-Path $PSScriptRoot 'Test-NativePackageRepack.ps1') `
-    -PackageRevision $PackageRevision `
-    -PreviousPackageRevision $PreviousPackageRevision `
-    -PackageIds $PackageIds `
-    -ManifestPath $ManifestPath `
-    -PackageDir $PackageDir
+$repackValidation = @{
+    PackageRevision = $PackageRevision
+    PreviousPackageRevision = $PreviousPackageRevision
+    PackageIds = $PackageIds
+    ManifestPath = $ManifestPath
+    PackageDir = $PackageDir
+}
+if ($VersionOnly) {
+    $repackValidation.VersionOnly = $true
+}
+& (Join-Path $PSScriptRoot 'Test-NativePackageRepack.ps1') @repackValidation
 
 $allPackages = @(Get-ReleasePackageVersions -Manifest $manifest -PackageRevision $PackageRevision)
 $packages = @()

--- a/.github/release-tools/Test-NativePackageRepack.Tests.ps1
+++ b/.github/release-tools/Test-NativePackageRepack.Tests.ps1
@@ -144,9 +144,11 @@ foreach ($forbidden in @('Build-Native.ps1', 'Invoke-NativeHostBuild.ps1', 'Invo
 }
 foreach ($modeExpectation in @(
     'selective_native_repack:',
+    'selective_repack_mode:',
     'publish_selective_nuget:',
     "throw 'Selective native repack requires managed_only=true",
-    'if: ${{ inputs.managed_only && !inputs.selective_native_repack }}'
+    'if: ${{ inputs.managed_only && !inputs.selective_native_repack }}',
+    'VersionOnly = $true'
 )) {
     Assert-TextContains -Text $workflowText -Expected $modeExpectation -Description 'fail-closed selective release mode'
 }
@@ -159,9 +161,11 @@ if (-not $tempRoot.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnor
 
 $previousDir = Join-Path $tempRoot 'previous'
 $targetDir = Join-Path $tempRoot 'target'
-New-Item -ItemType Directory -Force -Path $previousDir, $targetDir | Out-Null
+$versionOnlyDir = Join-Path $tempRoot 'version-only'
+New-Item -ItemType Directory -Force -Path $previousDir, $targetDir, $versionOnlyDir | Out-Null
 $previousPackage = Join-Path $previousDir 'SDL3-CS.Windows.Image.3.4.4.7.nupkg'
 $targetPackage = Join-Path $targetDir 'SDL3-CS.Windows.Image.3.4.4.8.nupkg'
+$versionOnlyPackage = Join-Path $versionOnlyDir 'SDL3-CS.Windows.Image.3.4.4.8.nupkg'
 $crlfLicensePackage = Join-Path $targetDir 'crlf-license-fixture.nupkg'
 
 try {
@@ -199,6 +203,40 @@ try {
     }
     Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'SDL3-CS.Windows.Image.nuspec') -Expected '<version>3.4.4.8</version>' -Description 'nuspec target version'
     Assert-TextContains -Text (Get-ZipEntryText -PackagePath $targetPackage -EntryName 'package/services/metadata/core-properties/test.psmdcp') -Expected '<version>3.4.4.8</version>' -Description 'core properties target version'
+
+    & $builder `
+        -PackageRevision 8 `
+        -PreviousPackageRevision 7 `
+        -PackageIds 'SDL3-CS.Windows.Image' `
+        -OutputDir $versionOnlyDir `
+        -PreviousPackageDir $previousDir `
+        -RepositoryCommit ('b' * 40) `
+        -VersionOnly `
+        -SkipSourceSignatureValidation
+
+    & $validator `
+        -PackageRevision 8 `
+        -PreviousPackageRevision 7 `
+        -PackageIds 'SDL3-CS.Windows.Image' `
+        -PackageDir $versionOnlyDir `
+        -PreviousPackageDir $previousDir `
+        -VersionOnly `
+        -SkipTargetAvailabilityCheck
+
+    $versionOnlyArchive = [System.IO.Compression.ZipFile]::OpenRead($versionOnlyPackage)
+    try {
+        if ($versionOnlyArchive.GetEntry('.signature.p7s')) {
+            throw 'Version-only repack must not preserve the source package signature.'
+        }
+        if ($versionOnlyArchive.GetEntry('licenses/libwebp/COPYING')) {
+            throw 'Version-only repack must not add the libwebp license.'
+        }
+    }
+    finally {
+        $versionOnlyArchive.Dispose()
+    }
+    Assert-TextContains -Text (Get-ZipEntryText -PackagePath $versionOnlyPackage -EntryName 'SDL3-CS.Windows.Image.nuspec') -Expected '<version>3.4.4.8</version>' -Description 'version-only nuspec target version'
+    Assert-TextContains -Text (Get-ZipEntryText -PackagePath $versionOnlyPackage -EntryName 'package/services/metadata/core-properties/test.psmdcp') -Expected '<version>3.4.4.8</version>' -Description 'version-only core properties target version'
 
     $sourceLicenseText = Get-Content -LiteralPath (Join-Path $repoRoot 'SDL3-CS.NativePackages/ThirdPartyLicenses/libwebp/COPYING') -Raw -Encoding UTF8
     $crlfLicenseBytes = [System.Text.Encoding]::UTF8.GetBytes(($sourceLicenseText -replace "`r?`n", "`r`n"))

--- a/.github/release-tools/Test-NativePackageRepack.ps1
+++ b/.github/release-tools/Test-NativePackageRepack.ps1
@@ -8,6 +8,7 @@ param(
     [string] $PackageDir,
     [string] $PreviousPackageDir,
     [string[]] $RequiredEntries = @('licenses/libwebp/COPYING'),
+    [switch] $VersionOnly,
     [switch] $SkipTargetAvailabilityCheck
 )
 
@@ -77,11 +78,63 @@ function Test-ZipEntryExists {
     }
 }
 
+function Get-ZipStableContentMap {
+    param(
+        [Parameter(Mandatory)][string] $Path,
+        [Parameter(Mandatory)][string[]] $ExcludedEntries
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $excluded = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($entryName in $ExcludedEntries) {
+        [void] $excluded.Add($entryName)
+    }
+    $map = [System.Collections.Generic.Dictionary[string, string]]::new([System.StringComparer]::Ordinal)
+    $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        foreach ($entry in $zip.Entries) {
+            $name = $entry.FullName.Replace('\', '/')
+            if (-not $name -or $name.EndsWith('/', [System.StringComparison]::Ordinal) -or
+                $excluded.Contains($name) -or
+                $name.EndsWith('.nuspec', [System.StringComparison]::OrdinalIgnoreCase) -or
+                $name.EndsWith('.psmdcp', [System.StringComparison]::OrdinalIgnoreCase)) {
+                continue
+            }
+
+            $sha256 = [System.Security.Cryptography.SHA256]::Create()
+            try {
+                $stream = $entry.Open()
+                try {
+                    $hash = $sha256.ComputeHash($stream)
+                    $map[$name] = ([System.BitConverter]::ToString($hash) -replace '-', '').ToLowerInvariant()
+                }
+                finally {
+                    $stream.Dispose()
+                }
+            }
+            finally {
+                $sha256.Dispose()
+            }
+        }
+    }
+    finally {
+        $zip.Dispose()
+    }
+
+    return $map
+}
+
 if ($PackageRevision -lt 0 -or $PreviousPackageRevision -lt 0) {
     throw 'Package revisions must be zero or greater.'
 }
 if (-not $PackageIds -or $PackageIds.Count -eq 0) {
     throw 'PackageIds must select at least one native package.'
+}
+if ($VersionOnly) {
+    if ($PSBoundParameters.ContainsKey('RequiredEntries') -and @($RequiredEntries).Count -gt 0) {
+        throw 'VersionOnly cannot require additional package entries.'
+    }
+    $RequiredEntries = @()
 }
 
 $manifest = Get-ReleaseManifest -ManifestPath $ManifestPath
@@ -188,12 +241,34 @@ try {
             }
         }
 
+        $excludedStableEntries = @('.signature.p7s')
+        if (-not $VersionOnly) {
+            $excludedStableEntries += '[Content_Types].xml'
+            $excludedStableEntries += $RequiredEntries
+        }
+        $previousStableContent = Get-ZipStableContentMap -Path $previousPath -ExcludedEntries $excludedStableEntries
+        $targetStableContent = Get-ZipStableContentMap -Path $targetPath -ExcludedEntries $excludedStableEntries
+        foreach ($entryName in $previousStableContent.Keys) {
+            if (-not $targetStableContent.ContainsKey($entryName)) {
+                $errors.Add("Target package $($target.Id) is missing unchanged package entry: $entryName")
+            }
+            elseif ($targetStableContent[$entryName] -ne $previousStableContent[$entryName]) {
+                $errors.Add("Target package $($target.Id) changed package entry: $entryName")
+            }
+        }
+        foreach ($entryName in $targetStableContent.Keys) {
+            if (-not $previousStableContent.ContainsKey($entryName)) {
+                $errors.Add("Target package $($target.Id) added unexpected package entry: $entryName")
+            }
+        }
+
         $status = if (@($errors | Where-Object { $_ -like "*$($target.Id)*" }).Count -eq 0) { 'valid' } else { 'failed' }
         $rows.Add([pscustomobject]@{
             Package = $target.Id
             PreviousVersion = $previous.PackageVersion
             TargetVersion = $target.PackageVersion
             PayloadEntries = $targetPayload.Count
+            Mode = if ($VersionOnly) { 'version-only' } else { 'content-add' }
             Status = $status
         })
     }

--- a/.github/release-tools/release-notes/v3.4.12.4.md
+++ b/.github/release-tools/release-notes/v3.4.12.4.md
@@ -1,6 +1,6 @@
 Stable SDL3-CS patch release for SDL 3.4.12.
 
-This release publishes the managed `SDL3-CS` wrapper and selectively repacks only the Android, Linux, and Windows SDL_image native packages to include the required libwebp license. Native binaries and source revisions are unchanged.
+This release publishes the managed `SDL3-CS` wrapper and aligns every SDL_image platform package on revision `3.4.4.8`. Android, Linux, and Windows packages include the required libwebp license; iOS, macOS, and tvOS use a version-only repack. Native binaries and source revisions are unchanged.
 
 ## Package Versions
 
@@ -8,8 +8,7 @@ This release publishes the managed `SDL3-CS` wrapper and selectively repacks onl
 |----------------|---------|
 | `SDL3-CS` | `3.4.12.4` |
 | `SDL3-CS.<Platform>` | `3.4.12.1` |
-| `SDL3-CS.{Android,Linux,Windows}.Image` | `3.4.4.8` |
-| `SDL3-CS.{iOS,MacOS,tvOS}.Image` | `3.4.4.7` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.8` |
 | `SDL3-CS.<Platform>.Mixer` | `3.2.4.7` |
 | `SDL3-CS.<Platform>.TTF` | `3.2.2.7` |
 | `SDL3-CS.<Platform>.Shadercross` | `3.0.0.7` |
@@ -20,6 +19,6 @@ This release publishes the managed `SDL3-CS` wrapper and selectively repacks onl
 - Corrected the source-region type used by `DownloadFromGPUBuffer` ([#221](https://github.com/edwardgushchin/SDL3-CS/issues/221)).
 - Added mixed nullable/pointer `CreateAudioStream` overloads for practical source and destination specification combinations ([#223](https://github.com/edwardgushchin/SDL3-CS/issues/223)).
 - Aligned `PointInRectFloat` edge handling with SDL and added a non-nullable overload ([#225](https://github.com/edwardgushchin/SDL3-CS/issues/225)).
-- Added the libwebp license to Android, Linux, and Windows Image runtime packages without rebuilding or changing their native payloads ([#226](https://github.com/edwardgushchin/SDL3-CS/issues/226)).
+- Added the libwebp license to Android, Linux, and Windows Image runtime packages and aligned iOS, macOS, and tvOS on the same Image package revision without rebuilding or changing native payloads ([#226](https://github.com/edwardgushchin/SDL3-CS/issues/226)).
 
-Applications should update `SDL3-CS` to `3.4.12.4`. Consumers of Android, Linux, or Windows Image packages should also update those packages to `3.4.4.8`; other native package versions remain unchanged.
+Applications should update `SDL3-CS` to `3.4.12.4`. Consumers of Image packages should update every platform package to `3.4.4.8`; other native component package versions remain unchanged.

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -44,6 +44,14 @@ on:
         required: true
         type: boolean
         default: false
+      selective_repack_mode:
+        description: Repack content mode. Use version-only when only a common family revision is required.
+        required: true
+        type: choice
+        options:
+          - add-libwebp-license
+          - version-only
+        default: add-libwebp-license
       previous_native_package_revision:
         description: Published source revision for selective native package repack.
         required: true
@@ -76,6 +84,7 @@ jobs:
         shell: pwsh
         run: |
           $selective = '${{ inputs.selective_native_repack }}' -eq 'true'
+          $repackMode = '${{ inputs.selective_repack_mode }}'
           $managed = '${{ inputs.managed_only }}' -eq 'true'
           $normalPublish = '${{ inputs.publish_github }}' -eq 'true' -or '${{ inputs.publish_nuget }}' -eq 'true'
           $selectivePublish = '${{ inputs.publish_selective_nuget }}' -eq 'true'
@@ -87,6 +96,9 @@ jobs:
           }
           if (-not $selective -and $selectivePublish) {
             throw 'publish_selective_nuget requires selective_native_repack=true.'
+          }
+          if ($selective -and $repackMode -notin @('add-libwebp-license', 'version-only')) {
+            throw "Unsupported selective repack mode: $repackMode"
           }
 
   plan:
@@ -737,13 +749,19 @@ jobs:
           PACKAGE_REVISION: ${{ inputs.package_revision }}
           PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
           PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+          REPACK_MODE: ${{ inputs.selective_repack_mode }}
         run: |
           $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-          ./.github/release-tools/New-NativePackageRepack.ps1 `
-            -PackageRevision ([int]$env:PACKAGE_REVISION) `
-            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
-            -PackageIds $ids `
-            -OutputDir 'artifacts/release/nuget'
+          $params = @{
+            PackageRevision = [int]$env:PACKAGE_REVISION
+            PreviousPackageRevision = [int]$env:PREVIOUS_PACKAGE_REVISION
+            PackageIds = $ids
+            OutputDir = 'artifacts/release/nuget'
+          }
+          if ($env:REPACK_MODE -eq 'version-only') {
+            $params.VersionOnly = $true
+          }
+          ./.github/release-tools/New-NativePackageRepack.ps1 @params
 
       - name: Prove package-only payload equivalence
         shell: pwsh
@@ -751,21 +769,30 @@ jobs:
           PACKAGE_REVISION: ${{ inputs.package_revision }}
           PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
           PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+          REPACK_MODE: ${{ inputs.selective_repack_mode }}
         run: |
           $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-          $rids = @('android-arm', 'android-arm64', 'android-x86', 'android-x64', 'linux-x64', 'linux-arm64', 'win-x86', 'win-x64', 'win-arm64')
+          $manifest = Get-Content -LiteralPath '.github/release-tools/release-manifest.json' -Raw | ConvertFrom-Json -Depth 64
+          $rids = @($manifest.rids.rid)
           ./.github/release-tools/Test-NuGetPackageContents.ps1 `
             -PackageRevision ([int]$env:PACKAGE_REVISION) `
             -PackageIds $ids `
             -Rids $rids `
             -PackageDir 'artifacts/release/nuget'
-          ./.github/release-tools/Test-NativePackageRepack.ps1 `
-            -PackageRevision ([int]$env:PACKAGE_REVISION) `
-            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
-            -PackageIds $ids `
-            -PackageDir 'artifacts/release/nuget'
-          $packagePaths = @(Get-ChildItem -LiteralPath 'artifacts/release/nuget' -Filter '*.nupkg' -File | ForEach-Object FullName)
-          ./.github/release-tools/Test-ImageLibwebpLicenses.ps1 -PackagePaths $packagePaths
+          $validation = @{
+            PackageRevision = [int]$env:PACKAGE_REVISION
+            PreviousPackageRevision = [int]$env:PREVIOUS_PACKAGE_REVISION
+            PackageIds = $ids
+            PackageDir = 'artifacts/release/nuget'
+          }
+          if ($env:REPACK_MODE -eq 'version-only') {
+            $validation.VersionOnly = $true
+          }
+          ./.github/release-tools/Test-NativePackageRepack.ps1 @validation
+          if ($env:REPACK_MODE -eq 'add-libwebp-license') {
+            $packagePaths = @(Get-ChildItem -LiteralPath 'artifacts/release/nuget' -Filter '*.nupkg' -File | ForEach-Object FullName)
+            ./.github/release-tools/Test-ImageLibwebpLicenses.ps1 -PackagePaths $packagePaths
+          }
 
       - name: Upload selected NuGet packages
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
@@ -809,11 +836,17 @@ jobs:
           PACKAGE_REVISION: ${{ inputs.package_revision }}
           PREVIOUS_PACKAGE_REVISION: ${{ inputs.previous_native_package_revision }}
           PACKAGE_IDS: ${{ inputs.selective_package_ids }}
+          REPACK_MODE: ${{ inputs.selective_repack_mode }}
         run: |
           $ids = @($env:PACKAGE_IDS -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })
-          ./.github/release-tools/Publish-NativePackageRepack.ps1 `
-            -PackageRevision ([int]$env:PACKAGE_REVISION) `
-            -PreviousPackageRevision ([int]$env:PREVIOUS_PACKAGE_REVISION) `
-            -PackageIds $ids `
-            -PackageDir 'artifacts/release/nuget' `
-            -NuGetPush
+          $params = @{
+            PackageRevision = [int]$env:PACKAGE_REVISION
+            PreviousPackageRevision = [int]$env:PREVIOUS_PACKAGE_REVISION
+            PackageIds = $ids
+            PackageDir = 'artifacts/release/nuget'
+            NuGetPush = $true
+          }
+          if ($env:REPACK_MODE -eq 'version-only') {
+            $params.VersionOnly = $true
+          }
+          ./.github/release-tools/Publish-NativePackageRepack.ps1 @params

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,6 +71,18 @@ pwsh .\.github\release-tools\Test-ReleaseReadiness.ps1 -FailOnError
 
 For a managed-only release, only inapplicable native artifact or toolchain steps may be skipped. The reason for each skip must follow from the milestone and the actual diff; managed build, tests, package validation, and release-scope validation remain mandatory.
 
+## Native Package Revision Consistency
+
+Every native component package family must use one package revision across all supported platforms. A component family includes all platform-specific packages that share the same native component and version, such as `SDL3-CS.<Platform>.Image` packages for one SDL_image version.
+
+- If any platform package requires a new revision because of a native binary, metadata, licensing, packaging, signing, or other package-content change, the same new revision must be reserved, produced, validated, and published for every supported platform package in that component family.
+- A platform whose native payload did not otherwise change must be repacked from its previously verified package. Its native binaries and source revision must remain unchanged; only the package revision and unavoidable NuGet metadata may differ.
+- Selective publication that leaves platform packages in the same component family on different revisions is prohibited.
+- If the intended revision is already occupied for any package ID in the component family, the release must use the next revision that is available for every package ID in that family.
+- Release readiness must verify that every supported platform package exists at the common revision before examples, shared dependency properties, release notes, or downstream consumers are updated to that revision and before the release is considered complete.
+
+A packaging-only revision does not change the component's upstream `nativeVersion` or source commit. It changes only the final package revision shared by the complete platform family.
+
 ## GitHub Wiki Freshness
 
 The public API reference in the GitHub Wiki is a generated release artifact. The public C# API and XML documentation from the exact release commit remain the source of truth.


### PR DESCRIPTION
## Summary
- require one native package revision across every platform in a component family
- add a validated version-only selective repack mode for unchanged platform packages
- align the v3.4.12.4 Image release notes on 3.4.4.8 for all platforms

## Validation
- focused native repack fixtures, including version-only mode
- release workflow, lifecycle, package versioning, manifest, and Wiki contract checks
- real signed iOS/macOS/tvOS Image 3.4.4.7 to 3.4.4.8 repack validation
- Release wrapper build and public XML documentation audit