### PR TITLE
fix: pin exact Apple SDK selection

### DIFF
--- a/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.Tests.ps1
@@ -100,6 +100,15 @@ try {
         & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
     }
 
+    $unpinnedAppleSdkSelectionWorkflow = $workflowText.Replace(
+        '"$DOTNET_ROOT/dotnet" new globaljson --sdk-version "$APPLE_DOTNET_SDK_VERSION" --roll-forward disable',
+        '"$DOTNET_ROOT/dotnet" new globaljson --sdk-version "$APPLE_DOTNET_SDK_VERSION" --roll-forward latestFeature'
+    )
+    Set-Content -LiteralPath $tempWorkflow -Value $unpinnedAppleSdkSelectionWorkflow -Encoding UTF8
+    Assert-WorkflowValidationFails -Description 'missing exact Apple .NET SDK selection pin' -Action {
+        & $validator -WorkflowPath $tempWorkflow -ManifestPath $ManifestPath *> $null
+    }
+
     $unpinnedAppleWorkloadWorkflow = $workflowText.Replace(
         'dotnet workload install ios tvos --version "$APPLE_DOTNET_WORKLOAD_VERSION"',
         'dotnet workload install ios tvos'

--- a/.github/release-tools/Test-ReleaseWorkflow.ps1
+++ b/.github/release-tools/Test-ReleaseWorkflow.ps1
@@ -305,6 +305,7 @@ Assert-WorkflowContains -Text $workflowText -Expected 'APPLE_DOTNET_SDK_VERSION:
 Assert-WorkflowContains -Text $workflowText -Expected 'APPLE_DOTNET_WORKLOAD_VERSION: ${{ needs.plan.outputs.apple_dotnet_workload_version }}' -Description 'manifest-derived Apple workload-set version handoff'
 Assert-WorkflowContains -Text $workflowText -Expected 'dotnet-version: ${{ needs.plan.outputs.apple_dotnet_sdk_version }}' -Description 'exact Apple .NET SDK setup'
 Assert-WorkflowContains -Text $workflowText -Expected 'test -x "$DOTNET_ROOT/dotnet"' -Description 'exact Apple .NET SDK executable gate'
+Assert-WorkflowContains -Text $workflowText -Expected '"$DOTNET_ROOT/dotnet" new globaljson --sdk-version "$APPLE_DOTNET_SDK_VERSION" --roll-forward disable' -Description 'exact Apple .NET SDK selection pin'
 Assert-WorkflowContains -Text $workflowText -Expected 'printf ''%s\n'' "$DOTNET_ROOT" >> "$GITHUB_PATH"' -Description 'exact Apple .NET SDK PATH activation'
 Assert-WorkflowContains -Text $workflowText -Expected 'xcode_path="/Applications/Xcode_${APPLE_XCODE_VERSION}.app"' -Description 'manifest-derived Apple Xcode application path'
 Assert-WorkflowContains -Text $workflowText -Expected 'test "$actual_xcode_version" = "$APPLE_XCODE_VERSION"' -Description 'exact Apple Xcode version gate'

--- a/.github/workflows/release-native-packages.yml
+++ b/.github/workflows/release-native-packages.yml
@@ -649,6 +649,8 @@ jobs:
         run: |
           set -euo pipefail
           test -x "$DOTNET_ROOT/dotnet"
+          test ! -e global.json
+          "$DOTNET_ROOT/dotnet" new globaljson --sdk-version "$APPLE_DOTNET_SDK_VERSION" --roll-forward disable
           printf '%s\n' "$DOTNET_ROOT" >> "$GITHUB_PATH"
 
       - name: Select exact Xcode


### PR DESCRIPTION
## Summary
- create a job-local `global.json` for Apple consumer jobs
- disable SDK roll-forward so a shared runner `DOTNET_ROOT` cannot select a newer SDK
- enforce the selection pin in release workflow contract tests

## Root cause
`actions/setup-dotnet` installed 10.0.302 into a shared `DOTNET_ROOT` that already contained other SDKs. PATH activation selected the intended muxer root, but without `global.json` the muxer still selected another installed SDK.

## Checks
- `pwsh -NoLogo -NoProfile -File ./.github/release-tools/Test-ReleaseWorkflow.ps1`
- `pwsh -NoLogo -NoProfile -File ./.github/release-tools/Test-ReleaseWorkflow.Tests.ps1`
- `git diff --check`