### PR TITLE
Fix SDL_image frame duration ABI

### DIFF
--- a/SDL3-CS.Tests/Image/PInvoke.cs
+++ b/SDL3-CS.Tests/Image/PInvoke.cs
@@ -1385,22 +1385,47 @@ internal static class PInvokeTests
 
     public static void GetAnimationDecoderFrame_ReturnsSurfaceForGifDecoder()
     {
-        AssertBoolReturnMethodMetadata(nameof(SDL3.Image.GetAnimationDecoderFrame), "IMG_GetAnimationDecoderFrame", [typeof(IntPtr), typeof(IntPtr).MakeByRefType(), typeof(long)]);
+        AssertBoolReturnMethodMetadata(nameof(SDL3.Image.GetAnimationDecoderFrame), "IMG_GetAnimationDecoderFrame", [typeof(IntPtr), typeof(IntPtr).MakeByRefType(), typeof(ulong).MakeByRefType()]);
+        MethodInfo? compatibilityMethod = typeof(SDL3.Image).GetMethod(nameof(SDL3.Image.GetAnimationDecoderFrame), BindingFlags.Public | BindingFlags.Static, [typeof(IntPtr), typeof(IntPtr).MakeByRefType(), typeof(long)]);
+        TestAssert.NotNull(compatibilityMethod, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) compatibility method must remain public static.");
+        TestAssert.NotNull(compatibilityMethod!.GetCustomAttribute<ObsoleteAttribute>(), "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) compatibility method must direct callers to the corrected ABI overload.");
 
-        using ConstMemIOStreamScope stream = ConstMemIOStreamScope.Create(OnePixelGif());
+        byte[] gif = OnePixelGif();
+        gif[23] = 10;
+        using ConstMemIOStreamScope stream = ConstMemIOStreamScope.Create(gif);
         using AnimationDecoderScope decoder = AnimationDecoderScope.CreateForGifIO(stream.Handle);
-        bool gotFrame = SDL3.Image.GetAnimationDecoderFrame(decoder.Handle, out IntPtr frame, duration: 0);
+        bool gotFrame = SDL3.Image.GetAnimationDecoderFrame(decoder.Handle, out IntPtr frame, out ulong duration);
 
         try
         {
-            TestAssert.True(gotFrame, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) must decode the first GIF frame.");
-            TestAssert.True(frame != IntPtr.Zero, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) must return a surface for the first GIF frame.");
+            TestAssert.True(gotFrame, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong) must decode the first GIF frame.");
+            TestAssert.True(frame != IntPtr.Zero, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong) must return a surface for the first GIF frame.");
+            TestAssert.True(duration > 0, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong) must return the configured nonzero GIF frame duration.");
         }
         finally
         {
             if (frame != IntPtr.Zero)
             {
                 SDL3.SDL.DestroySurface(frame);
+            }
+        }
+
+        using ConstMemIOStreamScope compatibilityStream = ConstMemIOStreamScope.Create(gif);
+        using AnimationDecoderScope compatibilityDecoder = AnimationDecoderScope.CreateForGifIO(compatibilityStream.Handle);
+#pragma warning disable CS0618
+        bool compatibilityGotFrame = SDL3.Image.GetAnimationDecoderFrame(compatibilityDecoder.Handle, out IntPtr compatibilityFrame, duration: 0);
+#pragma warning restore CS0618
+
+        try
+        {
+            TestAssert.True(compatibilityGotFrame, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) must forward through the corrected native ABI.");
+            TestAssert.True(compatibilityFrame != IntPtr.Zero, "Image.GetAnimationDecoderFrame(IntPtr, out IntPtr, long) must return the decoded frame.");
+        }
+        finally
+        {
+            if (compatibilityFrame != IntPtr.Zero)
+            {
+                SDL3.SDL.DestroySurface(compatibilityFrame);
             }
         }
     }

--- a/SDL3-CS/Image/PInvoke.cs
+++ b/SDL3-CS/Image/PInvoke.cs
@@ -2856,7 +2856,7 @@ public partial class Image
     /// <since>This function is available since SDL_image 3.4.0.</since>
     /// <seealso cref="CreateAnimationDecoderIO"/>
     /// <seealso cref="CreateAnimationDecoderWithProperties"/>
