### PR TITLE
Add scoped span overloads for GPU, TTF, and textures

### DIFF
--- a/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
@@ -58,6 +58,7 @@ internal static class PInvokeTests
     private static int capturedVPitch;
     private static int capturedUVPitch;
     private static int nextPitch;
+    private static int expectedByteCount;
     private static uint nextUInt;
     private static uint capturedProps;
     private static uint capturedEventType;
@@ -809,6 +810,34 @@ internal static class PInvokeTests
             TestAssert.Equal(8, capturedPitch, "SDL.UpdateTexture(Span, IntPtr) must forward pitch.");
         }
 
+        ResetCaptureState();
+        nextBool = false;
+        expectedByteCount = 3;
+        byte[] readOnlySource = [0xFF, 10, 20, 30, 0xEE];
+        ReadOnlySpan<byte> readOnlyPixels = readOnlySource.AsSpan(1, 3);
+        using (NativeHookScope _ = NativeHookScope.Install("UpdateTexturePointerNativeFunction", nameof(CaptureUpdateTextureReadOnlySpan)))
+        {
+            bool result = SDL3.SDL.UpdateTexture((IntPtr)0x2023, (IntPtr)0x2024, readOnlyPixels, 6);
+
+            TestAssert.Equal(false, result, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must return the native hook value.");
+            TestAssert.Equal((IntPtr)0x2023, capturedTexture, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must forward texture.");
+            TestAssert.Equal((IntPtr)0x2024, capturedRectPointer, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must forward rect pointer.");
+            TestAssert.True(capturedPixels != IntPtr.Zero, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must pin and forward pixels.");
+            AssertBytes([10, 20, 30], capturedBytes, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must forward the selected pixels.");
+            TestAssert.Equal(6, capturedPitch, "SDL.UpdateTexture(ReadOnlySpan, IntPtr) must forward pitch.");
+        }
+
+        ResetCaptureState();
+        nextBool = false;
+        using (NativeHookScope _ = NativeHookScope.Install("UpdateTexturePointerNativeFunction", nameof(CaptureUpdateTextureReadOnlySpan)))
+        {
+            bool result = SDL3.SDL.UpdateTexture((IntPtr)0x2025, (IntPtr)0x2026, ReadOnlySpan<byte>.Empty, 4);
+
+            TestAssert.Equal(false, result, "SDL.UpdateTexture(empty ReadOnlySpan, IntPtr) must return the native hook value.");
+            TestAssert.Equal(IntPtr.Zero, capturedPixels, "SDL.UpdateTexture(empty ReadOnlySpan, IntPtr) must forward a null pixel pointer.");
+            AssertBytes([], capturedBytes, "SDL.UpdateTexture(empty ReadOnlySpan, IntPtr) must forward no pixels.");
+        }
+
         SDL3.SDL.Rect rect = CreateRect(1, 2, 3, 4);
         ResetCaptureState();
         nextBool = true;
@@ -847,6 +876,23 @@ internal static class PInvokeTests
             AssertRect(rect, capturedRect, "SDL.UpdateTexture(in Rect, Span) must forward rect.");
             TestAssert.True(capturedPixels != IntPtr.Zero, "SDL.UpdateTexture(in Rect, Span) must pin and forward pixels.");
             TestAssert.Equal(12, capturedPitch, "SDL.UpdateTexture(in Rect, Span) must forward pitch.");
+        }
+
+        ResetCaptureState();
+        nextBool = true;
+        expectedByteCount = 3;
+        byte[] rectReadOnlySource = [0xFF, 40, 50, 60, 0xEE];
+        ReadOnlySpan<byte> rectReadOnlyPixels = rectReadOnlySource.AsSpan(1, 3);
+        using (NativeHookScope _ = NativeHookScope.Install("UpdateTextureRectPointerNativeFunction", nameof(CaptureUpdateTextureRectReadOnlySpan)))
+        {
+            bool result = SDL3.SDL.UpdateTexture((IntPtr)0x2052, in rect, rectReadOnlyPixels, 9);
+
+            TestAssert.Equal(true, result, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must return the native hook value.");
+            TestAssert.Equal((IntPtr)0x2052, capturedTexture, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must forward texture.");
+            AssertRect(rect, capturedRect, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must forward rect.");
+            TestAssert.True(capturedPixels != IntPtr.Zero, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must pin and forward pixels.");
+            AssertBytes([40, 50, 60], capturedBytes, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must forward the selected pixels.");
+            TestAssert.Equal(9, capturedPitch, "SDL.UpdateTexture(in Rect, ReadOnlySpan) must forward pitch.");
         }
     }
 
@@ -2773,6 +2819,16 @@ internal static class PInvokeTests
         return nextBool;
     }
 
+    private static bool CaptureUpdateTextureReadOnlySpan(IntPtr texture, IntPtr rect, IntPtr pixels, int pitch)
+    {
+        capturedTexture = texture;
+        capturedRectPointer = rect;
+        capturedPixels = pixels;
+        capturedBytes = CopyUnmanaged<byte>(pixels, expectedByteCount);
+        capturedPitch = pitch;
+        return nextBool;
+    }
+
     private static bool CaptureUpdateTextureArray(IntPtr texture, IntPtr rect, byte[] pixels, int pitch)
     {
         capturedTexture = texture;
@@ -2787,6 +2843,16 @@ internal static class PInvokeTests
         capturedTexture = texture;
         capturedRect = rect;
         capturedPixels = pixels;
+        capturedPitch = pitch;
+        return nextBool;
+    }
+
+    private static bool CaptureUpdateTextureRectReadOnlySpan(IntPtr texture, in SDL3.SDL.Rect rect, IntPtr pixels, int pitch)
+    {
+        capturedTexture = texture;
+        capturedRect = rect;
+        capturedPixels = pixels;
+        capturedBytes = CopyUnmanaged<byte>(pixels, expectedByteCount);
         capturedPitch = pitch;
         return nextBool;
     }
@@ -4263,6 +4329,7 @@ internal static class PInvokeTests
         capturedVPitch = 0;
         capturedUVPitch = 0;
         nextPitch = 0;
+        expectedByteCount = 0;
         nextUInt = 0;
         capturedProps = 0;
         capturedEventType = 0;

--- a/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/render/PInvoke.cs
@@ -2515,6 +2515,40 @@ internal static class PInvokeTests
 
         ResetCaptureState();
         nextBool = true;
+        byte[] uniformSource = [0xFF, 0x10, 0x20, 0x30, 0x40, 0xEE];
+        ReadOnlySpan<byte> uniformData = uniformSource.AsSpan(1, 4);
+        using (NativeHookScope _ = NativeHookScope.Install("SetGPURenderStateFragmentUniformsNativeFunction", nameof(CaptureSetGPURenderStateFragmentUniformSpan)))
+        {
+            bool result = SDL3.SDL.SetGPURenderStateFragmentUniforms((IntPtr)0xA083, 6u, uniformData);
+
+            TestAssert.Equal(true, result, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must return the native hook value.");
+            TestAssert.Equal((IntPtr)0xA083, capturedState, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must forward state.");
+            TestAssert.Equal(6u, capturedSlotIndex, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must forward slot index.");
+            TestAssert.True(capturedData != IntPtr.Zero, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must pin and forward data.");
+            TestAssert.Equal(4u, capturedLength, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must derive the byte length.");
+            AssertBytes([0x10, 0x20, 0x30, 0x40], capturedBytes, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must forward the selected bytes.");
+        }
+
+        ResetCaptureState();
+        using (NativeHookScope _ = NativeHookScope.Install("SetGPURenderStateFragmentUniformsNativeFunction", nameof(CaptureSetGPURenderStateFragmentUniformSpan)))
+        {
+            bool threw = false;
+            try
+            {
+                SDL3.SDL.SetGPURenderStateFragmentUniforms((IntPtr)0xA084, 7u, ReadOnlySpan<byte>.Empty);
+            }
+            catch (ArgumentException exception)
+            {
+                threw = true;
+                TestAssert.Equal("data", exception.ParamName, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must identify the empty data parameter.");
+            }
+
+            TestAssert.Equal(true, threw, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must reject empty data.");
+            TestAssert.Equal(IntPtr.Zero, capturedState, "SDL.SetGPURenderStateFragmentUniforms(ReadOnlySpan) must fail before invoking native code for empty data.");
+        }
+
+        ResetCaptureState();
+        nextBool = true;
         using (NativeHookScope _ = NativeHookScope.Install("SetGPURenderStateNativeFunction", nameof(CaptureSetGPURenderState)))
         {
             bool result = SDL3.SDL.SetGPURenderState((IntPtr)0xA091, (IntPtr)0xA092);
@@ -3748,6 +3782,18 @@ internal static class PInvokeTests
         capturedSlotIndex = slotIndex;
         capturedData = data;
         capturedLength = length;
+        return nextBool;
+    }
+
+    private static unsafe bool CaptureSetGPURenderStateFragmentUniformSpan(IntPtr state, uint slotIndex, IntPtr data, uint length)
+    {
+        capturedState = state;
+        capturedSlotIndex = slotIndex;
+        capturedData = data;
+        capturedLength = length;
+        capturedBytes = data == IntPtr.Zero
+            ? null
+            : new ReadOnlySpan<byte>((void*)data, checked((int)length)).ToArray();
         return nextBool;
     }
 

--- a/SDL3-CS.Tests/TTF/PInvoke.cs
+++ b/SDL3-CS.Tests/TTF/PInvoke.cs
@@ -90,6 +90,7 @@ internal static class PInvokeTests
     private static int capturedCallCount;
     private static string? capturedFile;
     private static string? capturedString;
+    private static byte[]? capturedBytes;
     private static SDL3.TTF.SubString capturedSubString;
     private static int capturedOffset;
     private static int capturedTextLength;
@@ -1309,6 +1310,44 @@ internal static class PInvokeTests
                     TestAssert.Equal(1, capturedCallCount, "TTF.GetStringSize byte pointer overload must call native hook once.");
                 }
             }
+        }
+
+        ResetCaptureState();
+        nextBool = false;
+        nextWidth = 52;
+        nextHeight = 13;
+        byte[] utf8Source = [0xFF, 0xE2, 0x82, 0xAC, 0xEE];
+        ReadOnlySpan<byte> utf8 = utf8Source.AsSpan(1, 3);
+        using (NativeHookScope _ = NativeHookScope.Install("GetStringSizeBytePointerNativeFunction", nameof(CaptureStringSizeBytePointer)))
+        {
+            bool actual = SDL3.TTF.GetStringSize((IntPtr)0x8017, utf8, out int w, out int h);
+
+            TestAssert.Equal(false, actual, "TTF.GetStringSize ReadOnlySpan overload must return native success value.");
+            TestAssert.Equal(52, w, "TTF.GetStringSize ReadOnlySpan overload must return native width.");
+            TestAssert.Equal(13, h, "TTF.GetStringSize ReadOnlySpan overload must return native height.");
+            TestAssert.Equal((IntPtr)0x8017, capturedFont, "TTF.GetStringSize ReadOnlySpan overload must forward font.");
+            TestAssert.True(capturedTextPointer != IntPtr.Zero, "TTF.GetStringSize ReadOnlySpan overload must pin and forward text.");
+            TestAssert.Equal((UIntPtr)3, capturedLength, "TTF.GetStringSize ReadOnlySpan overload must derive the byte length.");
+            AssertBytes([0xE2, 0x82, 0xAC], capturedBytes, "TTF.GetStringSize ReadOnlySpan overload must forward the selected UTF-8 bytes.");
+            TestAssert.Equal(1, capturedCallCount, "TTF.GetStringSize ReadOnlySpan overload must call native hook once.");
+        }
+
+        ResetCaptureState();
+        nextBool = true;
+        nextWidth = 0;
+        nextHeight = 21;
+        using (NativeHookScope _ = NativeHookScope.Install("GetStringSizeBytePointerNativeFunction", nameof(CaptureStringSizeBytePointer)))
+        {
+            bool actual = SDL3.TTF.GetStringSize((IntPtr)0x8018, ReadOnlySpan<byte>.Empty, out int w, out int h);
+
+            TestAssert.Equal(true, actual, "TTF.GetStringSize empty ReadOnlySpan overload must return native success value.");
+            TestAssert.Equal(0, w, "TTF.GetStringSize empty ReadOnlySpan overload must return native width.");
+            TestAssert.Equal(21, h, "TTF.GetStringSize empty ReadOnlySpan overload must return native height.");
+            TestAssert.Equal((IntPtr)0x8018, capturedFont, "TTF.GetStringSize empty ReadOnlySpan overload must forward font.");
+            TestAssert.True(capturedTextPointer != IntPtr.Zero, "TTF.GetStringSize empty ReadOnlySpan overload must pass a valid NUL sentinel pointer.");
+            TestAssert.Equal(UIntPtr.Zero, capturedLength, "TTF.GetStringSize empty ReadOnlySpan overload must pass zero length.");
+            AssertBytes([0], capturedBytes, "TTF.GetStringSize empty ReadOnlySpan overload must pass a NUL sentinel.");
+            TestAssert.Equal(1, capturedCallCount, "TTF.GetStringSize empty ReadOnlySpan overload must call native hook once.");
         }
 
         ResetCaptureState();
@@ -2573,6 +2612,9 @@ internal static class PInvokeTests
         capturedFont = font;
         capturedTextPointer = (IntPtr)text;
         capturedLength = length;
+        capturedBytes = text == null
+            ? null
+            : new ReadOnlySpan<byte>(text, length == UIntPtr.Zero ? 1 : checked((int)length.ToUInt64())).ToArray();
         w = nextWidth;
         h = nextHeight;
         capturedCallCount++;
@@ -3130,6 +3172,7 @@ internal static class PInvokeTests
         capturedCallCount = 0;
         capturedFile = null;
         capturedString = null;
+        capturedBytes = null;
         capturedSubString = default;
         capturedOffset = 0;
         capturedTextLength = 0;
@@ -3397,6 +3440,16 @@ internal static class PInvokeTests
         MarshalAsAttribute? marshalAs = method.GetParameters()[index].GetCustomAttribute<MarshalAsAttribute>();
         TestAssert.NotNull(marshalAs, $"TTF.{method.Name} parameter {index} must keep MarshalAs metadata.");
         TestAssert.Equal(expected, marshalAs!.Value, $"TTF.{method.Name} parameter {index} must keep expected MarshalAs value.");
+    }
+
+    private static void AssertBytes(byte[] expected, byte[]? actual, string message)
+    {
+        TestAssert.NotNull(actual, message);
+        TestAssert.Equal(expected.Length, actual!.Length, $"{message} Length.");
+        for (int i = 0; i < expected.Length; i++)
+        {
+            TestAssert.Equal(expected[i], actual[i], $"{message} [{i}].");
+        }
     }
 
     private static void AssertExcludedFromCoverage(MethodInfo method)

--- a/SDL3-CS.Tests/TTF/PInvoke.cs
+++ b/SDL3-CS.Tests/TTF/PInvoke.cs
@@ -1581,6 +1581,38 @@ internal static class PInvokeTests
         }
 
         ResetCaptureState();
+        nextPointer = (IntPtr)0x9123;
+        byte[] blendedSource = [0xFF, 66, 108, 101, 110, 100, 0xEE];
+        ReadOnlySpan<byte> blendedUtf8 = blendedSource.AsSpan(1, 5);
+        using (NativeHookScope _ = NativeHookScope.Install("RenderTextBlendedBytePointerNativeFunction", nameof(CaptureRenderTextBytePointer)))
+        {
+            IntPtr actual = SDL3.TTF.RenderTextBlended((IntPtr)0x9124, blendedUtf8, fg);
+
+            TestAssert.Equal((IntPtr)0x9123, actual, "TTF.RenderTextBlended ReadOnlySpan overload must return native surface.");
+            TestAssert.Equal((IntPtr)0x9124, capturedFont, "TTF.RenderTextBlended ReadOnlySpan overload must forward font.");
+            TestAssert.True(capturedTextPointer != IntPtr.Zero, "TTF.RenderTextBlended ReadOnlySpan overload must pin and forward text.");
+            TestAssert.Equal((UIntPtr)5, capturedLength, "TTF.RenderTextBlended ReadOnlySpan overload must derive the byte length.");
+            TestAssert.Equal(fg, capturedForeground, "TTF.RenderTextBlended ReadOnlySpan overload must forward foreground color.");
+            AssertBytes([66, 108, 101, 110, 100], capturedBytes, "TTF.RenderTextBlended ReadOnlySpan overload must forward the selected UTF-8 bytes.");
+            TestAssert.Equal(1, capturedCallCount, "TTF.RenderTextBlended ReadOnlySpan overload must call native hook once.");
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x9125;
+        using (NativeHookScope _ = NativeHookScope.Install("RenderTextBlendedBytePointerNativeFunction", nameof(CaptureRenderTextBytePointer)))
+        {
+            IntPtr actual = SDL3.TTF.RenderTextBlended((IntPtr)0x9126, ReadOnlySpan<byte>.Empty, fg);
+
+            TestAssert.Equal((IntPtr)0x9125, actual, "TTF.RenderTextBlended empty ReadOnlySpan overload must return native surface.");
+            TestAssert.Equal((IntPtr)0x9126, capturedFont, "TTF.RenderTextBlended empty ReadOnlySpan overload must forward font.");
+            TestAssert.True(capturedTextPointer != IntPtr.Zero, "TTF.RenderTextBlended empty ReadOnlySpan overload must pass a valid NUL sentinel pointer.");
+            TestAssert.Equal(UIntPtr.Zero, capturedLength, "TTF.RenderTextBlended empty ReadOnlySpan overload must pass zero length.");
+            TestAssert.Equal(fg, capturedForeground, "TTF.RenderTextBlended empty ReadOnlySpan overload must forward foreground color.");
+            AssertBytes([0], capturedBytes, "TTF.RenderTextBlended empty ReadOnlySpan overload must pass a NUL sentinel.");
+            TestAssert.Equal(1, capturedCallCount, "TTF.RenderTextBlended empty ReadOnlySpan overload must call native hook once.");
+        }
+
+        ResetCaptureState();
         nextPointer = (IntPtr)0x9025;
         using (NativeHookScope _ = NativeHookScope.Install("RenderTextBlendedWrappedNativeFunction", nameof(CaptureRenderTextWrapped)))
         {
@@ -2681,6 +2713,9 @@ internal static class PInvokeTests
         capturedFont = font;
         capturedTextPointer = (IntPtr)text;
         capturedLength = length;
+        capturedBytes = text == null
+            ? null
+            : new ReadOnlySpan<byte>(text, length == UIntPtr.Zero ? 1 : checked((int)length.ToUInt64())).ToArray();
         capturedForeground = fg;
         capturedCallCount++;
         return nextPointer;

--- a/SDL3-CS/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/render/PInvoke.cs
@@ -1392,6 +1392,15 @@ public static partial class SDL
         }
     }
 
+    /// <inheritdoc cref="UpdateTexture(IntPtr, IntPtr, byte[], int)"/>
+    public static unsafe bool UpdateTexture(IntPtr texture, IntPtr rect, ReadOnlySpan<byte> pixels, int pitch)
+    {
+        fixed (byte* p = pixels)
+        {
+            return UpdateTexture(texture, rect, (nint)p, pitch);
+        }
+    }
+
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_UpdateTexture"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1498,6 +1507,15 @@ public static partial class SDL
     /// <seealso cref="UpdateNVTexture(IntPtr, IntPtr, IntPtr, int, IntPtr, int)"/>
     /// <seealso cref="UpdateYUVTexture(IntPtr, IntPtr, IntPtr, int, IntPtr, int, IntPtr, int)"/>
     public static unsafe bool UpdateTexture(IntPtr texture, in Rect rect, Span<byte> pixels, int pitch)
+    {
+        fixed (byte* p = pixels)
+        {
+            return UpdateTexture(texture, rect, (nint)p, pitch);
+        }
+    }
+
+    /// <inheritdoc cref="UpdateTexture(IntPtr, in Rect, byte[], int)"/>
+    public static unsafe bool UpdateTexture(IntPtr texture, in Rect rect, ReadOnlySpan<byte> pixels, int pitch)
     {
         fixed (byte* p = pixels)
         {

--- a/SDL3-CS/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/render/PInvoke.cs
@@ -5474,7 +5474,7 @@ public static partial class SDL
     /// <threadsafety>This function should be called on the thread that created the
     /// renderer.</threadsafety>
     /// <since>This function is available since SDL 3.4.0.</since>
-    /// <seealso cref="SetGPURenderStateFragmentUniforms"/>
+    /// <seealso cref="SetGPURenderStateFragmentUniforms(IntPtr, uint, IntPtr, uint)"/>
     /// <seealso cref="SetGPURenderState"/>
     /// <seealso cref="DestroyGPURenderState"/>
     public static IntPtr CreateGPURenderState(IntPtr renderer, IntPtr createinfo)
@@ -5519,6 +5519,36 @@ public static partial class SDL
     public static bool SetGPURenderStateFragmentUniforms(IntPtr state, uint slotIndex, IntPtr data, uint length)
     {
         return SetGPURenderStateFragmentUniformsNativeFunction(state, slotIndex, data, length);
+    }
+
+    /// <code>extern SDL_DECLSPEC bool SDLCALL SDL_SetGPURenderStateFragmentUniforms(SDL_GPURenderState *state, Uint32 slot_index, const void *data, Uint32 length);</code>
+    /// <summary>
+    /// <para>Set fragment shader uniform variables in a custom GPU render state.</para>
+    /// <para>The data is copied and will be pushed using
+    /// <see cref="PushGPUFragmentUniformData(nint, uint, byte[], uint)"/> during draw call execution.</para>
+    /// <para>The byte length is derived from <paramref name="data"/>.</para>
+    /// </summary>
+    /// <param name="state">the state to modify.</param>
+    /// <param name="slotIndex">the fragment uniform slot to push data to.</param>
+    /// <param name="data">client data to write.</param>
+    /// <returns><c>true</c> on success or <c>false</c> on failure; call <see cref="GetError"/> for more
+    /// information.</returns>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <threadsafety>This function should be called on the thread that created the
+    /// renderer.</threadsafety>
+    /// <since>This function is available since SDL 3.4.0</since>
+    /// <seealso cref="SetGPURenderStateFragmentUniforms(IntPtr, uint, IntPtr, uint)"/>
+    public static unsafe bool SetGPURenderStateFragmentUniforms(IntPtr state, uint slotIndex, ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            throw new ArgumentException("Fragment uniform data must not be empty.", nameof(data));
+        }
+
+        fixed (byte* dataPointer = data)
+        {
+            return SetGPURenderStateFragmentUniforms(state, slotIndex, (IntPtr)dataPointer, (uint)data.Length);
+        }
     }
 
 

--- a/SDL3-CS/TTF/PInvoke.cs
+++ b/SDL3-CS/TTF/PInvoke.cs
@@ -1506,6 +1506,37 @@ public static partial class TTF
         return GetStringSizeBytePointerNativeFunction(font, text, length, out w, out h);
     }
 
+    /// <code>extern SDL_DECLSPEC bool SDLCALL TTF_GetStringSize(TTF_Font *font, const char *text, size_t length, int *w, int *h);</code>
+    /// <summary>
+    /// <para>Calculate the dimensions of a rendered string of UTF-8 text.</para>
+    /// <para>This will report the width and height, in pixels, of the space that the
+    /// specified string will take to fully render.</para>
+    /// <para>The byte length is derived from <paramref name="utf8"/>. An empty span is
+    /// passed as a valid NUL-terminated empty string.</para>
+    /// </summary>
+    /// <param name="font">the font to query.</param>
+    /// <param name="utf8">text to calculate, in UTF-8 encoding.</param>
+    /// <param name="w">will be filled with width, in pixels, on return.</param>
+    /// <param name="h">will be filled with height, in pixels, on return.</param>
+    /// <returns><c>true</c> on success or <c>false</c> on failure; call <see cref="SDL.GetError"/> for more
+    /// information.</returns>
+    /// <threadsafety>This function should be called on the thread that created the
+    /// font.</threadsafety>
+    /// <since>This function is available since SDL_ttf 3.0.0.</since>
+    public static unsafe bool GetStringSize(IntPtr font, ReadOnlySpan<byte> utf8, out int w, out int h)
+    {
+        if (utf8.IsEmpty)
+        {
+            byte terminator = 0;
+            return GetStringSize(font, &terminator, UIntPtr.Zero, out w, out h);
+        }
+
+        fixed (byte* text = utf8)
+        {
+            return GetStringSize(font, text, (UIntPtr)utf8.Length, out w, out h);
+        }
+    }
+
     [ExcludeFromCodeCoverage]
     [LibraryImport(FontLibrary, EntryPoint = "TTF_GetStringSize"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]

--- a/SDL3-CS/TTF/PInvoke.cs
+++ b/SDL3-CS/TTF/PInvoke.cs
@@ -2056,6 +2056,47 @@ public static partial class TTF
         return RenderTextBlendedBytePointerNativeFunction(font, text, length, fg);
     }
 
+    /// <code>extern SDL_DECLSPEC SDL_Surface * SDLCALL TTF_RenderText_Blended(TTF_Font *font, const char *text, size_t length, SDL_Color fg);</code>
+    /// <summary>
+    /// <para>Render UTF-8 text at high quality to a new ARGB surface.</para>
+    /// <para>This function will allocate a new 32-bit, ARGB surface, using alpha
+    /// blending to dither the font with the given color. This function returns the
+    /// new surface, or <c>null</c> if there was an error.</para>
+    /// <para>This will not word-wrap the string; you'll get a surface with a single line
+    /// of text, as long as the string requires. You can use
+    /// <see cref="RenderTextBlendedWrapped"/> instead if you need to wrap the output to
+    /// multiple lines.</para>
+    /// <para>This will not wrap on newline characters.</para>
+    /// <para>You can render at other quality levels with <see cref="RenderTextSolid(IntPtr, string, UIntPtr, SDL.Color)"/>,
+    /// <see cref="RenderTextShaded"/>, and <see cref="RenderTextLCD"/>.</para>
+    /// <para>The byte length is derived from <paramref name="utf8"/>. An empty span is
+    /// passed as a valid NUL-terminated empty string.</para>
+    /// </summary>
+    /// <param name="font">the font to render with.</param>
+    /// <param name="utf8">text to render, in UTF-8 encoding.</param>
+    /// <param name="fg">the foreground color for the text.</param>
+    /// <returns>a new 32-bit, ARGB surface, or <c>null</c> if there was an error.</returns>
+    /// <threadsafety>This function should be called on the thread that created the
+    /// font.</threadsafety>
+    /// <since>This function is available since SDL_ttf 3.0.0.</since>
+    /// <seealso cref="RenderTextBlendedWrapped"/>
+    /// <seealso cref="RenderTextLCD"/>
+    /// <seealso cref="RenderTextShaded"/>
+    /// <seealso cref="RenderTextSolid(IntPtr, string, UIntPtr, SDL.Color)"/>
+    public static unsafe IntPtr RenderTextBlended(IntPtr font, ReadOnlySpan<byte> utf8, SDL.Color fg)
+    {
+        if (utf8.IsEmpty)
+        {
+            byte terminator = 0;
+            return RenderTextBlended(font, &terminator, UIntPtr.Zero, fg);
+        }
+
+        fixed (byte* text = utf8)
+        {
+            return RenderTextBlended(font, text, (UIntPtr)utf8.Length, fg);
+        }
+    }
+
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(FontLibrary, EntryPoint = "TTF_RenderText_Blended_Wrapped"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]


### PR DESCRIPTION
## Summary

- add a scoped `ReadOnlySpan<byte>` overload for GPU render-state fragment uniforms
- add UTF-8 span overloads for TTF string sizing and blended text rendering
- add read-only span counterparts for both `UpdateTexture` rectangle forms
- preserve all existing pointer, array, and mutable-span overloads

Refs #249.
Refs #250.
Refs #251.
Refs #252.

## Verification

- managed test project Release build
- focused mirrored binding tests
- full `SDL3-CS.Tests` runner
- public wrapper XML documentation audit
- 100% line and branch coverage for the five new wrapper methods
