### PR TITLE
fix: activate exact Apple .NET SDK for consumers

### DIFF
--- a/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
@@ -91,6 +91,15 @@ try {
         & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
     }
 
+    $unactivatedAppleSdkWorkflow = $workflowText.Replace(
+        'test -x "$DOTNET_ROOT/dotnet"',
+        'test -f "$DOTNET_ROOT/dotnet"'
+    )
+    Set-Content -LiteralPath $tempWorkflow -Value $unactivatedAppleSdkWorkflow -Encoding UTF8
+    Assert-WorkflowValidationFails -Description 'missing exact Apple .NET SDK executable gate' -Action {
+        & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
+    }
+
     $unpinnedAppleWorkloadWorkflow = $workflowText.Replace(
         'dotnet workload install ios tvos --version "$APPLE_DOTNET_WORKLOAD_VERSION"',
         'dotnet workload install ios tvos'

--- a/.github/release-tools/Test-ReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.ps1
@@ -304,6 +304,8 @@ Assert-WorkflowContains -Text $workflowText -Expected 'APPLE_XCODE_BUILD: ${{ ne
 Assert-WorkflowContains -Text $workflowText -Expected 'APPLE_DOTNET_SDK_VERSION: ${{ needs.plan.outputs.apple_dotnet_sdk_version }}' -Description 'manifest-derived Apple .NET SDK version handoff'
 Assert-WorkflowContains -Text $workflowText -Expected 'APPLE_DOTNET_WORKLOAD_VERSION: ${{ needs.plan.outputs.apple_dotnet_workload_version }}' -Description 'manifest-derived Apple workload-set version handoff'
 Assert-WorkflowContains -Text $workflowText -Expected 'dotnet-version: ${{ needs.plan.outputs.apple_dotnet_sdk_version }}' -Description 'exact Apple .NET SDK setup'
+Assert-WorkflowContains -Text $workflowText -Expected 'test -x "$DOTNET_ROOT/dotnet"' -Description 'exact Apple .NET SDK executable gate'
+Assert-WorkflowContains -Text $workflowText -Expected 'printf ''%s\n'' "$DOTNET_ROOT" >> "$GITHUB_PATH"' -Description 'exact Apple .NET SDK PATH activation'
 Assert-WorkflowContains -Text $workflowText -Expected 'xcode_path="/Applications/Xcode_${APPLE_XCODE_VERSION}.app"' -Description 'manifest-derived Apple Xcode application path'
 Assert-WorkflowContains -Text $workflowText -Expected 'test "$actual_xcode_version" = "$APPLE_XCODE_VERSION"' -Description 'exact Apple Xcode version gate'
 Assert-WorkflowContains -Text $workflowText -Expected 'test "$actual_xcode_build" = "$APPLE_XCODE_BUILD"' -Description 'exact Apple Xcode build gate'

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -644,6 +644,13 @@ jobs:
         with:
           dotnet-version: ${{ needs.plan.outputs.apple_dotnet_sdk_version }}
 
+      - name: Activate exact Apple .NET SDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x "$DOTNET_ROOT/dotnet"
+          printf '%s\n' "$DOTNET_ROOT" >> "$GITHUB_PATH"
+
       - name: Select exact Xcode
         shell: bash
         run: |


### PR DESCRIPTION
Fixes the Apple consumer release gate on macOS Intel by activating the SDK installed by `actions/setup-dotnet` via `DOTNET_ROOT` before validating SDK/workload versions and building consumers.

The previous production run failed because `dotnet --version` resolved a runner-preinstalled SDK from PATH instead of the pinned SDK.