### PR TITLE
Add scoped GPU creation overloads

### DIFF
--- a/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
@@ -135,6 +135,7 @@ internal static class PInvokeTests
         CreateGPUSampler_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUShader_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUShaderSpan_OverridesScopedInputsAndPreservesTemplate();
+        CreateGPUShaderSpan_UnwindsPinsWhenNativeHookThrows();
         CreateGPUTexture_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUBuffer_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUTransferBuffer_ForwardsCreateInfoAndReturnsNativePointer();
@@ -742,6 +743,39 @@ internal static class PInvokeTests
 
         TestAssert.True(threw, "SDL.CreateGPUShader span overload must reject a null entrypoint with the correct parameter name.");
         TestAssert.Equal(0, capturedCallCount, "SDL.CreateGPUShader span overload must reject a null entrypoint before the native call.");
+    }
+
+    public static void CreateGPUShaderSpan_UnwindsPinsWhenNativeHookThrows()
+    {
+        byte[] code = [0x03, 0x02, 0x23, 0x07];
+        SDL3.SDL.GPUShaderCreateInfo createInfo = new()
+        {
+            Format = SDL3.SDL.GPUShaderFormat.SPIRV,
+            Stage = SDL3.SDL.GPUShaderStage.Vertex
+        };
+
+        using (NativeHookScope hookScope = NativeHookScope.Install("CreateGPUShaderNativeFunction", nameof(ThrowCreateGPUShader)))
+        {
+            try
+            {
+                _ = SDL3.SDL.CreateGPUShader(IntPtr.Zero, in createInfo, code, "main");
+                throw new InvalidOperationException("SDL.CreateGPUShader span overload must propagate native hook exceptions.");
+            }
+            catch (InvalidOperationException exception)
+            {
+                TestAssert.Equal("create shader hook failure", exception.Message, "SDL.CreateGPUShader span overload must preserve hook exceptions while unwinding pins.");
+            }
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)1416;
+        using (NativeHookScope hookScope = NativeHookScope.Install("CreateGPUShaderNativeFunction", nameof(CaptureCreateGPUShader)))
+        {
+            IntPtr result = SDL3.SDL.CreateGPUShader(IntPtr.Zero, in createInfo, code, "main_after_exception");
+            TestAssert.Equal((IntPtr)1416, result, "SDL.CreateGPUShader span overload must remain usable after exception unwinding.");
+            TestAssert.Equal("main_after_exception", capturedShaderEntrypoint, "SDL.CreateGPUShader span overload must re-pin a later entrypoint after exception unwinding.");
+            TestAssert.Equal(4, capturedShaderCode!.Length, "SDL.CreateGPUShader span overload must re-pin later code after exception unwinding.");
+        }
     }
 
     public static void CreateGPUTexture_ForwardsCreateInfoAndReturnsNativePointer()
@@ -2651,6 +2685,11 @@ internal static class PInvokeTests
         capturedShaderEntrypoint = Marshal.PtrToStringUTF8(createinfo._entrypoint);
         capturedCallCount++;
         return nextPointer;
+    }
+
+    private static IntPtr ThrowCreateGPUShader(IntPtr device, in SDL3.SDL.GPUShaderCreateInfo createinfo)
+    {
+        throw new InvalidOperationException("create shader hook failure");
     }
 
     private static IntPtr CaptureCreateGPUTexture(IntPtr device, in SDL3.SDL.GPUTextureCreateInfo createinfo)

--- a/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
@@ -97,6 +97,9 @@ internal static class PInvokeTests
     private static string? capturedText;
     private static SDL3.SDL.GPUComputePipelineCreateInfo capturedComputePipelineInfo;
     private static SDL3.SDL.GPUGraphicsPipelineCreateInfo capturedGraphicsPipelineInfo;
+    private static SDL3.SDL.GPUVertexBufferDescription[]? capturedVertexBufferDescriptions;
+    private static SDL3.SDL.GPUVertexAttribute[]? capturedVertexAttributes;
+    private static SDL3.SDL.GPUColorTargetDescription[]? capturedColorTargetDescriptions;
     private static SDL3.SDL.GPUSamplerCreateInfo capturedSamplerInfo;
     private static SDL3.SDL.GPUShaderCreateInfo capturedShaderInfo;
     private static byte[]? capturedShaderCode;
@@ -128,6 +131,7 @@ internal static class PInvokeTests
         GetGPUDeviceProperties_ForwardsDeviceAndReturnsNativeValue();
         CreateGPUComputePipeline_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUGraphicsPipeline_ForwardsCreateInfoAndReturnsNativePointer();
+        CreateGPUGraphicsPipelineSpans_OverrideNestedArraysAndPreserveTemplate();
         CreateGPUSampler_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUShader_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUShaderSpan_OverridesScopedInputsAndPreservesTemplate();
@@ -544,6 +548,100 @@ internal static class PInvokeTests
         TestAssert.Equal((IntPtr)1402, result, "SDL.CreateGPUGraphicsPipeline must return native pipeline pointer.");
         TestAssert.Equal((IntPtr)1304, capturedDevice, "SDL.CreateGPUGraphicsPipeline must forward device.");
         TestAssert.Equal((IntPtr)1, capturedGraphicsPipelineInfo.VertexShader, "SDL.CreateGPUGraphicsPipeline must forward createinfo.");
