### PR TITLE
Fix Wiki readiness in release publish job

### DIFF
--- a/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
@@ -245,6 +245,28 @@ try {
         & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
     }
 
+    $wikiReleaseBuildCommand = 'dotnet build ./SDL3-CS/SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false'
+    $publishJobStart = $workflowText.IndexOf('  publish:', [System.StringComparison]::Ordinal)
+    $managedBuildJobStart = $workflowText.IndexOf('  managed-build:', [System.StringComparison]::Ordinal)
+    $publishWikiBuildIndex = if ($publishJobStart -ge 0) {
+        $workflowText.IndexOf($wikiReleaseBuildCommand, $publishJobStart, [System.StringComparison]::Ordinal)
+    }
+    else {
+        -1
+    }
+    if ($publishJobStart -lt 0 -or $managedBuildJobStart -le $publishJobStart -or
+        $publishWikiBuildIndex -lt $publishJobStart -or $publishWikiBuildIndex -ge $managedBuildJobStart) {
+        throw 'Release workflow fixture must contain the Wiki Release output build inside the publish job.'
+    }
+    $missingPublishWikiBuildWorkflow = $workflowText.Remove(
+        $publishWikiBuildIndex,
+        $wikiReleaseBuildCommand.Length
+    ).Insert($publishWikiBuildIndex, 'dotnet --info')
+    Set-Content -LiteralPath $tempWorkflow -Value $missingPublishWikiBuildWorkflow -Encoding UTF8
+    Assert-WorkflowValidationFails -Description 'missing publish-job Wiki Release output build before readiness' -Action {
+        & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
+    }
+
     $missingBridgeBuildWorkflow = $workflowText.Replace(
         './.github/release-tools/Build-AndroidBridgeJar.ps1',
         './.github/release-tools/Build-AndroidBridgeJar-disabled.ps1'

--- a/.github/release-tools/Test-ReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.ps1
@@ -50,6 +50,25 @@ function Assert-WorkflowRegex {
     }
 }
 
+function Get-WorkflowJobText {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Text,
+
+        [Parameter(Mandatory)]
+        [string] $JobName
+    )
+
+    $pattern = '(?ms)^  ' + [regex]::Escape($JobName) + ':\r?\n.*?(?=^  [A-Za-z0-9_-]+:\r?\n|\z)'
+    $match = [regex]::Match($Text, $pattern)
+    if (-not $match.Success) {
+        Add-WorkflowError "Workflow job '$JobName' was not found or could not be isolated."
+        return ''
+    }
+
+    return $match.Value
+}
+
 $errors = New-Object System.Collections.Generic.List[string]
 $workflowFile = Resolve-ReleasePath $WorkflowPath
 if (-not (Test-Path -LiteralPath $workflowFile -PathType Leaf)) {
@@ -258,7 +277,16 @@ $assemblyIndex = $workflowText.IndexOf('./.github/release-tools/Invoke-ReleaseAs
 if ($bridgeBuildIndex -lt 0 -or $androidPackageJavaIndex -le $bridgeBuildIndex -or $assemblyIndex -le $androidPackageJavaIndex) {
     Add-WorkflowError 'Exact Android bridge rebuild must run before release assembly.'
 }
-Assert-WorkflowContains -Text $workflowText -Expected 'dotnet build ./SDL3-CS/SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false' -Description 'assembly Wiki Release output build'
+$wikiReleaseBuildCommand = 'dotnet build ./SDL3-CS/SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false'
+Assert-WorkflowContains -Text $workflowText -Expected $wikiReleaseBuildCommand -Description 'assembly Wiki Release output build'
+$publishJobText = Get-WorkflowJobText -Text $workflowText -JobName 'publish'
+Assert-WorkflowContains -Text $publishJobText -Expected 'Build wrapper Release output for publish Wiki readiness' -Description 'publish Wiki Release output build step'
+Assert-WorkflowContains -Text $publishJobText -Expected $wikiReleaseBuildCommand -Description 'publish Wiki Release output build command'
+$publishWikiBuildIndex = $publishJobText.IndexOf($wikiReleaseBuildCommand, [System.StringComparison]::Ordinal)
+$publishEntryPointIndex = $publishJobText.IndexOf('./.github/release-tools/Publish-Release.ps1 @params', [System.StringComparison]::Ordinal)
+if ($publishWikiBuildIndex -lt 0 -or $publishEntryPointIndex -lt 0 -or $publishWikiBuildIndex -ge $publishEntryPointIndex) {
+    Add-WorkflowError 'Publish job must build wrapper Release output before invoking Publish-Release.ps1.'
+}
 Assert-WorkflowContains -Text $workflowText -Expected 'path: artifacts/release/nuget/*.nupkg' -Description 'NuGet artifact upload'
 Assert-WorkflowContains -Text $workflowText -Expected 'release-assembly-state.zip' -Description 'release assembly state artifact'
 Assert-WorkflowContains -Text $workflowText -Expected './.github/release-tools/Test-ReleaseAssemblyState.ps1' -Description 'release assembly state validation'

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -1001,6 +1001,10 @@ jobs:
             -PackageRevision ([int]'${{ inputs.package_revision }}') `
             -StatePath '.'
 
+      - name: Build wrapper Release output for publish Wiki readiness
+        shell: pwsh
+        run: dotnet build ./SDL3-CS/SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false
+
       - name: NuGet trusted publishing login
         if: ${{ inputs.publish_nuget }}
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1


### PR DESCRIPTION
## Summary

- build the wrapper Release output inside the fresh full-release publish job
- require that build in the publish job before `Publish-Release.ps1`
- add a scoped mutation regression so an assembly-job-only build cannot satisfy the contract

This fixes the fail-closed Wiki readiness blocker observed in production run 30943431363 before any GitHub Release, tag, or NuGet package was published.

Refs #246.

## Verification

- `pwsh -NoProfile -File ./.github/release-tools/Test-ReleaseWorkflow.Tests.ps1`
- `pwsh -NoProfile -File ./.github/release-tools/Test-ReleaseWorkflow.ps1`
- `pwsh -NoProfile -File ./.github/release-tools/Test-ReleasePublishPlan.ps1`
- `dotnet build ./SDL3-CS/SDL3-CS.csproj -c Release /p:GeneratePackageOnBuild=false`
- `pwsh -NoProfile -File ./.github/wiki-tools/Test-WikiTools.Tests.ps1`
- `pwsh -NoProfile -File ./.github/wiki-tools/Test-WikiReleaseContract.Tests.ps1`
- `actionlint ./.github/workflows/release-native-packages.yml`