### PR TITLE
Update package README for 3.4.14.1

### DIFF
--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,16 +4,16 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Package Versions
 
-This package set uses managed version `SDL3-CS 3.4.14.0`.
+This package set uses managed version `SDL3-CS 3.4.14.1`.
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.14.0` |
-| `SDL3-CS.<Platform>` | `3.4.14.0` |
-| `SDL3-CS.<Platform>.Image` | `3.4.4.9` |
-| `SDL3-CS.<Platform>.Mixer` | `3.2.4.8` |
-| `SDL3-CS.<Platform>.TTF` | `3.2.2.8` |
-| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.8` |
+| `SDL3-CS` | `3.4.14.1` |
+| `SDL3-CS.<Platform>` | `3.4.14.1` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.10` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.9` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.9` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.9` |
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
- update the packaged README to identify managed release 3.4.14.1
- list the exact native package revisions selected for the release

## Checks
- `Test-PackageVersioning.ps1 -PackageRevision 1`
- `Test-ReleaseNotes.ps1 -ReleaseNotesPath .github/release-tools/release-notes/v3.4.14.1.md`
- `Test-ReleaseManifest.ps1 -SkipSourceCheckoutValidation`
- exact README package-version marker validation