### PR TITLE
Fix SDL display lookup pointer ABI

### DIFF
--- a/SDL3-CS.Tests/SDL/Video/video/PInvoke.cs
+++ b/SDL3-CS.Tests/SDL/Video/video/PInvoke.cs
@@ -124,8 +124,17 @@ internal static class PInvokeTests
         AssertBoolParameterMarshal(closestFullscreenDisplayMode, 4);
         AssertNativeImport(GetNativeMethod("SDL_GetDesktopDisplayMode"), "SDL_GetDesktopDisplayMode");
         AssertNativeImport(GetNativeMethod("SDL_GetCurrentDisplayMode"), "SDL_GetCurrentDisplayMode");
-        AssertNativeImport(GetNativeMethod("SDL_GetDisplayForPoint"), "SDL_GetDisplayForPoint");
-        AssertNativeImport(GetNativeMethod("SDL_GetDisplayForRect"), "SDL_GetDisplayForRect");
+        MethodInfo getDisplayForPoint = GetNativeMethod("SDL_GetDisplayForPoint");
+        AssertNativeImport(getDisplayForPoint, "SDL_GetDisplayForPoint");
+        ParameterInfo getDisplayForPointParameter = getDisplayForPoint.GetParameters()[0];
+        TestAssert.Equal(typeof(SDL3.SDL.Point).MakeByRefType(), getDisplayForPointParameter.ParameterType, "SDL_GetDisplayForPoint must pass Point by reference.");
+        TestAssert.True(getDisplayForPointParameter.IsIn, "SDL_GetDisplayForPoint must keep the const Point input read-only.");
+
+        MethodInfo getDisplayForRect = GetNativeMethod("SDL_GetDisplayForRect");
+        AssertNativeImport(getDisplayForRect, "SDL_GetDisplayForRect");
+        ParameterInfo getDisplayForRectParameter = getDisplayForRect.GetParameters()[0];
+        TestAssert.Equal(typeof(SDL3.SDL.Rect).MakeByRefType(), getDisplayForRectParameter.ParameterType, "SDL_GetDisplayForRect must pass Rect by reference.");
+        TestAssert.True(getDisplayForRectParameter.IsIn, "SDL_GetDisplayForRect must keep the const Rect input read-only.");
         AssertNativeImport(GetNativeMethod("SDL_GetDisplayForWindow"), "SDL_GetDisplayForWindow");
         AssertNativeImport(GetNativeMethod("SDL_GetWindowPixelDensity"), "SDL_GetWindowPixelDensity");
         AssertNativeImport(GetNativeMethod("SDL_GetWindowDisplayScale"), "SDL_GetWindowDisplayScale");
@@ -591,7 +600,7 @@ internal static class PInvokeTests
         SDL3.SDL.Point point = new() { X = -10, Y = 20 };
         using (NativeHookScope _ = NativeHookScope.Install("GetDisplayForPointNativeFunction", nameof(CapturePointReturnUInt)))
         {
-            TestAssert.Equal(0x501u, SDL3.SDL.GetDisplayForPoint(point), "SDL.GetDisplayForPoint must return native display id.");
+            TestAssert.Equal(0x501u, SDL3.SDL.GetDisplayForPoint(in point), "SDL.GetDisplayForPoint must return native display id.");
             AssertPoint(point, capturedPoint, "SDL.GetDisplayForPoint must forward point.");
         }
 
@@ -600,7 +609,7 @@ internal static class PInvokeTests
         SDL3.SDL.Rect rect = new() { X = 1, Y = 2, W = 640, H = 480 };
         using (NativeHookScope _ = NativeHookScope.Install("GetDisplayForRectNativeFunction", nameof(CaptureRectReturnUInt)))
         {
-            TestAssert.Equal(0x502u, SDL3.SDL.GetDisplayForRect(rect), "SDL.GetDisplayForRect must return native display id.");
+            TestAssert.Equal(0x502u, SDL3.SDL.GetDisplayForRect(in rect), "SDL.GetDisplayForRect must return native display id.");
             AssertRect(rect, capturedRect, "SDL.GetDisplayForRect must forward rect.");
         }
 
@@ -1874,13 +1883,13 @@ internal static class PInvokeTests
         return nextUInt;
     }
 
-    private static uint CapturePointReturnUInt(SDL3.SDL.Point point)
+    private static uint CapturePointReturnUInt(in SDL3.SDL.Point point)
     {
         capturedPoint = point;
         return nextUInt;
     }
 
-    private static uint CaptureRectReturnUInt(SDL3.SDL.Rect rect)
+    private static uint CaptureRectReturnUInt(in SDL3.SDL.Rect rect)
     {
         capturedRect = rect;
         return nextUInt;

--- a/SDL3-CS/SDL/Video/video/PInvoke.cs
+++ b/SDL3-CS/SDL/Video/video/PInvoke.cs
@@ -509,8 +509,8 @@ public static partial class SDL
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_GetDisplayForPoint"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial uint SDL_GetDisplayForPoint(Point point);
-    private delegate uint GetDisplayForPointNativeDelegate(Point point);
+    private static partial uint SDL_GetDisplayForPoint(in Point point);
+    private delegate uint GetDisplayForPointNativeDelegate(in Point point);
     private static GetDisplayForPointNativeDelegate GetDisplayForPointNativeFunction = SDL_GetDisplayForPoint;
 
     /// <code>extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForPoint(const SDL_Point *point);</code>
@@ -524,16 +524,16 @@ public static partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     /// <seealso cref="GetDisplayBounds"/>
     /// <seealso cref="GetDisplays"/>
-    public static uint GetDisplayForPoint(Point point)
+    public static uint GetDisplayForPoint(in Point point)
     {
-        return GetDisplayForPointNativeFunction(point);
+        return GetDisplayForPointNativeFunction(in point);
     }
 
 
     [ExcludeFromCodeCoverage]
     [LibraryImport(SDLLibrary, EntryPoint = "SDL_GetDisplayForRect"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    private static partial uint SDL_GetDisplayForRect(Rect rect);
-    private delegate uint GetDisplayForRectNativeDelegate(Rect rect);
+    private static partial uint SDL_GetDisplayForRect(in Rect rect);
+    private delegate uint GetDisplayForRectNativeDelegate(in Rect rect);
     private static GetDisplayForRectNativeDelegate GetDisplayForRectNativeFunction = SDL_GetDisplayForRect;
 
     /// <code>extern SDL_DECLSPEC SDL_DisplayID SDLCALL SDL_GetDisplayForRect(const SDL_Rect *rect);</code>
@@ -548,9 +548,9 @@ public static partial class SDL
     /// <since>This function is available since SDL 3.2.0</since>
     /// <seealso cref="GetDisplayBounds"/>
     /// <seealso cref="GetDisplays"/>
-    public static uint GetDisplayForRect(Rect rect)
+    public static uint GetDisplayForRect(in Rect rect)
     {
-        return GetDisplayForRectNativeFunction(rect);
+        return GetDisplayForRectNativeFunction(in rect);
     }
 
 


### PR DESCRIPTION
## Summary

- pass `SDL_Point` and `SDL_Rect` to display lookup imports by read-only reference
- align the managed hook delegates and public wrappers with the stable SDL ABI
- add mirrored ABI metadata and forwarding regression tests

## Verification

- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- production function coverage: 1813/1813 (100%) in the combined milestone candidate

Refs #267
