### PR TITLE
Fix SDL_mixer sine duration ABI

### DIFF
--- a/SDL3-CS.Tests/Mixer/PInvoke.cs
+++ b/SDL3-CS.Tests/Mixer/PInvoke.cs
@@ -187,6 +187,18 @@ internal static class PInvokeTests
         {
             DestroyAudioIfNeeded(audio);
         }
+
+        IntPtr infiniteAudio = SDL3.Mixer.CreateSineWaveAudio(mixer.Handle, 440, 0.125f);
+
+        try
+        {
+            TestAssert.True(infiniteAudio != IntPtr.Zero, "Mixer.CreateSineWaveAudio(IntPtr, int, float) compatibility method must create audio.");
+            TestAssert.Equal(SDL3.Mixer.DurationInfinite, SDL3.Mixer.GetAudioDuration(infiniteAudio), "Mixer.CreateSineWaveAudio(IntPtr, int, float) must create infinite audio explicitly.");
+        }
+        finally
+        {
+            DestroyAudioIfNeeded(infiniteAudio);
+        }
     }
 
     public static void LoadAudio_ReturnsAudioForWavFile()
@@ -322,16 +334,17 @@ internal static class PInvokeTests
 
     public static void CreateSineWaveAudio_ReturnsAudioForMemoryMixer()
     {
-        MethodInfo? method = typeof(SDL3.Mixer).GetMethod(nameof(SDL3.Mixer.CreateSineWaveAudio), BindingFlags.Public | BindingFlags.Static, [typeof(IntPtr), typeof(int), typeof(float)]);
-        TestAssert.NotNull(method, "Mixer.CreateSineWaveAudio(IntPtr, int, float) method must be public static.");
+        MethodInfo? method = typeof(SDL3.Mixer).GetMethod(nameof(SDL3.Mixer.CreateSineWaveAudio), BindingFlags.Public | BindingFlags.Static, [typeof(IntPtr), typeof(int), typeof(float), typeof(long)]);
+        TestAssert.NotNull(method, "Mixer.CreateSineWaveAudio(IntPtr, int, float, long) method must be public static.");
         AssertMixerLibraryImport(method!, "MIX_CreateSineWaveAudio");
 
         using MixerScope mixer = MixerScope.CreateMemoryMixer();
-        IntPtr audio = SDL3.Mixer.CreateSineWaveAudio(mixer.Handle, 440, 0.125f);
+        IntPtr audio = SDL3.Mixer.CreateSineWaveAudio(mixer.Handle, 440, 0.125f, 250);
 
         try
         {
-            TestAssert.True(audio != IntPtr.Zero, "Mixer.CreateSineWaveAudio(IntPtr, int, float) must create audio for a valid memory mixer.");
+            TestAssert.True(audio != IntPtr.Zero, "Mixer.CreateSineWaveAudio(IntPtr, int, float, long) must create audio for a valid memory mixer.");
+            TestAssert.Equal(12_000L, SDL3.Mixer.GetAudioDuration(audio), "Mixer.CreateSineWaveAudio(IntPtr, int, float, long) must honor 250 milliseconds at 48 kHz.");
         }
         finally
         {

--- a/SDL3-CS/Mixer/PInvoke.cs
+++ b/SDL3-CS/Mixer/PInvoke.cs
@@ -598,7 +598,7 @@ public partial class Mixer
     public static partial IntPtr LoadRawAudioNoCopy(IntPtr mixer, IntPtr data, UIntPtr datalen, in IntPtr spec, [MarshalAs(UnmanagedType.I1)] bool freeWhenDone);
 
 
-    /// <code>extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_CreateSineWaveAudio(MIX_Mixer *mixer, int hz, float amplitude);</code>
+    /// <code>extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_CreateSineWaveAudio(MIX_Mixer *mixer, int hz, float amplitude, Sint64 ms);</code>
     /// <summary>
     /// Create a MIX_Audio that generates a sinewave.
     /// <para>This is useful just to have _something_ to play, perhaps for testing or
@@ -618,7 +618,8 @@ public partial class Mixer
     /// </summary>
     /// <param name="mixer">a mixer this audio is intended to be used with. May be <c>null</c>.</param>
     /// <param name="hz">the sinewave's frequency in Hz.</param>
-    /// <param name="amplitude">the maximum number of milliseconds of audio to generate, or less
+    /// <param name="amplitude">the sinewave's amplitude from 0.0f to 1.0f.</param>
+    /// <param name="ms">the maximum number of milliseconds of audio to generate, or less
     /// than zero to generate infinite audio.</param>
     /// <returns>an audio object that can be used to make sound on a mixer, or <c>null</c>
     /// on failure; call <see cref="SDL.GetError"/> for more information.</returns>
@@ -628,7 +629,20 @@ public partial class Mixer
     /// <seealso cref="SetTrackAudio"/>
     /// <seealso cref="LoadAudioIO"/>
     [LibraryImport(MixerLibrary, EntryPoint = "MIX_CreateSineWaveAudio"), UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-    public static partial IntPtr CreateSineWaveAudio(IntPtr mixer, int hz, float amplitude);
+    public static partial IntPtr CreateSineWaveAudio(IntPtr mixer, int hz, float amplitude, long ms);
+
+    /// <summary>
+    /// Create infinite sine-wave audio for source compatibility with earlier SDL3-CS releases.
+    /// </summary>
+    /// <param name="mixer">a mixer this audio is intended to be used with. May be <c>null</c>.</param>
+    /// <param name="hz">the sinewave's frequency in Hz.</param>
+    /// <param name="amplitude">the sinewave's amplitude from 0.0f to 1.0f.</param>
+    /// <returns>an infinite audio object that can be used to make sound on a mixer, or <c>null</c> on failure.</returns>
+    /// <seealso cref="CreateSineWaveAudio(IntPtr, int, float, long)"/>
+    public static IntPtr CreateSineWaveAudio(IntPtr mixer, int hz, float amplitude)
+    {
+        return CreateSineWaveAudio(mixer, hz, amplitude, DurationInfinite);
+    }
 
 
     /// <code>extern SDL_DECLSPEC SDL_PropertiesID SDLCALL MIX_GetAudioProperties(MIX_Audio *audio);</code>


### PR DESCRIPTION
## Summary

- pass the required `Sint64 ms` duration to `MIX_CreateSineWaveAudio`
- retain the three-argument helper with an explicit infinite duration
- add mirrored native metadata, finite-duration, and compatibility regression tests

## Verification

- `dotnet build .\SDL3-CS\SDL3-CS.csproj -c Release`
- `dotnet run --project .\SDL3-CS.Tests\SDL3-CS.Tests.csproj -c Release --no-build --no-restore`
- `pwsh .\.github\release-tools\Test-PublicWrapperXmlDocs.ps1 -SourceRoot .\SDL3-CS`
- production function coverage: 1813/1813 (100%) in the combined milestone candidate

Refs #269