+    }
+
+    public static void CreateGPUGraphicsPipelineSpans_OverrideNestedArraysAndPreserveTemplate()
+    {
+        ResetCaptureState();
+        nextPointer = (IntPtr)1412;
+        using NativeHookScope hookScope = NativeHookScope.Install("CreateGPUGraphicsPipelineNativeFunction", nameof(CaptureCreateGPUGraphicsPipeline));
+        SDL3.SDL.GPUVertexBufferDescription[] vertexBufferBacking =
+        [
+            new() { Slot = 99, Pitch = 999 },
+            new() { Slot = 2, Pitch = 16, InputRate = SDL3.SDL.GPUVertexInputRate.Vertex },
+            new() { Slot = 98, Pitch = 998 }
+        ];
+        SDL3.SDL.GPUVertexAttribute[] vertexAttributeBacking =
+        [
+            new() { Location = 99 },
+            new() { Location = 3, BufferSlot = 2, Format = SDL3.SDL.GPUVertexElementFormat.Float2, Offset = 4 },
+            new() { Location = 4, BufferSlot = 2, Format = SDL3.SDL.GPUVertexElementFormat.Float4, Offset = 12 },
+            new() { Location = 98 }
+        ];
+        SDL3.SDL.GPUColorTargetDescription[] colorTargetBacking =
+        [
+            new() { Format = SDL3.SDL.GPUTextureFormat.R8G8B8A8Unorm },
+            new() { Format = SDL3.SDL.GPUTextureFormat.B8G8R8A8Unorm },
+            new() { Format = SDL3.SDL.GPUTextureFormat.R8Unorm }
+        ];
+        ReadOnlySpan<SDL3.SDL.GPUVertexBufferDescription> vertexBuffers = vertexBufferBacking.AsSpan(1, 1);
+        ReadOnlySpan<SDL3.SDL.GPUVertexAttribute> vertexAttributes = vertexAttributeBacking.AsSpan(1, 2);
+        ReadOnlySpan<SDL3.SDL.GPUColorTargetDescription> colorTargets = colorTargetBacking.AsSpan(1, 1);
+        SDL3.SDL.GPUGraphicsPipelineCreateInfo createInfo = new()
+        {
+            VertexShader = (IntPtr)0x5201,
+            FragmentShader = (IntPtr)0x5202,
+            VertexInputState = new()
+            {
+                VertexBufferDescriptions = (IntPtr)0x5203,
+                NumVertexBuffers = 91,
+                VertexAttributes = (IntPtr)0x5204,
+                NumVertexAttributes = 92
+            },
+            TargetInfo = new()
+            {
+                ColorTargetDescriptions = (IntPtr)0x5205,
+                NumColorTargets = 93
+            },
+            Props = 48
+        };
+
+        IntPtr result = SDL3.SDL.CreateGPUGraphicsPipeline(
+            (IntPtr)1314,
+            in createInfo,
+            vertexBuffers,
+            vertexAttributes,
+            colorTargets);
+
+        TestAssert.Equal((IntPtr)1412, result, "SDL.CreateGPUGraphicsPipeline span overload must return native pipeline pointer.");
+        TestAssert.Equal((IntPtr)1314, capturedDevice, "SDL.CreateGPUGraphicsPipeline span overload must forward device.");
+        TestAssert.Equal(1u, capturedGraphicsPipelineInfo.VertexInputState.NumVertexBuffers, "SDL.CreateGPUGraphicsPipeline span overload must derive vertex-buffer count.");
+        TestAssert.Equal(2u, capturedGraphicsPipelineInfo.VertexInputState.NumVertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must derive vertex-attribute count.");
+        TestAssert.Equal(1u, capturedGraphicsPipelineInfo.TargetInfo.NumColorTargets, "SDL.CreateGPUGraphicsPipeline span overload must derive color-target count.");
+        TestAssert.NotNull(capturedVertexBufferDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must expose vertex buffers during the native call.");
+        TestAssert.NotNull(capturedVertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must expose vertex attributes during the native call.");
+        TestAssert.NotNull(capturedColorTargetDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must expose color targets during the native call.");
+        TestAssert.Equal(2u, capturedVertexBufferDescriptions![0].Slot, "SDL.CreateGPUGraphicsPipeline span overload must forward the selected vertex-buffer slice.");
+        TestAssert.Equal(3u, capturedVertexAttributes![0].Location, "SDL.CreateGPUGraphicsPipeline span overload must forward vertex-attribute item 0.");
+        TestAssert.Equal(4u, capturedVertexAttributes[1].Location, "SDL.CreateGPUGraphicsPipeline span overload must forward vertex-attribute item 1.");
+        TestAssert.Equal(SDL3.SDL.GPUTextureFormat.B8G8R8A8Unorm, capturedColorTargetDescriptions![0].Format, "SDL.CreateGPUGraphicsPipeline span overload must forward the selected color-target slice.");
+        TestAssert.Equal((IntPtr)0x5201, capturedGraphicsPipelineInfo.VertexShader, "SDL.CreateGPUGraphicsPipeline span overload must preserve other template fields.");
+        TestAssert.Equal((IntPtr)0x5203, createInfo.VertexInputState.VertexBufferDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template vertex-buffer pointer.");
+        TestAssert.Equal(91u, createInfo.VertexInputState.NumVertexBuffers, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template vertex-buffer count.");
+        TestAssert.Equal((IntPtr)0x5204, createInfo.VertexInputState.VertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template vertex-attribute pointer.");
+        TestAssert.Equal(92u, createInfo.VertexInputState.NumVertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template vertex-attribute count.");
+        TestAssert.Equal((IntPtr)0x5205, createInfo.TargetInfo.ColorTargetDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template color-target pointer.");
+        TestAssert.Equal(93u, createInfo.TargetInfo.NumColorTargets, "SDL.CreateGPUGraphicsPipeline span overload must not mutate template color-target count.");
+        TestAssert.Equal(1, capturedCallCount, "SDL.CreateGPUGraphicsPipeline span overload must call native hook once.");
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)1413;
+
+        result = SDL3.SDL.CreateGPUGraphicsPipeline(
+            (IntPtr)1315,
+            in createInfo,
+            ReadOnlySpan<SDL3.SDL.GPUVertexBufferDescription>.Empty,
+            ReadOnlySpan<SDL3.SDL.GPUVertexAttribute>.Empty,
+            ReadOnlySpan<SDL3.SDL.GPUColorTargetDescription>.Empty);
+
+        TestAssert.Equal((IntPtr)1413, result, "SDL.CreateGPUGraphicsPipeline span overload must return native result for empty spans.");
+        TestAssert.Equal(IntPtr.Zero, capturedGraphicsPipelineInfo.VertexInputState.VertexBufferDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must pass null for empty vertex buffers.");
+        TestAssert.Equal(0u, capturedGraphicsPipelineInfo.VertexInputState.NumVertexBuffers, "SDL.CreateGPUGraphicsPipeline span overload must pass zero vertex-buffer count.");
+        TestAssert.Equal(IntPtr.Zero, capturedGraphicsPipelineInfo.VertexInputState.VertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must pass null for empty vertex attributes.");
+        TestAssert.Equal(0u, capturedGraphicsPipelineInfo.VertexInputState.NumVertexAttributes, "SDL.CreateGPUGraphicsPipeline span overload must pass zero vertex-attribute count.");
+        TestAssert.Equal(IntPtr.Zero, capturedGraphicsPipelineInfo.TargetInfo.ColorTargetDescriptions, "SDL.CreateGPUGraphicsPipeline span overload must pass null for empty color targets.");
+        TestAssert.Equal(0u, capturedGraphicsPipelineInfo.TargetInfo.NumColorTargets, "SDL.CreateGPUGraphicsPipeline span overload must pass zero color-target count.");
+        TestAssert.Equal(1, capturedCallCount, "SDL.CreateGPUGraphicsPipeline span overload must call native hook once for empty spans.");
     }
 
     public static void CreateGPUSampler_ForwardsCreateInfoAndReturnsNativePointer()
@@ -2415,6 +2513,9 @@ internal static class PInvokeTests
         capturedText = null;
         capturedComputePipelineInfo = default;
         capturedGraphicsPipelineInfo = default;
+        capturedVertexBufferDescriptions = null;
+        capturedVertexAttributes = null;
+        capturedColorTargetDescriptions = null;
         capturedSamplerInfo = default;
         capturedShaderInfo = default;
         capturedShaderCode = null;
@@ -2513,6 +2614,21 @@ internal static class PInvokeTests
     {
         capturedDevice = device;
         capturedGraphicsPipelineInfo = createinfo;
+        capturedVertexBufferDescriptions = createinfo.VertexInputState.VertexBufferDescriptions == IntPtr.Zero
+            ? []
+            : CopyUnmanaged<SDL3.SDL.GPUVertexBufferDescription>(
+                createinfo.VertexInputState.VertexBufferDescriptions,
+                checked((int)createinfo.VertexInputState.NumVertexBuffers));
+        capturedVertexAttributes = createinfo.VertexInputState.VertexAttributes == IntPtr.Zero
+            ? []
+            : CopyUnmanaged<SDL3.SDL.GPUVertexAttribute>(
+                createinfo.VertexInputState.VertexAttributes,
+                checked((int)createinfo.VertexInputState.NumVertexAttributes));
+        capturedColorTargetDescriptions = createinfo.TargetInfo.ColorTargetDescriptions == IntPtr.Zero
+            ? []
+            : CopyUnmanaged<SDL3.SDL.GPUColorTargetDescription>(
+                createinfo.TargetInfo.ColorTargetDescriptions,
+                checked((int)createinfo.TargetInfo.NumColorTargets));
         capturedCallCount++;
         return nextPointer;
     }

--- a/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/GPU/gpu/PInvoke.cs
@@ -99,6 +99,8 @@ internal static class PInvokeTests
     private static SDL3.SDL.GPUGraphicsPipelineCreateInfo capturedGraphicsPipelineInfo;
     private static SDL3.SDL.GPUSamplerCreateInfo capturedSamplerInfo;
     private static SDL3.SDL.GPUShaderCreateInfo capturedShaderInfo;
+    private static byte[]? capturedShaderCode;
+    private static string? capturedShaderEntrypoint;
     private static SDL3.SDL.GPUTextureCreateInfo capturedTextureInfo;
     private static SDL3.SDL.GPUBufferCreateInfo capturedBufferInfo;
     private static SDL3.SDL.GPUTransferBufferCreateInfo capturedTransferBufferInfo;
@@ -128,6 +130,7 @@ internal static class PInvokeTests
         CreateGPUGraphicsPipeline_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUSampler_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUShader_ForwardsCreateInfoAndReturnsNativePointer();
+        CreateGPUShaderSpan_OverridesScopedInputsAndPreservesTemplate();
         CreateGPUTexture_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUBuffer_ForwardsCreateInfoAndReturnsNativePointer();
         CreateGPUTransferBuffer_ForwardsCreateInfoAndReturnsNativePointer();
@@ -577,6 +580,70 @@ internal static class PInvokeTests
         TestAssert.Equal((IntPtr)1404, result, "SDL.CreateGPUShader must return native shader pointer.");
         TestAssert.Equal((IntPtr)1306, capturedDevice, "SDL.CreateGPUShader must forward device.");
         TestAssert.Equal(5u, capturedShaderInfo.NumUniformBuffers, "SDL.CreateGPUShader must forward createinfo.");
+    }
+
+    public static void CreateGPUShaderSpan_OverridesScopedInputsAndPreservesTemplate()
+    {
+        ResetCaptureState();
+        nextPointer = (IntPtr)1414;
+        using NativeHookScope hookScope = NativeHookScope.Install("CreateGPUShaderNativeFunction", nameof(CaptureCreateGPUShader));
+        byte[] backingCode = [0xFF, 0x03, 0x02, 0x23, 0x07, 0xEE];
+        ReadOnlySpan<byte> code = backingCode.AsSpan(1, 4);
+        SDL3.SDL.GPUShaderCreateInfo createInfo = new()
+        {
+            Code = (IntPtr)0x5101,
+            CodeSize = (UIntPtr)99,
+            _entrypoint = (IntPtr)0x5102,
+            Format = SDL3.SDL.GPUShaderFormat.SPIRV,
+            Stage = SDL3.SDL.GPUShaderStage.Vertex,
+            NumUniformBuffers = 3,
+            Props = 47
+        };
+
+        IntPtr result = SDL3.SDL.CreateGPUShader((IntPtr)1306, in createInfo, code, "māin_着");
+
+        TestAssert.Equal((IntPtr)1414, result, "SDL.CreateGPUShader span overload must return native shader pointer.");
+        TestAssert.Equal((IntPtr)1306, capturedDevice, "SDL.CreateGPUShader span overload must forward device.");
+        TestAssert.Equal((UIntPtr)4, capturedShaderInfo.CodeSize, "SDL.CreateGPUShader span overload must derive code size.");
+        TestAssert.True(capturedShaderInfo.Code != IntPtr.Zero, "SDL.CreateGPUShader span overload must pin non-empty code.");
+        TestAssert.NotNull(capturedShaderCode, "SDL.CreateGPUShader span overload must expose code during the native call.");
+        TestAssert.Equal(4, capturedShaderCode!.Length, "SDL.CreateGPUShader span overload must forward the selected span length.");
+        TestAssert.Equal((byte)0x03, capturedShaderCode[0], "SDL.CreateGPUShader span overload must forward span item 0.");
+        TestAssert.Equal((byte)0x07, capturedShaderCode[3], "SDL.CreateGPUShader span overload must forward span item 3.");
+        TestAssert.Equal("māin_着", capturedShaderEntrypoint, "SDL.CreateGPUShader span overload must forward a null-terminated UTF-8 entrypoint.");
+        TestAssert.Equal(SDL3.SDL.GPUShaderFormat.SPIRV, capturedShaderInfo.Format, "SDL.CreateGPUShader span overload must preserve template format.");
+        TestAssert.Equal(3u, capturedShaderInfo.NumUniformBuffers, "SDL.CreateGPUShader span overload must preserve template resource counts.");
+        TestAssert.Equal((IntPtr)0x5101, createInfo.Code, "SDL.CreateGPUShader span overload must not mutate template code.");
+        TestAssert.Equal((UIntPtr)99, createInfo.CodeSize, "SDL.CreateGPUShader span overload must not mutate template code size.");
+        TestAssert.Equal((IntPtr)0x5102, createInfo._entrypoint, "SDL.CreateGPUShader span overload must not mutate template entrypoint.");
+        TestAssert.Equal(1, capturedCallCount, "SDL.CreateGPUShader span overload must call native hook once.");
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)1415;
+
+        result = SDL3.SDL.CreateGPUShader((IntPtr)1307, in createInfo, ReadOnlySpan<byte>.Empty, "main");
+
+        TestAssert.Equal((IntPtr)1415, result, "SDL.CreateGPUShader span overload must return native result for empty code.");
+        TestAssert.Equal(IntPtr.Zero, capturedShaderInfo.Code, "SDL.CreateGPUShader span overload must pass a null pointer for empty code.");
+        TestAssert.Equal(UIntPtr.Zero, capturedShaderInfo.CodeSize, "SDL.CreateGPUShader span overload must pass zero size for empty code.");
+        TestAssert.NotNull(capturedShaderCode, "SDL.CreateGPUShader span overload must capture an empty code buffer.");
+        TestAssert.Equal(0, capturedShaderCode!.Length, "SDL.CreateGPUShader span overload must forward empty code.");
+        TestAssert.Equal("main", capturedShaderEntrypoint, "SDL.CreateGPUShader span overload must keep entrypoint valid for empty code.");
+        TestAssert.Equal(1, capturedCallCount, "SDL.CreateGPUShader span overload must call native hook once for empty code.");
+
+        ResetCaptureState();
+        bool threw = false;
+        try
+        {
+            _ = SDL3.SDL.CreateGPUShader((IntPtr)1308, in createInfo, code, null!);
+        }
+        catch (ArgumentNullException exception)
+        {
+            threw = exception.ParamName == "entrypoint";
+        }
+
+        TestAssert.True(threw, "SDL.CreateGPUShader span overload must reject a null entrypoint with the correct parameter name.");
+        TestAssert.Equal(0, capturedCallCount, "SDL.CreateGPUShader span overload must reject a null entrypoint before the native call.");
     }
 
     public static void CreateGPUTexture_ForwardsCreateInfoAndReturnsNativePointer()
@@ -2350,6 +2417,8 @@ internal static class PInvokeTests
         capturedGraphicsPipelineInfo = default;
         capturedSamplerInfo = default;
         capturedShaderInfo = default;
+        capturedShaderCode = null;
+        capturedShaderEntrypoint = null;
         capturedTextureInfo = default;
         capturedBufferInfo = default;
         capturedTransferBufferInfo = default;
@@ -2460,6 +2529,10 @@ internal static class PInvokeTests
     {
         capturedDevice = device;
         capturedShaderInfo = createinfo;
+        capturedShaderCode = createinfo.Code == IntPtr.Zero || createinfo.CodeSize == UIntPtr.Zero
+            ? []
+            : CopyUnmanaged<byte>(createinfo.Code, checked((int)createinfo.CodeSize.ToUInt64()));
+        capturedShaderEntrypoint = Marshal.PtrToStringUTF8(createinfo._entrypoint);
         capturedCallCount++;
         return nextPointer;
     }

--- a/SDL3-CS/SDL/GPU/gpu/GPUBlendFactor.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUBlendFactor.cs
@@ -32,7 +32,7 @@ public static partial class SDL
     /// destination color is the value currently existing in the texture.</para>
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUBlendFactor
     {
         Invalid,

--- a/SDL3-CS/SDL/GPU/gpu/GPUBlendOp.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUBlendOp.cs
@@ -32,7 +32,7 @@ public static partial class SDL
     /// destination color is the value currently existing in the texture.</para>
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUBlendOp
     {
         Invalid,

--- a/SDL3-CS/SDL/GPU/gpu/GPUColorComponentFlags.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUColorComponentFlags.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies which color components are written in a graphics pipeline.
     /// </summary>
     /// <since>This datatype is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     [Flags]
     public enum GPUColorComponentFlags : byte
     {

--- a/SDL3-CS/SDL/GPU/gpu/GPUCompareOp.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUCompareOp.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies a comparison operator for depth, stencil and sampler operations.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUCompareOp
     {
         Invalid,

--- a/SDL3-CS/SDL/GPU/gpu/GPUCullMode.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUCullMode.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies the facing direction in which triangle faces will be culled.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUCullMode
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/GPUFillMode.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUFillMode.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies the fill mode of the graphics pipeline.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUFillMode
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/GPUFrontFace.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUFrontFace.cs
@@ -30,7 +30,7 @@ public static partial class SDL
     /// be front-facing.</para>
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUFrontFace
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/GPUGraphicsPipelineCreateInfo.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUGraphicsPipelineCreateInfo.cs
@@ -31,7 +31,7 @@ public static partial class SDL
     /// A structure specifying the parameters of a graphics pipeline state.
     /// </summary>
     /// <since>This struct is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     /// <seealso cref="GPUVertexInputState"/>
     /// <seealso cref="GPUPrimitiveType"/>
     /// <seealso cref="GPURasterizerState"/>

--- a/SDL3-CS/SDL/GPU/gpu/GPUIndexElementSize.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUIndexElementSize.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies the size of elements in an index buffer.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUIndexElementSize
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/GPUPrimitiveType.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUPrimitiveType.cs
@@ -42,7 +42,7 @@ public static partial class SDL
     /// regret using it.</para>
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUPrimitiveType
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/GPUShaderCreateInfo.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUShaderCreateInfo.cs
@@ -31,7 +31,7 @@ public static partial class SDL
     /// <para>A structure specifying code and metadata for creating a shader object.</para>
     /// </summary>
     /// <since>This struct is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     /// <seealso cref="GPUShaderFormat"/>
     /// <seealso cref="GPUShaderStage"/>
     [StructLayout(LayoutKind.Sequential)]

--- a/SDL3-CS/SDL/GPU/gpu/GPUShaderFormat.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUShaderFormat.cs
@@ -30,7 +30,7 @@ public static partial class SDL
     /// <para>Each format corresponds to a specific backend that accepts it.</para>
     /// </summary>
     /// <since>This datatype is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     [Flags]
     public enum GPUShaderFormat : uint
     {

--- a/SDL3-CS/SDL/GPU/gpu/GPUShaderStage.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUShaderStage.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies which stage a shader program corresponds to.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public enum GPUShaderStage
     {
         Vertex,

--- a/SDL3-CS/SDL/GPU/gpu/GPUStencilOp.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUStencilOp.cs
@@ -30,7 +30,7 @@ public static partial class SDL
     /// pass.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUStencilOp
     {
         Invalid,

--- a/SDL3-CS/SDL/GPU/gpu/GPUVertexElementFormat.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUVertexElementFormat.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies the format of a vertex attribute.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUVertexElementFormat
     {
         Invalid,

--- a/SDL3-CS/SDL/GPU/gpu/GPUVertexInputRate.cs
+++ b/SDL3-CS/SDL/GPU/gpu/GPUVertexInputRate.cs
@@ -29,7 +29,7 @@ public static partial class SDL
     /// Specifies the rate at which vertex attributes are pulled from buffers.
     /// </summary>
     /// <since>This enum is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     public enum GPUVertexInputRate
     {
         /// <summary>

--- a/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
@@ -24,6 +24,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SDL3;
 
@@ -502,7 +503,7 @@ public partial class SDL
     /// <returns>a graphics pipeline object on success, or <c>null</c> on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     /// <seealso cref="BindGPUGraphicsPipeline"/>
     /// <seealso cref="ReleaseGPUGraphicsPipeline"/>
     public static IntPtr CreateGPUGraphicsPipeline(IntPtr device, in GPUGraphicsPipelineCreateInfo createinfo)
@@ -614,6 +615,43 @@ public partial class SDL
     public static IntPtr CreateGPUShader(IntPtr device, in GPUShaderCreateInfo createinfo)
     {
         return CreateGPUShaderNativeFunction(device, in createinfo);
+    }
+
+    /// <summary>
+    /// Creates a GPU shader from scoped managed shader code and an entrypoint string.
+    /// </summary>
+    /// <remarks>
+    /// <para>The <see cref="GPUShaderCreateInfo.Code"/>, <see cref="GPUShaderCreateInfo.CodeSize"/>,
+    /// and entrypoint pointer in <paramref name="createinfo"/> are replaced in a local copy.</para>
+    /// <para>The shader code and UTF-8 entrypoint remain pinned only for the native call.</para>
+    /// </remarks>
+    /// <param name="device">a GPU Context.</param>
+    /// <param name="createinfo">a template describing the shader state.</param>
+    /// <param name="code">the shader code consumed during creation.</param>
+    /// <param name="entrypoint">the shader entrypoint encoded as a <c>null</c>-terminated UTF-8 string.</param>
+    /// <returns>a shader object on success, or <c>null</c> on failure; call
+    /// <see cref="GetError"/> for more information.</returns>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
+    public static unsafe IntPtr CreateGPUShader(
+        IntPtr device,
+        in GPUShaderCreateInfo createinfo,
+        ReadOnlySpan<byte> code,
+        string entrypoint)
+    {
+        ArgumentNullException.ThrowIfNull(entrypoint);
+
+        byte[] entrypointUtf8 = new byte[Encoding.UTF8.GetByteCount(entrypoint) + 1];
+        Encoding.UTF8.GetBytes(entrypoint, entrypointUtf8);
+        GPUShaderCreateInfo scopedCreateInfo = createinfo;
+
+        fixed (byte* codePointer = code)
+        fixed (byte* entrypointPointer = entrypointUtf8)
+        {
+            scopedCreateInfo.Code = code.IsEmpty ? IntPtr.Zero : (IntPtr)codePointer;
+            scopedCreateInfo.CodeSize = (UIntPtr)(uint)code.Length;
+            scopedCreateInfo._entrypoint = (IntPtr)entrypointPointer;
+            return CreateGPUShaderNativeFunction(device, in scopedCreateInfo);
+        }
     }
 
 
@@ -1077,7 +1115,7 @@ public partial class SDL
     /// terms this means you must ensure that vec3 and vec4 fields are 16-byte
     /// aligned.</para>
     /// <para>For detailed information about accessing uniform data from a shader, please
-    /// refer to <see cref="CreateGPUShader"/>.</para>
+    /// refer to <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="commandBuffer">a command buffer.</param>
     /// <param name="slotIndex">the vertex uniform slot to push data to.</param>
@@ -1580,7 +1618,7 @@ public partial class SDL
     /// <summary>
     /// <para>Binds texture-sampler pairs for use on the vertex shader.</para>
     /// <para>The textures must have been created with <see cref="GPUTextureUsageFlags.Sampler"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the vertex sampler slot to begin binding from.</param>
@@ -1589,7 +1627,7 @@ public partial class SDL
     /// <param name="numBindings">the number of texture-sampler pairs to bind from the
     /// array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUVertexSamplers(IntPtr renderPass, uint firstSlot, GPUTextureSamplerBinding[] textureSamplerBindings, uint numBindings)
     {
         if (textureSamplerBindings.Length == 0)
@@ -1628,7 +1666,7 @@ public partial class SDL
     /// <summary>
     /// <para>Binds texture-sampler pairs for use on the vertex shader.</para>
     /// <para>The textures must have been created with <see cref="GPUTextureUsageFlags.Sampler"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the vertex sampler slot to begin binding from.</param>
@@ -1637,7 +1675,7 @@ public partial class SDL
     /// <param name="numBindings">the number of texture-sampler pairs to bind from the
     /// array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUVertexSamplers(IntPtr renderPass, uint firstSlot, IntPtr textureSamplerBindings, uint numBindings)
     {
         BindGPUVertexSamplersPointerNativeFunction(renderPass, firstSlot, textureSamplerBindings, numBindings);
@@ -1656,14 +1694,14 @@ public partial class SDL
     /// <para>Binds storage textures for use on the vertex shader.</para>
     /// <para>These textures must have been created with
     /// <see cref="GPUTextureUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the vertex storage texture slot to begin binding from.</param>
     /// <param name="storageTextures">an array of storage textures.</param>
     /// <param name="numBindings">the number of storage texture to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUVertexStorageTextures(IntPtr renderPass, uint firstSlot, IntPtr[] storageTextures, uint numBindings)
     {
         BindGPUVertexStorageTexturesNativeFunction(renderPass, firstSlot, storageTextures, numBindings);
@@ -1696,14 +1734,14 @@ public partial class SDL
     /// <para>Binds storage buffers for use on the vertex shader.</para>
     /// <para>These buffers must have been created with
     /// <see cref="GPUBufferUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the vertex storage buffer slot to begin binding from.</param>
     /// <param name="storageBuffers">an array of buffers.</param>
     /// <param name="numBindings">the number of buffers to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUVertexStorageBuffers(IntPtr renderPass, uint firstSlot, IntPtr[] storageBuffers, uint numBindings)
     {
         BindGPUVertexStorageBuffersNativeFunction(renderPass, firstSlot, storageBuffers, numBindings);
@@ -1736,7 +1774,7 @@ public partial class SDL
     /// <summary>
     /// <para>Binds texture-sampler pairs for use on the fragment shader.</para>
     /// <para>The textures must have been created with <see cref="GPUTextureUsageFlags.Sampler"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment sampler slot to begin binding from.</param>
@@ -1745,7 +1783,7 @@ public partial class SDL
     /// <param name="numBindings">the number of texture-sampler pairs to bind from the
     /// array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentSamplers(IntPtr renderPass, uint firstSlot, GPUTextureSamplerBinding[] textureSamplerBindings, uint numBindings)
     {
         BindGPUFragmentSamplersArrayNativeFunction(renderPass, firstSlot, textureSamplerBindings, numBindings);
@@ -1762,7 +1800,7 @@ public partial class SDL
     /// <summary>
     /// <para>Binds texture-sampler pairs for use on the fragment shader.</para>
     /// <para>The textures must have been created with <see cref="GPUTextureUsageFlags.Sampler"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment sampler slot to begin binding from.</param>
@@ -1771,7 +1809,7 @@ public partial class SDL
     /// <param name="numBindings">the number of texture-sampler pairs to bind from the
     /// array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentSamplers(IntPtr renderPass, uint firstSlot, IntPtr textureSamplerBindings, uint numBindings)
     {
         BindGPUFragmentSamplersPointerNativeFunction(renderPass, firstSlot, textureSamplerBindings, numBindings);
@@ -1800,14 +1838,14 @@ public partial class SDL
     /// <para>Binds storage textures for use on the fragment shader.</para>
     /// <para>These textures must have been created with
     /// <see cref="GPUTextureUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment storage texture slot to begin binding from.</param>
     /// <param name="storageTextures">an array of storage textures.</param>
     /// <param name="numBindings">the number of storage textures to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentStorageTextures(IntPtr renderPass, uint firstSlot, IntPtr[] storageTextures, uint numBindings)
     {
         BindGPUFragmentStorageTexturesArrayNativeFunction(renderPass, firstSlot, storageTextures, numBindings);
@@ -1825,14 +1863,14 @@ public partial class SDL
     /// <para>Binds storage textures for use on the fragment shader.</para>
     /// <para>These textures must have been created with
     /// <see cref="GPUTextureUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <see cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment storage texture slot to begin binding from.</param>
     /// <param name="storageTextures">an array of storage textures.</param>
     /// <param name="numBindings">the number of storage textures to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentStorageTextures(IntPtr renderPass, uint firstSlot, IntPtr storageTextures, uint numBindings)
     {
         BindGPUFragmentStorageTexturesPointerNativeFunction(renderPass, firstSlot, storageTextures, numBindings);
@@ -1861,14 +1899,14 @@ public partial class SDL
     /// <para>Binds storage buffers for use on the fragment shader.</para>
     /// <para>These buffers must have been created with
     /// <see cref="GPUBufferUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment storage buffer slot to begin binding from.</param>
     /// <param name="storageBuffers">an array of storage buffers.</param>
     /// <param name="numBindings">the number of storage buffers to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentStorageBuffers(IntPtr renderPass, uint firstSlot, IntPtr[] storageBuffers, uint numBindings)
     {
         BindGPUFragmentStorageBuffersArrayNativeFunction(renderPass, firstSlot, storageBuffers, numBindings);
@@ -1886,14 +1924,14 @@ public partial class SDL
     /// <para>Binds storage buffers for use on the fragment shader.</para>
     /// <para>These buffers must have been created with
     /// <see cref="GPUBufferUsageFlags.GraphicsStorageRead"/>.</para>
-    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader"/>.</para>
+    /// <para>Be sure your shader is set up according to the requirements documented in <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>.</para>
     /// </summary>
     /// <param name="renderPass">a render pass handle.</param>
     /// <param name="firstSlot">the fragment storage buffer slot to begin binding from.</param>
     /// <param name="storageBuffers">an array of storage buffers.</param>
     /// <param name="numBindings">the number of storage buffers to bind from the array.</param>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     public static void BindGPUFragmentStorageBuffers(IntPtr renderPass, uint firstSlot, IntPtr storageBuffers, uint numBindings)
     {
         BindGPUFragmentStorageBuffersPointerNativeFunction(renderPass, firstSlot, storageBuffers, numBindings);

--- a/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
+++ b/SDL3-CS/SDL/GPU/gpu/PInvoke.cs
@@ -511,6 +511,50 @@ public partial class SDL
         return CreateGPUGraphicsPipelineNativeFunction(device, in createinfo);
     }
 
+    /// <summary>
+    /// Creates a graphics pipeline from scoped managed vertex-input and color-target descriptions.
+    /// </summary>
+    /// <remarks>
+    /// The three pointer/count pairs in <paramref name="createinfo"/> are replaced in a local copy.
+    /// The spans remain pinned only for the native call.
+    /// </remarks>
+    /// <param name="device">a GPU Context.</param>
+    /// <param name="createinfo">a template describing the graphics pipeline state.</param>
+    /// <param name="vertexBuffers">the vertex buffer descriptions consumed during creation.</param>
+    /// <param name="vertexAttributes">the vertex attribute descriptions consumed during creation.</param>
+    /// <param name="colorTargets">the color target descriptions consumed during creation.</param>
+    /// <returns>a graphics pipeline object on success, or <c>null</c> on failure; call
+    /// <see cref="GetError"/> for more information.</returns>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
+    public static unsafe IntPtr CreateGPUGraphicsPipeline(
+        IntPtr device,
+        in GPUGraphicsPipelineCreateInfo createinfo,
+        ReadOnlySpan<GPUVertexBufferDescription> vertexBuffers,
+        ReadOnlySpan<GPUVertexAttribute> vertexAttributes,
+        ReadOnlySpan<GPUColorTargetDescription> colorTargets)
+    {
+        GPUGraphicsPipelineCreateInfo scopedCreateInfo = createinfo;
+
+        fixed (GPUVertexBufferDescription* vertexBufferPointer = vertexBuffers)
+        fixed (GPUVertexAttribute* vertexAttributePointer = vertexAttributes)
+        fixed (GPUColorTargetDescription* colorTargetPointer = colorTargets)
+        {
+            scopedCreateInfo.VertexInputState.VertexBufferDescriptions = vertexBuffers.IsEmpty
+                ? IntPtr.Zero
+                : (IntPtr)vertexBufferPointer;
+            scopedCreateInfo.VertexInputState.NumVertexBuffers = (uint)vertexBuffers.Length;
+            scopedCreateInfo.VertexInputState.VertexAttributes = vertexAttributes.IsEmpty
+                ? IntPtr.Zero
+                : (IntPtr)vertexAttributePointer;
+            scopedCreateInfo.VertexInputState.NumVertexAttributes = (uint)vertexAttributes.Length;
+            scopedCreateInfo.TargetInfo.ColorTargetDescriptions = colorTargets.IsEmpty
+                ? IntPtr.Zero
+                : (IntPtr)colorTargetPointer;
+            scopedCreateInfo.TargetInfo.NumColorTargets = (uint)colorTargets.Length;
+            return CreateGPUGraphicsPipelineNativeFunction(device, in scopedCreateInfo);
+        }
+    }
+
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_CreateGPUSampler"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -610,7 +654,7 @@ public partial class SDL
     /// <returns>a shader object on success, or <c>null</c> on failure; call
     /// <see cref="GetError"/> for more information.</returns>
     /// <since>This function is available since SDL 3.2.0</since>
-    /// <seealso cref="CreateGPUGraphicsPipeline"/>
+    /// <seealso cref="CreateGPUGraphicsPipeline(nint, in GPUGraphicsPipelineCreateInfo)"/>
     /// <seealso cref="ReleaseGPUShader"/>
     public static IntPtr CreateGPUShader(IntPtr device, in GPUShaderCreateInfo createinfo)
     {

--- a/SDL3-CS/SDL/Video/render/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/render/PInvoke.cs
@@ -252,7 +252,7 @@ public static partial class SDL
     /// <since>This function is available since SDL 3.4.0.</since>
     /// <seealso cref="CreateRendererWithProperties"/>
     /// <seealso cref="GetGPURendererDevice"/>
-    /// <seealso cref="CreateGPUShader"/>
+    /// <seealso cref="CreateGPUShader(nint, in GPUShaderCreateInfo)"/>
     /// <seealso cref="CreateGPURenderState(nint, in GPURenderStateCreateInfo)"/>
     /// <seealso cref="SetGPURenderState"/>
     public static IntPtr CreateGPURenderer(IntPtr device, IntPtr window)


### PR DESCRIPTION
## Summary

- add a scoped `ReadOnlySpan<byte>` overload for GPU shader code and managed UTF-8 entrypoints
- add scoped span inputs for graphics-pipeline vertex buffers, vertex attributes, and color targets
- preserve the existing raw create-info overloads for advanced callers

Refs #253
Refs #254