### PR TITLE
fix: align Roslyn package references at 5.9.0

### DIFF
--- a/SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj
+++ b/SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SDL3-CS\SDL3-CS.csproj" />
     <ProjectReference Include="..\SDL3-CS.Generators\SDL3-CS.Generators.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
   </ItemGroup>
 
 </Project>

--- a/SDL3-CS.Generators/SDL3-CS.Generators.csproj
+++ b/SDL3-CS.Generators/SDL3-CS.Generators.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- align the generator and generator-test direct Roslyn references on 5.9.0
- replace the uneditable Dependabot change in #277, which fails with CS1705

## Validation

- reproduced CS1705 on exact #277 head with a focused Release build
- `dotnet build ./SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj -c Release`
- `DOTNET_ROLL_FORWARD=Major dotnet run --project ./SDL3-CS.Generators.Tests/SDL3-CS.Generators.Tests.csproj -c Release --no-build`
- `dotnet build ./SDL3-CS.sln -c Release`

The local SDK is 10.0.101 and emits CS9057 while loading a 5.9 analyzer; CI uses 10.0.400, whose successful wrapper/example builds on #277 reported zero warnings. The new CI run is the acceptance check for that host-version difference.