-    /// <seealso cref="GetAnimationDecoderFrame"/>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
     /// <seealso cref="ResetAnimationDecoder"/>
     /// <seealso cref="CloseAnimationDecoder"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_CreateAnimationDecoder"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2887,7 +2887,7 @@ public partial class Image
     /// <since>This function is available since SDL_image 3.4.0.</since>
     /// <seealso cref="CreateAnimationDecoder"/>
     /// <seealso cref="CreateAnimationDecoderWithProperties"/>
-    /// <seealso cref="GetAnimationDecoderFrame"/>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
     /// <seealso cref="ResetAnimationDecoder"/>
     /// <seealso cref="CloseAnimationDecoder"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_CreateAnimationDecoder_IO"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2928,7 +2928,7 @@ public partial class Image
     /// <since>This function is available since SDL_image 3.4.0.</since>
     /// <seealso cref="CreateAnimationDecoder"/>
     /// <seealso cref="CreateAnimationDecoderIO"/>
-    /// <seealso cref="GetAnimationDecoderFrame"/>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
     /// <seealso cref="ResetAnimationDecoder"/>
     /// <seealso cref="CloseAnimationDecoder"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_CreateAnimationDecoderWithProperties"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2987,7 +2987,22 @@ public partial class Image
     /// <seealso cref="CloseAnimationDecoder"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_GetAnimationDecoderFrame"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]
-    public static partial bool GetAnimationDecoderFrame(IntPtr decoder, out IntPtr frame, long duration);
+    public static partial bool GetAnimationDecoderFrame(IntPtr decoder, out IntPtr frame, out ulong duration);
+
+    /// <summary>
+    /// Decode the next animation frame while discarding its duration.
+    /// </summary>
+    /// <param name="decoder">the animation decoder.</param>
+    /// <param name="frame">a pointer filled in with the surface for the next frame.</param>
+    /// <param name="duration">an unused compatibility argument.</param>
+    /// <returns><c>true</c> on success or <c>false</c> on failure and when no more frames are available.</returns>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
+    [Obsolete("Use GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong) to receive the frame duration.")]
+    public static bool GetAnimationDecoderFrame(IntPtr decoder, out IntPtr frame, long duration)
+    {
+        _ = duration;
+        return GetAnimationDecoderFrame(decoder, out frame, out _);
+    }
     
 
     /// <code>extern SDL_DECLSPEC IMG_AnimationDecoderStatus SDLCALL IMG_GetAnimationDecoderStatus(IMG_AnimationDecoder *decoder);</code>
@@ -2998,7 +3013,7 @@ public partial class Image
     /// <returns>the status of the underlying decoder, or
     /// <seealso cref="AnimationDecoderStatus.Invalid"/> if the given decoder is invalid.</returns>
     /// <since>This function is available since SDL_image 3.4.0.</since>
-    /// <seealso cref="GetAnimationDecoderFrame"/>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_GetAnimationDecoderStatus"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     public static partial AnimationDecoderStatus GetAnimationDecoderStatus(IntPtr decoder);
     
@@ -3017,7 +3032,7 @@ public partial class Image
     /// <seealso cref="CreateAnimationDecoder"/>
     /// <seealso cref="CreateAnimationDecoderIO"/>
     /// <seealso cref="CreateAnimationDecoderWithProperties"/>
-    /// <seealso cref="GetAnimationDecoderFrame"/>
+    /// <seealso cref="GetAnimationDecoderFrame(IntPtr, out IntPtr, out ulong)"/>
     /// <seealso cref="CloseAnimationDecoder"/>
     [LibraryImport(ImageLibrary, EntryPoint = "IMG_ResetAnimationDecoder"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
     [return: MarshalAs(UnmanagedType.I1)]


### PR DESCRIPTION
## Summary

- return `IMG_GetAnimationDecoderFrame` duration through `out ulong`
- retain an obsolete source-compatibility overload that safely discards the returned duration
- add mirrored native metadata, frame-duration, and compatibility regression tests

## Verification

- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- production function coverage: 1813/1813 (100%) in the combined milestone candidate

Refs #268
