### PR TITLE
docs: update package README for 3.4.14.2

### DIFF
--- a/README-nuget.md
+++ b/README-nuget.md
@@ -4,11 +4,11 @@ SDL3-CS is a C# wrapper for SDL3. The managed `SDL3-CS` package contains the C# 
 
 ## Package Versions
 
-This package set uses managed version `SDL3-CS 3.4.14.1`.
+This package set uses managed version `SDL3-CS 3.4.14.2`.
 
 | Package family | Version |
 |----------------|---------|
-| `SDL3-CS` | `3.4.14.1` |
+| `SDL3-CS` | `3.4.14.2` |
 | `SDL3-CS.<Platform>` | `3.4.14.1` |
 | `SDL3-CS.<Platform>.Image` | `3.4.4.10` |
 | `SDL3-CS.<Platform>.Mixer` | `3.2.4.9` |


### PR DESCRIPTION
## Summary

- identify the managed `SDL3-CS` package as version 3.4.14.2
- keep all reused native package versions unchanged

## Verification

- `pwsh .\.github\release-tools\Pack-NuGet.ps1 -PackageRevision 2 -ManagedOnly`
- managed package content validation passed for all four target frameworks
- reusable native revision 1 scope passed for all 30 published package coordinates

Release-readiness follow-up for #267, #268, and #269.
