### PR TITLE
Fix application callback argv marshalling

### DIFF
--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -1,5 +1,15 @@
 using SDL3;
 
+if (args.SequenceEqual(["--argv-callbacks-only"]))
+{
+    SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_AdaptsCompleteUtf8ArgumentsFromNativeCallback();
+    SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_AdaptsNullArgumentsFromNativeCallback();
+    SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_AdaptsCompleteUtf8ArgumentsFromNativeCallback();
+    SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_AdaptsNullArgumentsFromNativeCallback();
+    Console.WriteLine("SDL native callback argv adapter focused tests passed.");
+    return;
+}
+
 if (args.SequenceEqual(["--main-callbacks-only"]))
 {
     SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunManagedMainCallbackFocusedTests();
@@ -135,6 +145,14 @@ SDL3.Tests.SDL.Basics.Main.PInvokeTests.Main_NullAndEmptyArgumentsForwardNull();
 Console.WriteLine("SDL.Main null and empty argv normalization test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.SetMainReady_CallsNativeHook();
 Console.WriteLine("SDL.SetMainReady binding test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_AdaptsCompleteUtf8ArgumentsFromNativeCallback();
+Console.WriteLine("SDL.RunApp native callback argv adapter test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_AdaptsNullArgumentsFromNativeCallback();
+Console.WriteLine("SDL.RunApp native callback null argv adapter test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_AdaptsCompleteUtf8ArgumentsFromNativeCallback();
+Console.WriteLine("SDL.EnterAppMainCallbacks native callback argv adapter test passed.");
+SDL3.Tests.SDL.Basics.Main.PInvokeTests.EnterAppMainCallbacks_AdaptsNullArgumentsFromNativeCallback();
+Console.WriteLine("SDL.EnterAppMainCallbacks native callback null argv adapter test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_ForwardsArgumentsCallbackReservedAndReturnsNativeValue();
 Console.WriteLine("SDL.RunApp binding test passed.");
 SDL3.Tests.SDL.Basics.Main.PInvokeTests.RunApp_NullAndEmptyArgumentsForwardNull();

--- a/SDL3-CS.Tests/SDL/Basics/main/ManagedCallbacks.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/ManagedCallbacks.cs
@@ -188,11 +188,11 @@ internal static partial class PInvokeTests
         TestAssert.Equal(false, usage.Inherited, "SDL.GenerateMainAttribute must not be inherited.");
     }
 
-    private static int RunManagedLifecycle(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedLifecycle(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         AssertNativeArguments(argc, argv, "--renderer", "software");
         managedAppstate = IntPtr.Zero;
-        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appinit(ref managedAppstate, argc, argv), "Managed AppInit must continue.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv), "Managed AppInit must continue.");
         TestAssert.True(managedAppstate != IntPtr.Zero, "Managed AppInit must provide an opaque native state handle.");
         TestAssert.Equal(SDL3.SDL.AppResult.Continue, appiter(managedAppstate), "Managed AppIterate must continue.");
         SDL3.SDL.Event @event = new() { Type = (uint)SDL3.SDL.EventType.Quit };
@@ -206,29 +206,29 @@ internal static partial class PInvokeTests
         return 73;
     }
 
-    private static int RunManagedEarlyExit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedEarlyExit(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         AssertNativeArguments(argc, argv);
         managedAppstate = IntPtr.Zero;
-        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        SDL3.SDL.AppResult result = InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         TestAssert.Equal(SDL3.SDL.AppResult.Success, result, "Managed AppInit must return configured early success.");
         appquit(managedAppstate, result);
         return 17;
     }
 
-    private static int RunManagedInitFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedInitFailure(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        SDL3.SDL.AppResult result = InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         TestAssert.Equal(SDL3.SDL.AppResult.Failure, result, "Invalid managed state must become native failure.");
         appquit(managedAppstate, result);
         return -1;
     }
 
-    private static int RunManagedFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedFailure(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        SDL3.SDL.AppResult result = appinit(ref managedAppstate, argc, argv);
+        SDL3.SDL.AppResult result = InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         if (result == SDL3.SDL.AppResult.Continue)
         {
             result = appiter(managedAppstate);
@@ -245,33 +245,33 @@ internal static partial class PInvokeTests
         return -1;
     }
 
-    private static int RunManagedWithoutQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedWithoutQuit(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        TestAssert.Equal(SDL3.SDL.AppResult.Continue, appinit(ref managedAppstate, argc, argv), "Managed AppInit must continue before fallback cleanup.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Continue, InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv), "Managed AppInit must continue before fallback cleanup.");
         return 0;
     }
 
-    private static int RunManagedDuplicateQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedDuplicateQuit(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        appinit(ref managedAppstate, argc, argv);
+        InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         appquit(managedAppstate, SDL3.SDL.AppResult.Success);
         appquit(managedAppstate, SDL3.SDL.AppResult.Failure);
         return 0;
     }
 
-    private static int RunManagedNativeFailure(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedNativeFailure(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        appinit(ref managedAppstate, argc, argv);
+        InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         throw new NotSupportedException("native bridge");
     }
 
-    private static int RunManagedConcurrentQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedConcurrentQuit(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        appinit(ref managedAppstate, argc, argv);
+        InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         SDL3.SDL.Event @event = new() { Type = (uint)SDL3.SDL.EventType.Quit };
         Task<SDL3.SDL.AppResult> eventTask = Task.Run(() => appevent(managedAppstate, ref @event));
         TestAssert.True(RecordingApp.EventEntered.Wait(TimeSpan.FromSeconds(5)), "Managed AppEvent did not start in time.");
@@ -283,10 +283,10 @@ internal static partial class PInvokeTests
         return 0;
     }
 
-    private static int RunManagedConcurrentDuplicateQuit(int argc, string[]? argv, SDL3.SDL.AppInitFunc appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
+    private static int RunManagedConcurrentDuplicateQuit(int argc, string[]? argv, IntPtr appinit, SDL3.SDL.AppIterateFunc appiter, SDL3.SDL.AppEventFunc appevent, SDL3.SDL.AppQuitFunc appquit)
     {
         managedAppstate = IntPtr.Zero;
-        appinit(ref managedAppstate, argc, argv);
+        InvokeNativeAppInit(appinit, ref managedAppstate, argc, argv);
         Task firstQuit = Task.Run(() => appquit(managedAppstate, SDL3.SDL.AppResult.Success));
         TestAssert.True(RecordingApp.QuitEntered.Wait(TimeSpan.FromSeconds(5)), "The first managed AppQuit did not start in time.");
         Task duplicateQuit = Task.Run(() => appquit(managedAppstate, SDL3.SDL.AppResult.Failure));
@@ -302,6 +302,26 @@ internal static partial class PInvokeTests
         TestAssert.Equal(2, arguments.Length, "Native arguments must prepend exactly one executable identifier.");
         TestAssert.Equal(expectedExecutable, arguments[0], "Native arguments must use the expected executable fallback.");
         TestAssert.Equal("--test", arguments[1], "Native arguments must preserve managed arguments.");
+    }
+
+    private static unsafe SDL3.SDL.AppResult InvokeNativeAppInit(IntPtr appinit, ref IntPtr appstate, int argc, string[]? argv)
+    {
+        delegate* unmanaged[Cdecl]<IntPtr*, int, IntPtr, SDL3.SDL.AppResult> callback = (delegate* unmanaged[Cdecl]<IntPtr*, int, IntPtr, SDL3.SDL.AppResult>)(void*)appinit;
+        IntPtr nativeAppstate = appstate;
+        SDL3.SDL.AppResult result;
+
+        if (argc <= 0 || argv is null)
+        {
+            result = callback(&nativeAppstate, 0, IntPtr.Zero);
+        }
+        else
+        {
+            using Utf8ArgvScope nativeArguments = new(argv);
+            result = callback(&nativeAppstate, argc, nativeArguments.Pointer);
+        }
+
+        appstate = nativeAppstate;
+        return result;
     }
 
     private static void AssertNativeArguments(int argc, string[]? argv, params string[] expectedArgs)

--- a/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Basics/main/PInvoke.cs
@@ -13,8 +13,8 @@ internal static partial class PInvokeTests
     private static string[]? capturedArgv;
     private static uint capturedEventType;
     private static SDL3.SDL.AppResult capturedResult;
-    private static SDL3.SDL.MainFunc? capturedMainFunction;
-    private static SDL3.SDL.AppInitFunc? capturedAppInit;
+    private static IntPtr capturedMainFunctionPointer;
+    private static IntPtr capturedAppInitPointer;
     private static SDL3.SDL.AppIterateFunc? capturedAppIterate;
     private static SDL3.SDL.AppEventFunc? capturedAppEvent;
     private static SDL3.SDL.AppQuitFunc? capturedAppQuit;
@@ -26,6 +26,9 @@ internal static partial class PInvokeTests
     private static int nextInt;
     private static bool nextBool;
     private static int capturedCallCount;
+    private static int capturedCallbackArgc;
+    private static string[]? capturedCallbackArgv;
+    private static string[]? nativeCallbackArgv;
 
     public static void AppInit_ForwardsStateArgumentsAndReturnsNativeValue()
     {
@@ -188,6 +191,91 @@ internal static partial class PInvokeTests
         TestAssert.Equal(1, capturedCallCount, "SDL.SetMainReady must call native hook once.");
     }
 
+    public static void RunApp_AdaptsCompleteUtf8ArgumentsFromNativeCallback()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_RunApp");
+        AssertIntPtrParameter(nativeMethod, "mainFunction");
+
+        ResetCaptureState();
+        nextInt = 73;
+        nativeCallbackArgv = ["app", "naïve", "тест"];
+        using NativeHookScope _ = NativeHookScope.Install("RunAppNativeFunction", nameof(CaptureRunAppAndInvokeNativeMain));
+
+        int result = SDL3.SDL.RunApp(2, ["app", "--managed"], CaptureAdaptedMain, (IntPtr)505);
+
+        TestAssert.Equal(73, result, "SDL.RunApp must return the result from the adapted main callback.");
+        AssertAdaptedCallbackArguments(nativeCallbackArgv);
+        TestAssert.True(capturedMainFunctionPointer != IntPtr.Zero, "SDL.RunApp must pass a non-null native callback pointer.");
+    }
+
+    public static void RunApp_AdaptsNullArgumentsFromNativeCallback()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_RunApp");
+        AssertIntPtrParameter(nativeMethod, "mainFunction");
+
+        ResetCaptureState();
+        nextInt = 17;
+        nativeCallbackArgv = null;
+        using NativeHookScope _ = NativeHookScope.Install("RunAppNativeFunction", nameof(CaptureRunAppAndInvokeNativeMain));
+
+        int result = SDL3.SDL.RunApp(1, ["app"], CaptureAdaptedMain, IntPtr.Zero);
+
+        TestAssert.Equal(17, result, "SDL.RunApp must return the result from a callback receiving null argv.");
+        TestAssert.Equal(0, capturedCallbackArgc, "SDL.MainFunc must receive zero argc from the native callback.");
+        TestAssert.Equal<string[]?>(null, capturedCallbackArgv, "SDL.MainFunc must receive null argv for a native null pointer with zero argc.");
+    }
+
+    public static void EnterAppMainCallbacks_AdaptsCompleteUtf8ArgumentsFromNativeCallback()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_EnterAppMainCallbacks");
+        AssertIntPtrParameter(nativeMethod, "appinit");
+
+        ResetCaptureState();
+        nextInt = 99;
+        nextAppResult = SDL3.SDL.AppResult.Success;
+        nextAppstate = (IntPtr)5150;
+        nativeCallbackArgv = ["app", "naïve", "тест"];
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(CaptureEnterAppMainCallbacksAndInvokeNativeInit));
+
+        int result = SDL3.SDL.EnterAppMainCallbacks(
+            2,
+            ["app", "--managed"],
+            CaptureAdaptedAppInit,
+            HandleAppIterate,
+            HandleAppEvent,
+            HandleAppQuit);
+
+        TestAssert.Equal(99, result, "SDL.EnterAppMainCallbacks must return the native boundary result.");
+        AssertAdaptedCallbackArguments(nativeCallbackArgv);
+        TestAssert.Equal((IntPtr)5150, capturedAppstate, "SDL.AppInitFunc must preserve appstate assignment through the native adapter.");
+        TestAssert.Equal(SDL3.SDL.AppResult.Success, capturedResult, "SDL.AppInitFunc must preserve its result through the native adapter.");
+        TestAssert.True(capturedAppInitPointer != IntPtr.Zero, "SDL.EnterAppMainCallbacks must pass a non-null native appinit pointer.");
+    }
+
+    public static void EnterAppMainCallbacks_AdaptsNullArgumentsFromNativeCallback()
+    {
+        MethodInfo nativeMethod = GetNativeMethod("SDL_EnterAppMainCallbacks");
+        AssertIntPtrParameter(nativeMethod, "appinit");
+
+        ResetCaptureState();
+        nextInt = 19;
+        nextAppResult = SDL3.SDL.AppResult.Success;
+        nativeCallbackArgv = null;
+        using NativeHookScope _ = NativeHookScope.Install("EnterAppMainCallbacksNativeFunction", nameof(CaptureEnterAppMainCallbacksAndInvokeNativeInit));
+
+        int result = SDL3.SDL.EnterAppMainCallbacks(
+            1,
+            ["app"],
+            CaptureAdaptedAppInit,
+            HandleAppIterate,
+            HandleAppEvent,
+            HandleAppQuit);
+
+        TestAssert.Equal(19, result, "SDL.EnterAppMainCallbacks must return after adapting native null argv.");
+        TestAssert.Equal(0, capturedCallbackArgc, "SDL.AppInitFunc must receive zero argc from the native callback.");
+        TestAssert.Equal<string[]?>(null, capturedCallbackArgv, "SDL.AppInitFunc must receive null argv for a native null pointer with zero argc.");
+    }
+
     public static void RunApp_ForwardsArgumentsCallbackReservedAndReturnsNativeValue()
     {
         MethodInfo nativeMethod = GetNativeMethod("SDL_RunApp");
@@ -206,7 +294,7 @@ internal static partial class PInvokeTests
         TestAssert.Equal(77, result, "SDL.RunApp must return native int value.");
         TestAssert.Equal(argv.Length, capturedArgc, "SDL.RunApp must forward argc.");
         TestAssert.True(ReferenceEquals(argv, capturedArgv), "SDL.RunApp must forward argv array.");
-        TestAssert.Equal(mainFunction, capturedMainFunction!, "SDL.RunApp must forward main callback.");
+        TestAssert.True(capturedMainFunctionPointer != IntPtr.Zero, "SDL.RunApp must forward a non-null native main callback pointer.");
         TestAssert.Equal((IntPtr)505, capturedReserved, "SDL.RunApp must forward reserved pointer.");
         TestAssert.Equal(1, capturedCallCount, "SDL.RunApp must call native hook once.");
     }
@@ -255,7 +343,7 @@ internal static partial class PInvokeTests
         TestAssert.Equal(99, result, "SDL.EnterAppMainCallbacks must return native int value.");
         TestAssert.Equal(argv.Length, capturedArgc, "SDL.EnterAppMainCallbacks must forward argc.");
         TestAssert.True(ReferenceEquals(argv, capturedArgv), "SDL.EnterAppMainCallbacks must forward argv array.");
-        TestAssert.Equal(appinit, capturedAppInit!, "SDL.EnterAppMainCallbacks must forward appinit.");
+        TestAssert.True(capturedAppInitPointer != IntPtr.Zero, "SDL.EnterAppMainCallbacks must forward a non-null native appinit callback pointer.");
         TestAssert.Equal(appiter, capturedAppIterate!, "SDL.EnterAppMainCallbacks must forward appiter.");
         TestAssert.Equal(appevent, capturedAppEvent!, "SDL.EnterAppMainCallbacks must forward appevent.");
         TestAssert.Equal(appquit, capturedAppQuit!, "SDL.EnterAppMainCallbacks must forward appquit.");
@@ -345,8 +433,8 @@ internal static partial class PInvokeTests
         capturedArgv = null;
         capturedEventType = 0;
         capturedResult = default;
-        capturedMainFunction = null;
-        capturedAppInit = null;
+        capturedMainFunctionPointer = IntPtr.Zero;
+        capturedAppInitPointer = IntPtr.Zero;
         capturedAppIterate = null;
         capturedAppEvent = null;
         capturedAppQuit = null;
@@ -359,6 +447,9 @@ internal static partial class PInvokeTests
         nextInt = 0;
         nextBool = false;
         capturedCallCount = 0;
+        capturedCallbackArgc = 0;
+        capturedCallbackArgv = null;
+        nativeCallbackArgv = null;
     }
 
     private static SDL3.SDL.AppResult CaptureAppInit(ref IntPtr appstate, int argc, string[]? argv)
@@ -407,31 +498,81 @@ internal static partial class PInvokeTests
         capturedCallCount++;
     }
 
-    private static int CaptureRunApp(int argc, string[]? argv, SDL3.SDL.MainFunc mainFunction, IntPtr reserved)
+    private static int CaptureRunApp(int argc, string[]? argv, IntPtr mainFunction, IntPtr reserved)
     {
         capturedArgc = argc;
         capturedArgv = argv;
-        capturedMainFunction = mainFunction;
+        capturedMainFunctionPointer = mainFunction;
         capturedReserved = reserved;
         capturedCallCount++;
         return nextInt;
     }
 
+    private static unsafe int CaptureRunAppAndInvokeNativeMain(int argc, string[]? argv, IntPtr mainFunction, IntPtr reserved)
+    {
+        capturedArgc = argc;
+        capturedArgv = argv;
+        capturedMainFunctionPointer = mainFunction;
+        capturedReserved = reserved;
+        capturedCallCount++;
+
+        delegate* unmanaged[Cdecl]<int, IntPtr, int> callback = (delegate* unmanaged[Cdecl]<int, IntPtr, int>)(void*)mainFunction;
+        if (nativeCallbackArgv is null)
+        {
+            return callback(0, IntPtr.Zero);
+        }
+
+        using Utf8ArgvScope nativeArguments = new(nativeCallbackArgv);
+        return callback(nativeCallbackArgv.Length, nativeArguments.Pointer);
+    }
+
     private static int CaptureEnterAppMainCallbacks(
         int argc,
         string[]? argv,
-        SDL3.SDL.AppInitFunc appinit,
+        IntPtr appinit,
         SDL3.SDL.AppIterateFunc appiter,
         SDL3.SDL.AppEventFunc appevent,
         SDL3.SDL.AppQuitFunc appquit)
     {
         capturedArgc = argc;
         capturedArgv = argv;
-        capturedAppInit = appinit;
+        capturedAppInitPointer = appinit;
         capturedAppIterate = appiter;
         capturedAppEvent = appevent;
         capturedAppQuit = appquit;
         capturedCallCount++;
+        return nextInt;
+    }
+
+    private static unsafe int CaptureEnterAppMainCallbacksAndInvokeNativeInit(
+        int argc,
+        string[]? argv,
+        IntPtr appinit,
+        SDL3.SDL.AppIterateFunc appiter,
+        SDL3.SDL.AppEventFunc appevent,
+        SDL3.SDL.AppQuitFunc appquit)
+    {
+        capturedArgc = argc;
+        capturedArgv = argv;
+        capturedAppInitPointer = appinit;
+        capturedAppIterate = appiter;
+        capturedAppEvent = appevent;
+        capturedAppQuit = appquit;
+        capturedCallCount++;
+
+        IntPtr appstate = (IntPtr)101;
+        delegate* unmanaged[Cdecl]<IntPtr*, int, IntPtr, SDL3.SDL.AppResult> callback = (delegate* unmanaged[Cdecl]<IntPtr*, int, IntPtr, SDL3.SDL.AppResult>)(void*)appinit;
+        if (nativeCallbackArgv is null)
+        {
+            capturedResult = callback(&appstate, 0, IntPtr.Zero);
+        }
+        else
+        {
+            using Utf8ArgvScope nativeArguments = new(nativeCallbackArgv);
+            capturedResult = callback(&appstate, nativeCallbackArgv.Length, nativeArguments.Pointer);
+        }
+
+        capturedAppstate = appstate;
         return nextInt;
     }
 
@@ -459,9 +600,24 @@ internal static partial class PInvokeTests
         return 0;
     }
 
+    private static int CaptureAdaptedMain(int argc, string[]? argv)
+    {
+        capturedCallbackArgc = argc;
+        capturedCallbackArgv = argv;
+        return nextInt;
+    }
+
     private static SDL3.SDL.AppResult HandleAppInit(ref IntPtr appstate, int argc, string[]? argv)
     {
         return SDL3.SDL.AppResult.Continue;
+    }
+
+    private static SDL3.SDL.AppResult CaptureAdaptedAppInit(ref IntPtr appstate, int argc, string[]? argv)
+    {
+        capturedCallbackArgc = argc;
+        capturedCallbackArgv = argv;
+        appstate = nextAppstate;
+        return nextAppResult;
     }
 
     private static SDL3.SDL.AppResult AssignAppstate(ref IntPtr appstate, int argc, string[]? argv)
@@ -556,6 +712,23 @@ internal static partial class PInvokeTests
         TestAssert.Equal(elementType, parameter.ParameterType.GetElementType(), $"{method.DeclaringType?.Name}.{method.Name} parameter {parameterName} must point to the expected element type.");
     }
 
+    private static void AssertIntPtrParameter(MethodInfo method, string parameterName)
+    {
+        ParameterInfo parameter = method.GetParameters().Single(param => param.Name == parameterName);
+        TestAssert.Equal(typeof(IntPtr), parameter.ParameterType, $"SDL.{method.Name} parameter {parameterName} must be an unmanaged callback pointer.");
+    }
+
+    private static void AssertAdaptedCallbackArguments(string[] expected)
+    {
+        TestAssert.Equal(expected.Length, capturedCallbackArgc, "Managed callback argc must equal the native argument count.");
+        TestAssert.NotNull(capturedCallbackArgv, "Managed callback argv must not be null when native argc is positive.");
+        TestAssert.Equal(expected.Length, capturedCallbackArgv!.Length, "Managed callback argv length must equal native argc.");
+        for (int index = 0; index < expected.Length; index++)
+        {
+            TestAssert.Equal(expected[index], capturedCallbackArgv[index], $"Managed callback argv[{index}] must preserve UTF-8 content and ordering.");
+        }
+    }
+
     private static void AssertCallbackCdecl(Type callbackType, string callbackName)
     {
         UnmanagedFunctionPointerAttribute? callbackAttribute = callbackType.GetCustomAttribute<UnmanagedFunctionPointerAttribute>();
@@ -589,6 +762,39 @@ internal static partial class PInvokeTests
         public void Dispose()
         {
             field.SetValue(null, originalValue);
+        }
+    }
+
+    private sealed class Utf8ArgvScope : IDisposable
+    {
+        private readonly IntPtr[] strings;
+
+        public Utf8ArgvScope(string[] values)
+        {
+            strings = new IntPtr[values.Length];
+            Pointer = Marshal.AllocHGlobal((values.Length + 1) * IntPtr.Size);
+            for (int index = 0; index < values.Length; index++)
+            {
+                strings[index] = Marshal.StringToCoTaskMemUTF8(values[index]);
+                Marshal.WriteIntPtr(Pointer, index * IntPtr.Size, strings[index]);
+            }
+
+            Marshal.WriteIntPtr(Pointer, values.Length * IntPtr.Size, IntPtr.Zero);
+        }
+
+        public IntPtr Pointer { get; }
+
+        public void Dispose()
+        {
+            foreach (IntPtr value in strings)
+            {
+                if (value != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(value);
+                }
+            }
+
+            Marshal.FreeHGlobal(Pointer);
         }
     }
 }

--- a/SDL3-CS/SDL/Basics/main/PInvoke.cs
+++ b/SDL3-CS/SDL/Basics/main/PInvoke.cs
@@ -281,8 +281,10 @@ public partial class SDL
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_RunApp"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial int SDL_RunApp(int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv, MainFunc mainFunction, IntPtr reserved);
-    private delegate int RunAppNative(int argc, string[]? argv, MainFunc mainFunction, IntPtr reserved);
+    private static partial int SDL_RunApp(int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv, IntPtr mainFunction, IntPtr reserved);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate int MainFuncNative(int argc, IntPtr argv);
+    private delegate int RunAppNative(int argc, string[]? argv, IntPtr mainFunction, IntPtr reserved);
     private static RunAppNative RunAppNativeFunction = SDL_RunApp;
 
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_RunApp(int argc, char *argv[], SDL_main_func mainFunction, void *reserved);</code>
@@ -312,14 +314,27 @@ public partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     public static int RunApp(int argc, string[]? argv, MainFunc mainFunction, IntPtr reserved)
     {
-        return RunAppNativeFunction(argc, NormalizeMainArgv(argv), mainFunction, reserved);
+        MainFuncNative nativeMainFunction = (nativeArgc, nativeArgv) =>
+            mainFunction(nativeArgc, MarshalMainCallbackArguments(nativeArgc, nativeArgv));
+        IntPtr nativeMainFunctionPointer = Marshal.GetFunctionPointerForDelegate(nativeMainFunction);
+
+        try
+        {
+            return RunAppNativeFunction(argc, NormalizeMainArgv(argv), nativeMainFunctionPointer, reserved);
+        }
+        finally
+        {
+            GC.KeepAlive(nativeMainFunction);
+        }
     }
 
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_EnterAppMainCallbacks"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial int SDL_EnterAppMainCallbacks(int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv, AppInitFunc appinit, AppIterateFunc appiter, AppEventFunc appevent, AppQuitFunc appquit);
-    private delegate int EnterAppMainCallbacksNative(int argc, string[]? argv, AppInitFunc appinit, AppIterateFunc appiter, AppEventFunc appevent, AppQuitFunc appquit);
+    private static partial int SDL_EnterAppMainCallbacks(int argc, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPUTF8Str)] string[]? argv, IntPtr appinit, AppIterateFunc appiter, AppEventFunc appevent, AppQuitFunc appquit);
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    private delegate AppResult AppInitFuncNative(ref IntPtr appstate, int argc, IntPtr argv);
+    private delegate int EnterAppMainCallbacksNative(int argc, string[]? argv, IntPtr appinit, AppIterateFunc appiter, AppEventFunc appevent, AppQuitFunc appquit);
     private static EnterAppMainCallbacksNative EnterAppMainCallbacksNativeFunction = SDL_EnterAppMainCallbacks;
 
     /// <code>extern SDL_DECLSPEC int SDLCALL SDL_EnterAppMainCallbacks(int argc, char *argv[], SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit);</code>
