### PR TITLE
Add managed ShaderCross input overloads

### DIFF
--- a/SDL3-CS.Tests/ShaderCross/PInvoke.cs
+++ b/SDL3-CS.Tests/ShaderCross/PInvoke.cs
@@ -17,6 +17,7 @@ internal static class PInvokeTests
     private static bool nextBool;
     private static int capturedCallCount;
     private static SDL3.ShaderCross.SPIRVInfo capturedSpirvInfo;
+    private static string? capturedSpirvEntrypoint;
     private static SDL3.ShaderCross.HLSLInfo capturedHlslInfo;
     private static string? capturedHlslSource;
     private static string? capturedHlslEntrypoint;
@@ -31,6 +32,7 @@ internal static class PInvokeTests
         ManagedStringProperties_SetPointersAndRoundTripValues();
         LifecycleAndFormatFunctions_ForwardInputsAndReturnNativeValues();
         SPIRVFunctions_ForwardInputsOutputsAndReturnNativeValues();
+        CompileGraphicsShaderFromSPIRVString_UsesScopedUtf8Entrypoint();
         HLSLFunctions_ForwardInputsOutputsAndReturnNativeValues();
         CompileSPIRVFromHLSLStrings_UsesScopedUtf8Inputs();
     }
@@ -456,6 +458,120 @@ internal static class PInvokeTests
         }
     }
 
