### PR TITLE
Prepare v3.4.14.1 release metadata

### DIFF
--- a/.github/release-tools/Test-PackageVersioning.ps1
+++ b/.github/release-tools/Test-PackageVersioning.ps1
@@ -124,10 +124,17 @@ else {
             Add-VersioningError "componentPackageRevisionOverrides must declare release revision '1'."
         }
         else {
-            foreach ($componentId in @('SDL_image', 'SDL_mixer', 'SDL_ttf', 'SDL_shadercross')) {
+            $requiredRevisionOneOverrides = [ordered]@{
+                SDL_image = 10
+                SDL_mixer = 9
+                SDL_ttf = 9
+                SDL_shadercross = 9
+            }
+            foreach ($componentOverride in $requiredRevisionOneOverrides.GetEnumerator()) {
+                $componentId = $componentOverride.Key
                 $override = $revisionOne.Value.PSObject.Properties[$componentId]
-                if (-not $override -or [int] $override.Value -ne 7) {
-                    Add-VersioningError "componentPackageRevisionOverrides.1.$componentId must be 7 for public release v3.4.12.1."
+                if (-not $override -or [int] $override.Value -ne $componentOverride.Value) {
+                    Add-VersioningError "componentPackageRevisionOverrides.1.$componentId must be $($componentOverride.Value) for public release v3.4.14.1."
                 }
             }
             if ($revisionOne.Value.PSObject.Properties['SDL']) {

--- a/.github/release-tools/Test-ReleaseManifest.ps1
+++ b/.github/release-tools/Test-ReleaseManifest.ps1
@@ -57,6 +57,7 @@ else {
 
 $requiredReleaseOverrides = [ordered]@{
     '0' = [ordered]@{ SDL_image = 9; SDL_mixer = 8; SDL_ttf = 8; SDL_shadercross = 8 }
+    '1' = [ordered]@{ SDL_image = 10; SDL_mixer = 9; SDL_ttf = 9; SDL_shadercross = 9 }
     '6' = [ordered]@{ SDL_image = 8; SDL_mixer = 7; SDL_ttf = 7; SDL_shadercross = 7 }
     '7' = [ordered]@{ SDL_image = 9; SDL_mixer = 8; SDL_ttf = 8; SDL_shadercross = 8 }
 }

--- a/.github/release-tools/release-manifest.json
+++ b/.github/release-tools/release-manifest.json
@@ -34,10 +34,10 @@
         "SDL_shadercross": 8
       },
       "1": {
-        "SDL_image": 7,
-        "SDL_mixer": 7,
-        "SDL_ttf": 7,
-        "SDL_shadercross": 7
+        "SDL_image": 10,
+        "SDL_mixer": 9,
+        "SDL_ttf": 9,
+        "SDL_shadercross": 9
       },
       "6": {
         "SDL_image": 8,

--- a/.github/release-tools/release-notes/v3.4.14.1.md
+++ b/.github/release-tools/release-notes/v3.4.14.1.md
@@ -1,0 +1,23 @@
+SDL3-CS patch release for SDL 3.4.14 with a native Metal GPU fix and managed API improvements.
+
+This release rebuilds and validates the complete native RID matrix from the exact manifest source revisions. The core SDL packages include the corrected Metal fence behavior; the remaining native component families are rebuilt at common free revisions so every supported platform remains version-aligned.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.14.1` |
+| `SDL3-CS.<Platform>` | `3.4.14.1` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.10` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.9` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.9` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.9` |
+
+## Changes
+
+- Corrected the inverted `SDL_QueryGPUFence` completion result in the Metal backend used by the macOS native packages ([#257](https://github.com/edwardgushchin/SDL3-CS/issues/257)).
+- Fixed `SDL_AppInit` callback argument marshalling so the managed callback receives the complete `argv` array ([#262](https://github.com/edwardgushchin/SDL3-CS/issues/262)).
+- Added scoped span-based overloads for GPU uniforms, shader and graphics-pipeline creation, texture updates, and SDL_ttf UTF-8 input ([#249](https://github.com/edwardgushchin/SDL3-CS/issues/249), [#250](https://github.com/edwardgushchin/SDL3-CS/issues/250), [#251](https://github.com/edwardgushchin/SDL3-CS/issues/251), [#252](https://github.com/edwardgushchin/SDL3-CS/issues/252), [#253](https://github.com/edwardgushchin/SDL3-CS/issues/253), [#254](https://github.com/edwardgushchin/SDL3-CS/issues/254)).
+- Added managed ShaderCross overloads for HLSL source and SPIR-V graphics-shader entry points ([#255](https://github.com/edwardgushchin/SDL3-CS/issues/255), [#256](https://github.com/edwardgushchin/SDL3-CS/issues/256)).
+
+Applications using the Metal GPU backend should update the managed package and every native component package to the versions shown above.


### PR DESCRIPTION
## Summary

- reserve the free native package-family revisions for SDL3-CS 3.4.14.1;
- add the exact package-version table and milestone release notes;
- update release metadata contract checks for the new public revision mapping.

## Verification

- `Test-ReleaseManifest.ps1 -SkipSourceCheckoutValidation`
- `Test-PackageVersioning.ps1 -PackageRevision 1`
- `Test-ReleaseNotes.ps1 -ReleaseNotesPath .github/release-tools/release-notes/v3.4.14.1.md`
- all 31 computed NuGet target coordinates return 404 and are available for publication.