### PR TITLE
docs: prepare release 3.4.14.2 metadata

### DIFF
--- a/.github/release-tools/release-manifest.json
+++ b/.github/release-tools/release-manifest.json
@@ -39,6 +39,12 @@
         "SDL_ttf": 9,
         "SDL_shadercross": 9
       },
+      "2": {
+        "SDL_image": 11,
+        "SDL_mixer": 10,
+        "SDL_ttf": 10,
+        "SDL_shadercross": 10
+      },
       "6": {
         "SDL_image": 8,
         "SDL_mixer": 7,

--- a/.github/release-tools/release-notes/v3.4.14.2.md
+++ b/.github/release-tools/release-notes/v3.4.14.2.md
@@ -1,0 +1,24 @@
+SDL3-CS patch release for SDL 3.4.14 with managed ABI corrections and the verified Avalonia Android audio-only reference.
+
+This release rebuilds and validates the complete native RID matrix from the exact manifest source revisions. The Android base and SDL_mixer package READMEs now document the supported audio-only integration, so their payload changes are published together with a full native-package verification.
+
+## Package Versions
+
+| Package family | Version |
+|----------------|---------|
+| `SDL3-CS` | `3.4.14.2` |
+| `SDL3-CS.<Platform>` | `3.4.14.2` |
+| `SDL3-CS.<Platform>.Image` | `3.4.4.11` |
+| `SDL3-CS.<Platform>.Mixer` | `3.2.4.10` |
+| `SDL3-CS.<Platform>.TTF` | `3.2.2.10` |
+| `SDL3-CS.<Platform>.Shadercross` | `3.0.0.10` |
+
+## Changes
+
+- Corrected display lookup bindings so SDL display structures are passed by pointer, matching the native ABI ([#267](https://github.com/edwardgushchin/SDL3-CS/issues/267)).
+- Added frame-duration output support to `IMG_GetAnimationDecoderFrame` ([#268](https://github.com/edwardgushchin/SDL3-CS/issues/268)).
+- Added the required duration parameter to `MIX_CreateSineWaveAudio` ([#269](https://github.com/edwardgushchin/SDL3-CS/issues/269)).
+- Added a verified audio-only Avalonia Android SDL_mixer reference that keeps an existing Activity and documents the JNI/context and lifecycle sequence ([#274](https://github.com/edwardgushchin/SDL3-CS/issues/274)).
+- Aligned the Roslyn package references with version 5.9.0.
+
+Applications should update `SDL3-CS` and all platform-native package families to the versions shown above.


### PR DESCRIPTION
Prepares the release metadata for 3.4.14.2.

- records the next common free revisions for every native component family;
- adds release notes for #267, #268, #269, and #274;
- keeps the full native release required by the changed Android package README payloads.

Validation:
- Test-ReleaseNotes.ps1 for v3.4.14.2;
- Test-PackageVersioning.ps1 -PackageRevision 2;
- Test-ReleaseManifest.ps1 -SkipSourceCheckoutValidation;
- Test-ReleaseWorkflow.ps1;
- Test-ReleasePublishPlan.ps1;
- read-only NuGet target availability for all 31 target package versions.