+    public static void CompileGraphicsShaderFromSPIRVString_UsesScopedUtf8Entrypoint()
+    {
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4201;
+        SDL3.ShaderCross.GraphicsShaderResourceInfo resourceInfo = CreateResourceInfo();
+        SDL3.ShaderCross.GraphicsShaderResourceInfo originalResourceInfo = resourceInfo;
+        using (NativeHookScope hookScope = NativeHookScope.Install(
+            "CompileGraphicsShaderFromSPIRVNativeFunction",
+            nameof(CaptureScopedCompileGraphicsShaderFromSPIRV)))
+        {
+            IntPtr actual = SDL3.ShaderCross.CompileGraphicsShaderFromSPIRV(
+                (IntPtr)0x2201,
+                (IntPtr)0x3201,
+                (UIntPtr)768,
+                "main_цвет",
+                SDL3.ShaderCross.ShaderStage.Fragment,
+                in resourceInfo,
+                94,
+                95);
+
+            TestAssert.Equal(nextPointer, actual, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must return native pointer.");
+            TestAssert.Equal((IntPtr)0x2201, capturedDevice, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward device.");
+            TestAssert.Equal((IntPtr)0x3201, capturedSpirvInfo.ByteCode, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward bytecode.");
+            TestAssert.Equal((UIntPtr)768, capturedSpirvInfo.ByteCodeSize, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward bytecode size.");
+            TestAssert.Equal("main_цвет", capturedSpirvEntrypoint, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must encode entrypoint as UTF-8.");
+            TestAssert.Equal(SDL3.ShaderCross.ShaderStage.Fragment, capturedSpirvInfo.ShaderStage, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward shader stage.");
+            TestAssert.Equal(94u, capturedSpirvInfo.Props, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward info properties.");
+            TestAssert.Equal(95u, capturedProps, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward shader properties.");
+            AssertResourceInfoEqual(originalResourceInfo, capturedResourceInfo, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must forward resource info.");
+            AssertResourceInfoEqual(originalResourceInfo, resourceInfo, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must protect read-only resource info from native mutation.");
+            TestAssert.Equal(1, capturedCallCount, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must call native hook once.");
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4202;
+        using (NativeHookScope hookScope = NativeHookScope.Install(
+            "CompileGraphicsShaderFromSPIRVNativeFunction",
+            nameof(CaptureScopedCompileGraphicsShaderFromSPIRV)))
+        {
+            _ = SDL3.ShaderCross.CompileGraphicsShaderFromSPIRV(
+                (IntPtr)0x2202,
+                (IntPtr)0x3202,
+                (UIntPtr)512,
+                "main",
+                SDL3.ShaderCross.ShaderStage.Vertex,
+                in resourceInfo);
+
+            TestAssert.Equal(0u, capturedSpirvInfo.Props, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must default info properties to zero.");
+            TestAssert.Equal(0u, capturedProps, "ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must default shader properties to zero.");
+        }
+
+        ResetCaptureState();
+        using (NativeHookScope hookScope = NativeHookScope.Install(
+            "CompileGraphicsShaderFromSPIRVNativeFunction",
+            nameof(CaptureScopedCompileGraphicsShaderFromSPIRV)))
+        {
+            try
+            {
+                _ = SDL3.ShaderCross.CompileGraphicsShaderFromSPIRV(
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    UIntPtr.Zero,
+                    null!,
+                    SDL3.ShaderCross.ShaderStage.Vertex,
+                    in resourceInfo);
+                throw new InvalidOperationException("ShaderCross.CompileGraphicsShaderFromSPIRV managed-entrypoint overload must reject a null entrypoint.");
+            }
+            catch (ArgumentNullException exception)
+            {
+                TestAssert.Equal("entrypoint", exception.ParamName, "ShaderCross.CompileGraphicsShaderFromSPIRV must identify the null entrypoint parameter.");
+            }
+
+            TestAssert.Equal(0, capturedCallCount, "ShaderCross.CompileGraphicsShaderFromSPIRV must validate entrypoint before native invocation.");
+        }
+
+        using (NativeHookScope hookScope = NativeHookScope.Install(
+            "CompileGraphicsShaderFromSPIRVNativeFunction",
+            nameof(ThrowCompileGraphicsShaderFromSPIRV)))
+        {
+            try
+            {
+                _ = SDL3.ShaderCross.CompileGraphicsShaderFromSPIRV(
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    UIntPtr.Zero,
+                    "main",
+                    SDL3.ShaderCross.ShaderStage.Vertex,
+                    in resourceInfo);
+                throw new InvalidOperationException("ShaderCross.CompileGraphicsShaderFromSPIRV must propagate native hook exceptions.");
+            }
+            catch (InvalidOperationException exception)
+            {
+                TestAssert.Equal("compile graphics hook failure", exception.Message, "ShaderCross.CompileGraphicsShaderFromSPIRV must preserve native hook exceptions while unwinding the entrypoint pin.");
+            }
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4203;
+        using (NativeHookScope hookScope = NativeHookScope.Install(
+            "CompileGraphicsShaderFromSPIRVNativeFunction",
+            nameof(CaptureScopedCompileGraphicsShaderFromSPIRV)))
+        {
+            IntPtr actual = SDL3.ShaderCross.CompileGraphicsShaderFromSPIRV(
+                IntPtr.Zero,
+                IntPtr.Zero,
+                UIntPtr.Zero,
+                "main",
+                SDL3.ShaderCross.ShaderStage.Vertex,
+                in resourceInfo);
+            TestAssert.Equal((IntPtr)0x4203, actual, "ShaderCross.CompileGraphicsShaderFromSPIRV must remain usable after exception unwinding.");
+            TestAssert.Equal("main", capturedSpirvEntrypoint, "ShaderCross.CompileGraphicsShaderFromSPIRV must re-pin a later entrypoint after exception unwinding.");
+        }
+    }
+
     public static void CompileSPIRVFromHLSLStrings_UsesScopedUtf8Inputs()
     {
         ResetCaptureState();
@@ -635,6 +751,31 @@ internal static class PInvokeTests
         return nextPointer;
     }
 
+    private static IntPtr CaptureScopedCompileGraphicsShaderFromSPIRV(
+        IntPtr device,
+        ref SDL3.ShaderCross.SPIRVInfo info,
+        ref SDL3.ShaderCross.GraphicsShaderResourceInfo resourceInfo,
+        uint props)
+    {
+        capturedDevice = device;
+        capturedSpirvInfo = info;
+        capturedSpirvEntrypoint = Marshal.PtrToStringUTF8(info.Entrypoint);
+        capturedResourceInfo = resourceInfo;
+        capturedProps = props;
+        capturedCallCount++;
+        resourceInfo.NumSamplers = uint.MaxValue;
+        return nextPointer;
+    }
+
+    private static IntPtr ThrowCompileGraphicsShaderFromSPIRV(
+        IntPtr device,
+        ref SDL3.ShaderCross.SPIRVInfo info,
+        ref SDL3.ShaderCross.GraphicsShaderResourceInfo resourceInfo,
+        uint props)
+    {
+        throw new InvalidOperationException("compile graphics hook failure");
+    }
+
     private static IntPtr ThrowCompileSPIRVFromHLSL(ref SDL3.ShaderCross.HLSLInfo info, out UIntPtr size)
     {
         size = UIntPtr.Zero;
@@ -788,6 +929,7 @@ internal static class PInvokeTests
         nextBool = false;
         capturedCallCount = 0;
         capturedSpirvInfo = default;
+        capturedSpirvEntrypoint = null;
         capturedHlslInfo = default;
         capturedHlslSource = null;
         capturedHlslEntrypoint = null;

--- a/SDL3-CS.Tests/ShaderCross/PInvoke.cs
+++ b/SDL3-CS.Tests/ShaderCross/PInvoke.cs
@@ -18,6 +18,9 @@ internal static class PInvokeTests
     private static int capturedCallCount;
     private static SDL3.ShaderCross.SPIRVInfo capturedSpirvInfo;
     private static SDL3.ShaderCross.HLSLInfo capturedHlslInfo;
+    private static string? capturedHlslSource;
+    private static string? capturedHlslEntrypoint;
+    private static string? capturedHlslIncludeDir;
     private static SDL3.ShaderCross.GraphicsShaderResourceInfo capturedResourceInfo;
     private static SDL3.ShaderCross.ComputePipelineMetadata capturedComputeMetadata;
 
@@ -29,6 +32,7 @@ internal static class PInvokeTests
         LifecycleAndFormatFunctions_ForwardInputsAndReturnNativeValues();
         SPIRVFunctions_ForwardInputsOutputsAndReturnNativeValues();
         HLSLFunctions_ForwardInputsOutputsAndReturnNativeValues();
+        CompileSPIRVFromHLSLStrings_UsesScopedUtf8Inputs();
     }
 
     public static void NativeEntryPoints_KeepExpectedLibraryImportMetadata()
@@ -452,6 +456,97 @@ internal static class PInvokeTests
         }
     }
 
+    public static void CompileSPIRVFromHLSLStrings_UsesScopedUtf8Inputs()
+    {
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4101;
+        nextSize = (UIntPtr)3072;
+        using (NativeHookScope hookScope = NativeHookScope.Install("CompileSPIRVFromHLSLNativeFunction", nameof(CaptureCompileSPIRVFromHLSL)))
+        {
+            IntPtr actual = SDL3.ShaderCross.CompileSPIRVFromHLSL(
+                "float4 main_цвет() : SV_Target { return 1; }",
+                "main_цвет",
+                SDL3.ShaderCross.ShaderStage.Fragment,
+                out UIntPtr size,
+                "шэйдеры/include",
+                93);
+
+            TestAssert.Equal(nextPointer, actual, "ShaderCross.CompileSPIRVFromHLSL string overload must return native pointer.");
+            TestAssert.Equal(nextSize, size, "ShaderCross.CompileSPIRVFromHLSL string overload must return native size.");
+            TestAssert.Equal("float4 main_цвет() : SV_Target { return 1; }", capturedHlslSource, "ShaderCross.CompileSPIRVFromHLSL string overload must encode source as UTF-8.");
+            TestAssert.Equal("main_цвет", capturedHlslEntrypoint, "ShaderCross.CompileSPIRVFromHLSL string overload must encode entrypoint as UTF-8.");
+            TestAssert.Equal("шэйдеры/include", capturedHlslIncludeDir, "ShaderCross.CompileSPIRVFromHLSL string overload must encode include directory as UTF-8.");
+            TestAssert.Equal(IntPtr.Zero, capturedHlslInfo.Defines, "ShaderCross.CompileSPIRVFromHLSL string overload must leave defines empty.");
+            TestAssert.Equal(SDL3.ShaderCross.ShaderStage.Fragment, capturedHlslInfo.ShaderStage, "ShaderCross.CompileSPIRVFromHLSL string overload must forward shader stage.");
+            TestAssert.Equal(93u, capturedHlslInfo.Props, "ShaderCross.CompileSPIRVFromHLSL string overload must forward properties.");
+            TestAssert.Equal(1, capturedCallCount, "ShaderCross.CompileSPIRVFromHLSL string overload must call native hook once.");
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4102;
+        nextSize = (UIntPtr)4096;
+        using (NativeHookScope hookScope = NativeHookScope.Install("CompileSPIRVFromHLSLNativeFunction", nameof(CaptureCompileSPIRVFromHLSL)))
+        {
+            _ = SDL3.ShaderCross.CompileSPIRVFromHLSL(
+                "void main() {}",
+                "main",
+                SDL3.ShaderCross.ShaderStage.Vertex,
+                out _);
+
+            TestAssert.Equal<string?>(null, capturedHlslIncludeDir, "ShaderCross.CompileSPIRVFromHLSL string overload must pass a null include directory by default.");
+            TestAssert.Equal(IntPtr.Zero, capturedHlslInfo.IncludeDir, "ShaderCross.CompileSPIRVFromHLSL string overload must pass a null include-directory pointer by default.");
+            TestAssert.Equal(0u, capturedHlslInfo.Props, "ShaderCross.CompileSPIRVFromHLSL string overload must pass zero properties by default.");
+        }
+
+        ResetCaptureState();
+        using (NativeHookScope hookScope = NativeHookScope.Install("CompileSPIRVFromHLSLNativeFunction", nameof(CaptureCompileSPIRVFromHLSL)))
+        {
+            try
+            {
+                _ = SDL3.ShaderCross.CompileSPIRVFromHLSL(null!, "main", SDL3.ShaderCross.ShaderStage.Vertex, out _);
+                throw new InvalidOperationException("ShaderCross.CompileSPIRVFromHLSL string overload must reject a null source.");
+            }
+            catch (ArgumentNullException exception)
+            {
+                TestAssert.Equal("source", exception.ParamName, "ShaderCross.CompileSPIRVFromHLSL must identify the null source parameter.");
+            }
+
+            try
+            {
+                _ = SDL3.ShaderCross.CompileSPIRVFromHLSL("void main() {}", null!, SDL3.ShaderCross.ShaderStage.Vertex, out _);
+                throw new InvalidOperationException("ShaderCross.CompileSPIRVFromHLSL string overload must reject a null entrypoint.");
+            }
+            catch (ArgumentNullException exception)
+            {
+                TestAssert.Equal("entrypoint", exception.ParamName, "ShaderCross.CompileSPIRVFromHLSL must identify the null entrypoint parameter.");
+            }
+
+            TestAssert.Equal(0, capturedCallCount, "ShaderCross.CompileSPIRVFromHLSL must validate required strings before native invocation.");
+        }
+
+        using (NativeHookScope hookScope = NativeHookScope.Install("CompileSPIRVFromHLSLNativeFunction", nameof(ThrowCompileSPIRVFromHLSL)))
+        {
+            try
+            {
+                _ = SDL3.ShaderCross.CompileSPIRVFromHLSL("void main() {}", "main", SDL3.ShaderCross.ShaderStage.Vertex, out _);
+                throw new InvalidOperationException("ShaderCross.CompileSPIRVFromHLSL must propagate native hook exceptions.");
+            }
+            catch (InvalidOperationException exception)
+            {
+                TestAssert.Equal("compile SPIR-V hook failure", exception.Message, "ShaderCross.CompileSPIRVFromHLSL must preserve native hook exceptions while unwinding pins.");
+            }
+        }
+
+        ResetCaptureState();
+        nextPointer = (IntPtr)0x4103;
+        using (NativeHookScope hookScope = NativeHookScope.Install("CompileSPIRVFromHLSLNativeFunction", nameof(CaptureCompileSPIRVFromHLSL)))
+        {
+            IntPtr actual = SDL3.ShaderCross.CompileSPIRVFromHLSL("void main() {}", "main", SDL3.ShaderCross.ShaderStage.Vertex, out _);
+            TestAssert.Equal((IntPtr)0x4103, actual, "ShaderCross.CompileSPIRVFromHLSL must remain usable after exception unwinding.");
+            TestAssert.Equal("main", capturedHlslEntrypoint, "ShaderCross.CompileSPIRVFromHLSL must re-pin a later entrypoint after exception unwinding.");
+        }
+    }
+
     private static bool ReturnNextBool()
     {
         capturedCallCount++;
@@ -532,9 +627,18 @@ internal static class PInvokeTests
     private static IntPtr CaptureCompileSPIRVFromHLSL(ref SDL3.ShaderCross.HLSLInfo info, out UIntPtr size)
     {
         capturedHlslInfo = info;
+        capturedHlslSource = Marshal.PtrToStringUTF8(info.Source);
+        capturedHlslEntrypoint = Marshal.PtrToStringUTF8(info.Entrypoint);
+        capturedHlslIncludeDir = Marshal.PtrToStringUTF8(info.IncludeDir);
         size = nextSize;
         capturedCallCount++;
         return nextPointer;
+    }
+
+    private static IntPtr ThrowCompileSPIRVFromHLSL(ref SDL3.ShaderCross.HLSLInfo info, out UIntPtr size)
+    {
+        size = UIntPtr.Zero;
+        throw new InvalidOperationException("compile SPIR-V hook failure");
     }
 
     private static SDL3.ShaderCross.SPIRVInfo CreateSpirvInfo()
@@ -685,6 +789,9 @@ internal static class PInvokeTests
         capturedCallCount = 0;
         capturedSpirvInfo = default;
         capturedHlslInfo = default;
+        capturedHlslSource = null;
+        capturedHlslEntrypoint = null;
+        capturedHlslIncludeDir = null;
         capturedResourceInfo = default;
         capturedComputeMetadata = default;
     }

--- a/SDL3-CS/ShaderCross/PInvoke.cs
+++ b/SDL3-CS/ShaderCross/PInvoke.cs
@@ -191,6 +191,55 @@ public partial class ShaderCross
         return CompileGraphicsShaderFromSPIRVNativeFunction(device, ref info, ref resourceInfo, props);
     }
 
+    /// <summary>
+    /// Compiles a graphics shader from unmanaged SPIR-V bytecode and a scoped managed entrypoint.
+    /// </summary>
+    /// <remarks>
+    /// The bytecode remains owned by the caller. The UTF-8 entrypoint remains pinned only for the
+    /// native call, and the read-only resource information is forwarded through a local copy.
+    /// </remarks>
+    /// <param name="device">the SDL GPU device.</param>
+    /// <param name="bytecode">the unmanaged SPIR-V bytecode.</param>
+    /// <param name="bytecodeSize">the length of the SPIR-V bytecode.</param>
+    /// <param name="entrypoint">the UTF-8 entrypoint name.</param>
+    /// <param name="shaderStage">the shader stage to compile.</param>
+    /// <param name="resourceInfo">the read-only resource metadata for the shader.</param>
+    /// <param name="infoProps">a properties object filled in with SPIR-V input metadata.</param>
+    /// <param name="shaderProps">a properties object filled in with output shader metadata.</param>
+    /// <returns>a compiled SDL GPU shader, or <c>null</c> on failure.</returns>
+    /// <threadsafety>It is safe to call this function from any thread.</threadsafety>
+    /// <seealso cref="CompileGraphicsShaderFromSPIRV(nint, ref SPIRVInfo, ref GraphicsShaderResourceInfo, uint)"/>
+    public static unsafe IntPtr CompileGraphicsShaderFromSPIRV(
+        IntPtr device,
+        IntPtr bytecode,
+        UIntPtr bytecodeSize,
+        string entrypoint,
+        ShaderStage shaderStage,
+        in GraphicsShaderResourceInfo resourceInfo,
+        uint infoProps = 0,
+        uint shaderProps = 0)
+    {
+        ArgumentNullException.ThrowIfNull(entrypoint);
+
+        byte[] entrypointUtf8 = new byte[Encoding.UTF8.GetByteCount(entrypoint) + 1];
+        Encoding.UTF8.GetBytes(entrypoint, entrypointUtf8);
+
+        fixed (byte* entrypointPointer = entrypointUtf8)
+        {
+            SPIRVInfo info = new()
+            {
+                ByteCode = bytecode,
+                ByteCodeSize = bytecodeSize,
+                Entrypoint = (IntPtr)entrypointPointer,
+                ShaderStage = shaderStage,
+                Props = infoProps
+            };
+            GraphicsShaderResourceInfo scopedResourceInfo = resourceInfo;
+
+            return CompileGraphicsShaderFromSPIRV(device, ref info, ref scopedResourceInfo, shaderProps);
+        }
+    }
+
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(ShaderCrossLibrary, EntryPoint = "SDL_ShaderCross_CompileComputePipelineFromSPIRV"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3-CS/ShaderCross/PInvoke.cs
+++ b/SDL3-CS/ShaderCross/PInvoke.cs
@@ -24,6 +24,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SDL3;
 
@@ -177,7 +178,7 @@ public partial class ShaderCross
 
     /// <code>extern SDL_DECLSPEC SDL_GPUShader * SDLCALL SDL_ShaderCross_CompileGraphicsShaderFromSPIRV(SDL_GPUDevice *device, const SDL_ShaderCross_SPIRV_Info *info, const SDL_ShaderCross_GraphicsShaderMetadata *metadata, SDL_PropertiesID props);</code>
     /// <summary>
-    /// Compile an SDL GPU shader from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL"/>.
+    /// Compile an SDL GPU shader from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL(ref HLSLInfo, out UIntPtr)"/>.
     /// </summary>
     /// <param name="device">the SDL GPU device.</param>
     /// <param name="info">a struct describing the shader to transpile.</param>
@@ -199,7 +200,7 @@ public partial class ShaderCross
 
     /// <code>extern SDL_DECLSPEC SDL_GPUComputePipeline * SDLCALL SDL_ShaderCross_CompileComputePipelineFromSPIRV(SDL_GPUDevice *device, const SDL_ShaderCross_SPIRV_Info *info, const SDL_ShaderCross_ComputePipelineMetadata *metadata, SDL_PropertiesID props);</code>
     /// <summary>
-    /// Compile an SDL GPU compute pipeline from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL"/>.
+    /// Compile an SDL GPU compute pipeline from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL(ref HLSLInfo, out UIntPtr)"/>.
     /// </summary>
     /// <param name="device">the SDL GPU device.</param>
     /// <param name="info">a struct describing the shader to transpile.</param>
@@ -221,7 +222,7 @@ public partial class ShaderCross
 
     /// <code>extern SDL_DECLSPEC SDL_ShaderCross_GraphicsShaderMetadata * SDLCALL SDL_ShaderCross_ReflectGraphicsSPIRV(const Uint8 *bytecode, size_t bytecode_size, SDL_PropertiesID props);</code>
     /// <summary>
-    /// Reflect graphics shader info from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL"/>. This must be freed with <see cref="SDL.Free"/> when you are done with the metadata.
+    /// Reflect graphics shader info from SPIRV code. If your shader source is HLSL, you should obtain SPIR-V bytecode from <see cref="CompileSPIRVFromHLSL(ref HLSLInfo, out UIntPtr)"/>. This must be freed with <see cref="SDL.Free"/> when you are done with the metadata.
     /// </summary>
     /// <param name="bytecode">the SPIRV bytecode.</param>
     /// <param name="bytecodeSize">the length of the SPIRV bytecode.</param>
@@ -353,5 +354,64 @@ public partial class ShaderCross
     public static IntPtr CompileSPIRVFromHLSL(ref HLSLInfo info, out UIntPtr size)
     {
         return CompileSPIRVFromHLSLNativeFunction(ref info, out size);
+    }
+
+    /// <summary>
+    /// Compiles managed HLSL source to SPIR-V using scoped UTF-8 input strings.
+    /// </summary>
+    /// <remarks>
+    /// The source, entrypoint, and optional include directory remain pinned only for the native call.
+    /// The returned SDL-allocated buffer must be released with <see cref="SDL.Free"/>.
+    /// Use <see cref="CompileSPIRVFromHLSL(ref HLSLInfo, out UIntPtr)"/> for custom defines and other
+    /// advanced pointer-based scenarios.
+    /// </remarks>
+    /// <param name="source">the HLSL source text.</param>
+    /// <param name="entrypoint">the UTF-8 entrypoint name.</param>
+    /// <param name="shaderStage">the shader stage to compile.</param>
+    /// <param name="size">filled in with the returned SPIR-V bytecode size.</param>
+    /// <param name="includeDir">an optional include directory, or <c>null</c>.</param>
+    /// <param name="props">a properties object filled in with compiler options.</param>
+    /// <returns>an SDL-allocated buffer containing SPIR-V bytecode, or <c>null</c> on failure.</returns>
+    /// <threadsafety>It is safe to call this function from any thread.</threadsafety>
+    public static unsafe IntPtr CompileSPIRVFromHLSL(
+        string source,
+        string entrypoint,
+        ShaderStage shaderStage,
+        out UIntPtr size,
+        string? includeDir = null,
+        uint props = 0)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(entrypoint);
+
+        byte[] sourceUtf8 = new byte[Encoding.UTF8.GetByteCount(source) + 1];
+        Encoding.UTF8.GetBytes(source, sourceUtf8);
+        byte[] entrypointUtf8 = new byte[Encoding.UTF8.GetByteCount(entrypoint) + 1];
+        Encoding.UTF8.GetBytes(entrypoint, entrypointUtf8);
+        byte[] includeDirUtf8 = includeDir is null
+            ? []
+            : new byte[Encoding.UTF8.GetByteCount(includeDir) + 1];
+
+        if (includeDir is not null)
+        {
+            Encoding.UTF8.GetBytes(includeDir, includeDirUtf8);
+        }
+
+        fixed (byte* sourcePointer = sourceUtf8)
+        fixed (byte* entrypointPointer = entrypointUtf8)
+        fixed (byte* includeDirPointer = includeDirUtf8)
+        {
+            HLSLInfo info = new()
+            {
+                Source = (IntPtr)sourcePointer,
+                Entrypoint = (IntPtr)entrypointPointer,
+                IncludeDir = includeDir is null ? IntPtr.Zero : (IntPtr)includeDirPointer,
+                Defines = IntPtr.Zero,
+                ShaderStage = shaderStage,
+                Props = props
+            };
+
+            return CompileSPIRVFromHLSLNativeFunction(ref info, out size);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- add a managed-string HLSL-to-SPIR-V overload with scoped UTF-8 source, entrypoint, and include-directory storage
- add an unmanaged-SPIR-V workflow with a managed scoped entrypoint and read-only resource metadata
- preserve existing raw structure overloads and returned-buffer ownership

Refs #255
Refs #256