### PR TITLE
build: bump SDL3-CS.Linux.Mixer to 3.2.4.9

### DIFF
--- a/SDL3-CS.Examples/Directory.Build.props
+++ b/SDL3-CS.Examples/Directory.Build.props
@@ -9,7 +9,7 @@
     <LangVersion Condition="'$(LangVersion)' == ''">14</LangVersion>
     <SDL3CSVersion>3.4.14.1</SDL3CSVersion>
     <SDL3CSImageVersion>3.4.4.10</SDL3CSImageVersion>
-    <SDL3CSMixerVersion>3.2.4.7</SDL3CSMixerVersion>
+    <SDL3CSMixerVersion>3.2.4.9</SDL3CSMixerVersion>
     <SDL3CSTTFVersion>3.2.2.1</SDL3CSTTFVersion>
     <SDL3CSShadercrossVersion>3.0.0.1</SDL3CSShadercrossVersion>
   </PropertyGroup>


### PR DESCRIPTION
Update the shared SDL3-CS Mixer package revision. Replaces #280, which conflicts after the preceding shared-version updates.