@@ -346,7 +361,23 @@ public partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     public static int EnterAppMainCallbacks(int argc, string[]? argv, AppInitFunc appinit, AppIterateFunc appiter, AppEventFunc appevent, AppQuitFunc appquit)
     {
-        return EnterAppMainCallbacksNativeFunction(argc, NormalizeMainArgv(argv), appinit, appiter, appevent, appquit);
+        AppInitFuncNative nativeAppInit = (ref IntPtr appstate, int nativeArgc, IntPtr nativeArgv) =>
+            appinit(ref appstate, nativeArgc, MarshalMainCallbackArguments(nativeArgc, nativeArgv));
+        IntPtr nativeAppInitPointer = Marshal.GetFunctionPointerForDelegate(nativeAppInit);
+
+        try
+        {
+            return EnterAppMainCallbacksNativeFunction(argc, NormalizeMainArgv(argv), nativeAppInitPointer, appiter, appevent, appquit);
+        }
+        finally
+        {
+            GC.KeepAlive(nativeAppInit);
+        }
+    }
+
+    private static string[]? MarshalMainCallbackArguments(int argc, IntPtr argv)
+    {
+        return argc > 0 ? PointerToStringArray(argv, argc) : null;
     }
 
     private static string[]? NormalizeMainArgv(string[]? argv)


### PR DESCRIPTION
## Summary

- adapt `SDL_RunApp` and `SDL_EnterAppMainCallbacks` through native `cdecl` callback pointers
- decode exactly `argc` UTF-8 arguments before invoking the existing managed delegates
- cover multi-argument, non-ASCII, null, result, and `appstate` behavior

Relates to #262.

## Verification

- focused callback adapter tests
- full managed wrapper test runner
- Release wrapper build (net7.0, net8.0, net9.0, net10.0)
- public XML documentation audit
- focused function coverage